### PR TITLE
[REVIEW] upfirdn/resample_poly documentation update and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #9 - Update cuSignal documentation and Conda install ymls to better support Jetson Devices and prune dependencies
 - PR #11 - Update cuSignal structure to match other RAPIDS projects
 - PR #20 - Updated conda environment and README file
+- PR #27 - Add use_numba documentation in upfirdn and resample_poly; remove int support
 
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - PR #9 - Update cuSignal documentation and Conda install ymls to better support Jetson Devices and prune dependencies
 - PR #11 - Update cuSignal structure to match other RAPIDS projects
 - PR #20 - Updated conda environment and README file
-- PR #27 - Add use_numba documentation in upfirdn and resample_poly; remove int support
+- PR #28 - Add use_numba documentation in upfirdn and resample_poly; remove int support
 
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -125,6 +125,9 @@ _cached_modules = dict()
 
 def _init_raw_apply1d_modules():
 
+    if '_raw_apply_1d_double' in _cached_modules:
+        return
+
     loaded_from_source = r"""
     extern "C" {
 

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1398,6 +1398,9 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
     window : string, tuple, or array_like, optional
         Desired window to use to design the low-pass filter, or the FIR filter
         coefficients to employ. See below for details.
+    use_numba : bool, optional
+        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
+        can yield performance gains over Numba. Default is True.
 
     Returns
     -------


### PR DESCRIPTION
This PR addresses recommendations by @mnicely to remove orphaned code targeting `int` support for upfirdn. This also adds documentation on the `use_numba` option in both `cusignal.upfirdn` and `cusignal.resample_poly`.