### PR TITLE
[REVIEW] Expansion of Docs to include all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ## Bug Fixes
 - PR #4 - Direct method convolution isn't supported in CuPy, defaulting to NumPy [Examine in future for performance]
 - PR #33 - Removes the conda test phase
+- PR #37 - Fix docs to include all cuSignal modules
 
 # cuSignal 0.1 (04 Nov 2019)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,13 +3,85 @@ cuSignal API Reference
 ~~~~~~~~~~~~~~~~~~~~~~
 
 
-
-Signal Tools
+Core Signal Processing Functions
 ============
 
 Signal Tools
 ------------
 
 .. automodule:: cusignal.signaltools
+    :members:
+    :undoc-members:
+
+
+Waveforms
+============
+
+Waveform Generation
+------------
+
+.. automodule:: cusignal.waveforms
+    :members:
+    :undoc-members:
+
+
+Filter Design
+============
+
+FIR Filters
+------------
+
+.. automodule:: cusignal.fir_filter_design
+    :members:
+    :undoc-members:
+
+
+Window Functions
+============
+
+Windows
+------------
+
+.. automodule:: cusignal.windows
+    :members:
+    :undoc-members:
+
+
+Spectrum Analysis
+============
+
+Spectral
+------------
+
+.. automodule:: cusignal.spectral
+    :members:
+    :undoc-members:
+
+Acoustics
+------------
+
+.. automodule:: cusignal.acoustics
+    :members:
+    :undoc-members:
+
+
+Wavelets
+============
+
+Wavelets
+------------
+
+.. automodule:: cusignal.wavelets
+    :members:
+    :undoc-members:
+
+
+B-splines
+============
+
+B-splines
+------------
+
+.. automodule:: cusignal.bsplines
     :members:
     :undoc-members:


### PR DESCRIPTION
Closes https://github.com/rapidsai/cusignal/issues/12

This hot fix PR adjusts the `api.rst` in the cuSignal docs to include:
* waveforms
* fir_filter_design
* windows
* spectral
* acoustics
* wavelets
* bsplines
