### PR TITLE
[REVIEW] Remove conda test phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]
+- PR #33 - Removes the conda test phase
 
 # cuSignal 0.1 (04 Nov 2019)
 

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -31,10 +31,6 @@ requirements:
     - numba>=0.46.0
     - cupy>=6.2.0
 
-test:
-  commands:
-    - python -c "import cusignal"
-
 about:
   home: http://rapids.ai/
   license: Apache-2.0


### PR DESCRIPTION
Removes the conda test phase since importing cusignal now needs a GPU for JIT compilation.