### PR TITLE
[REVIEW] Implement CuPy kernels as module object and templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #29 - Fix typos in README
 - PR #30 - Add Apache 2.0 license header to acoustics.py
 - PR #31 - Adding stream support and additional data types to upfirdn
+- PR #34 - Implement CuPy kernels as module object and templating
 
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]


### PR DESCRIPTION
1. Move x_shape_a, h_per_phase, and padded_len to apply_filter to remove redundant code

2. Move CuPy kernels from _init_cupy_upfirdn_1d_modules to module object.
   This allows the cupy kernels to be compiled at import, and eliminates
   compile at first call.
   There's one limitation at the moment, a compile at import is not "device aware";
   therefore, compiled code will reside in the CUDA context of the active device
   during import
   If the user were to target a new GPU, cupy.cuda.runtime.setDevice(X), where
   X is a GPU device id, a crash will occur.
   This error can be mitigated by re-importing after setDevice.
   This mitigation will not be necessary when CuPy implements device awareness.
   https://github.com/cupy/cupy/pull/3200

3. To minimize code due to multiple kernels, where possible, kernels will be templated

4. Multiple types have been put into a dictionary to be used when get_functions,
   CuPy and Numba, in the for loops. Hopefully, this technique will reducing
   coding errors.

By moving CuPy kernel to a Python Module Object, compile on first call is eliminated. See screenshots
![_cached_dicts](https://user-images.githubusercontent.com/50021634/77081378-f30c3900-69d0-11ea-9e7e-cbb9e6147c59.png)
![raw_module_as_object](https://user-images.githubusercontent.com/50021634/77081379-f3a4cf80-69d0-11ea-977e-b4028e700703.png)

