### PR TITLE
Disable Numba CUDA backend in upfirdn/resample_poly by default and update associated docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - PR #32 - Enable filter coefficient reuse across multiple calls to resample_poly and performance bug fixes
 - PR #34 - Implement CuPy kernels as module object and templating
 - PR #35 - Make upfirdn's kernel caching more generic; support 2D
+- PR #36 - Set default upfirdn/resample_poly behavior to use Raw CuPy CUDA kernel rather than Numba; Doc updates
 
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import math
+import warnings
 from string import Template
 
 import cupy as cp
@@ -260,8 +261,10 @@ def _get_backend_kernel(ndim, dtype, grid, block, stream, use_numba):
         raise NotImplementedError(
             "upfirdn() requires ndim <= 2")
     elif ndim > 1 and not use_numba:
-        raise NotImplementedError(
-            "CuPy backend is only implemented for ndim == 1")
+        warnings.warn(
+            "CuPy backend is only implemented for ndim == 1 \
+                Running with Numba CUDA backend", UserWarning)
+        use_numba = True
 
     if use_numba:
         nb_stream = stream_cupy_to_numba(stream)
@@ -322,7 +325,7 @@ class _UpFIRDn(object):
         x,
         axis=-1,
         cp_stream=cp.cuda.stream.Stream(null=True),
-        use_numba=True,
+        use_numba=False,
     ):
         """Apply the prepared filter to the specified axis of a nD signal x"""
 
@@ -380,7 +383,7 @@ def upfirdn(
     down=1,
     axis=-1,
     cp_stream=cp.cuda.stream.Stream(null=True),
-    use_numba=True,
+    use_numba=False,
 ):
     """Upsample, FIR filter, and downsample
     Parameters
@@ -404,7 +407,7 @@ def upfirdn(
         or default stream.
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is True.
+        can yield performance gains over Numba. Default is False.
     Returns
     -------
     y : ndarray

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1374,7 +1374,8 @@ def resample(x, num, t=None, axis=0, window=None):
         return y, new_t
 
 
-def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=False):
+def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0),
+                  use_numba=False):
     """
     Resample `x` along the given axis using polyphase filtering.
 

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1374,7 +1374,7 @@ def resample(x, num, t=None, axis=0, window=None):
         return y, new_t
 
 
-def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
+def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=False):
     """
     Resample `x` along the given axis using polyphase filtering.
 
@@ -1399,7 +1399,7 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), use_numba=True):
         coefficients to employ. See below for details.
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is True.
+        can yield performance gains over Numba. Default is False.
 
     Returns
     -------


### PR DESCRIPTION
This PR makes the following changes:

- Set `use_numba` default value from True to False
- The CuPy backend is only supported for 1D signals presently; if the user sets `use_numba=True` and inputs a 2D array, use Numba CUDA backend
- Update README to V100 updated stats for `resample_poly` and fix data type error