### PR TITLE
Add GH Action moving new issues to triage projects [skip-ci]

### DIFF
--- a/.github/workflows/new-issues-to-triage-projects.yml
+++ b/.github/workflows/new-issues-to-triage-projects.yml
@@ -1,0 +1,35 @@
+name: Auto Assign New Issues to Triage Project
+
+on:
+  issues:
+    types: [opened]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to New Issues to Triage Project
+    steps:
+    - name: Process bug issues
+      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+      if: contains(github.event.issue.labels.*.name, 'bug') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuspatial/projects/7
+        GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
+    - name: Process feature issues
+      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+      if: contains(github.event.issue.labels.*.name, 'feature request') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuspatial/projects/8
+        GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
+    - name: Process other issues
+      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+      if: contains(github.event.issue.labels.*.name, '? - Needs Triage') && (!contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'feature request'))
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuspatial/projects/9
+        GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'

--- a/.github/workflows/new-issues-to-triage-projects.yml
+++ b/.github/workflows/new-issues-to-triage-projects.yml
@@ -17,19 +17,19 @@ jobs:
       if: contains(github.event.issue.labels.*.name, 'bug') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuspatial/projects/7
+        GITHUB_PROJECT_URL: https://github.com/rapidsai/cusignal/projects/4
         GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
     - name: Process feature issues
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: contains(github.event.issue.labels.*.name, 'feature request') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuspatial/projects/8
+        GITHUB_PROJECT_URL: https://github.com/rapidsai/cusignal/projects/5
         GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
     - name: Process other issues
       uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: contains(github.event.issue.labels.*.name, '? - Needs Triage') && (!contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'feature request'))
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuspatial/projects/9
+        GITHUB_PROJECT_URL: https://github.com/rapidsai/cusignal/projects/6
         GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'


### PR DESCRIPTION
New GitHub Action to move new issues to their appropriate triage projects.

- [x] Move all existing bugs to bug triage project
- [x] Move all existing feature requests to feature triage project
- [x] Move all existing other requests to other triage project

No need for CI as this is not a code change. Review is needed to make sure that correct projects are linked.

---

FYI the triage boards did not exist so they are created now. Also the following labels have been replaced to match the rest of the RAPIDS repos:
- `documentation` is now `doc`
- `enhancement` is now `feature request`

Also the rest of the common RAPIDS labels have been added.