### PR TITLE
Use np.convolve() for direct version convolutions

### DIFF
--- a/cusignal/signaltools.py
+++ b/cusignal/signaltools.py
@@ -757,7 +757,7 @@ def convolve(in1, in2, mode='full', method='auto'):
     elif method == 'direct':
         # fastpath to faster numpy.convolve for 1d inputs when possible
         if _np_conv_ok(volume, kernel, mode):
-            return cp.convolve(volume, kernel, mode)
+            return cp.asarray(np.convolve(cp.asnumpy(volume), cp.asnumpy(kernel), mode))
 
         return correlate(volume, _reverse_and_conj(kernel), mode, 'direct')
     else:


### PR DESCRIPTION
Uses np.convolve() for short/direct version convolutions. 

cusignal/test/test_signaltools.py::test_wiener[32768] PASSED                                                                         [ 18%]
cusignal/test/test_signaltools.py::test_wiener[16777216] PASSED                                                                      [ 19%]

Fixes https://github.com/rapidsai/cusignal/issues/3
