### PR TITLE
[REVIEW] Fix multiple issues with resample_poly's prototype filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #29 - Fix typos in README
 - PR #30 - Add Apache 2.0 license header to acoustics.py
 - PR #31 - Adding stream support and additional data types to upfirdn
+- PR #32 - Enable filter coefficient reuse across multiple calls to resample_poly and performance bug fixes
 
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1484,6 +1484,7 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
         half_len = (window.size - 1) // 2
         h = up * window
     else:
+        half_len = 10 * max(up, down)
         h = up * _signaltools._design_resample_poly(up, down, window)
 
     # Zero-pad our filter to put the output samples at the center

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -52,7 +52,6 @@ from . import _signaltools
 from .windows import get_window
 from .fftpack_helper import _init_nd_shape_and_axes_sorted, next_fast_len
 from ._upfirdn import upfirdn, _output_len
-from .fir_filter_design import firwin
 
 _modedict = {"valid": 0, "same": 1, "full": 2}
 
@@ -1485,12 +1484,8 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
         half_len = (window.size - 1) // 2
         h = window
     else:
-        # Design a linear-phase low-pass FIR filter
-        max_rate = max(up, down)
-        f_c = 1.0 / max_rate  # cutoff of FIR filter (rel. to Nyquist)
-        # reasonable cutoff for our sinc-like function
-        half_len = 10 * max_rate
-        h = firwin(2 * half_len + 1, f_c, window=window)
+        h = _signaltools._design_resample_poly(up, down, window)
+
     h *= up
 
     # Zero-pad our filter to put the output samples at the center

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1482,11 +1482,9 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
         if window.ndim > 1:
             raise ValueError("window must be 1-D")
         half_len = (window.size - 1) // 2
-        h = window
+        h = up * window
     else:
-        h = _signaltools._design_resample_poly(up, down, window)
-
-    h *= up
+        h = up * _signaltools._design_resample_poly(up, down, window)
 
     # Zero-pad our filter to put the output samples at the center
     n_pre_pad = down - half_len % down

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1496,7 +1496,10 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
         < n_out + n_pre_remove
     ):
         n_post_pad += 1
-    h = cp.concatenate((zeros(n_pre_pad), h, zeros(n_post_pad)))
+
+    h = cp.concatenate(
+        (zeros(n_pre_pad, h.dtype), h, zeros(n_post_pad, h.dtype))
+    )
     n_pre_remove_end = n_pre_remove + n_out
 
     # filter then remove excess


### PR DESCRIPTION
This set of changes enables filter coefficients to be reused across multiple calls to `cusignal.resample_poly()`. This is important for performance as re-creating the 
coefficient array and uploading it to the GPU each time can be expensive.

Several bugs were found and fixed along the way:

1) Input filter coefficients were supported but would be modified in-place.
2) Double-precision outputs would be produced even if both the input array and the filter coefficients were of lower precision. In practice, this made the float32 kernels never be called which was confirmed by examining `nvprof` traces.
