### PR TITLE
Add frequency domain input option to the Resample function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #40 - Ability to specify time/freq domain for resample.
 
 ## Bug Fixes
 

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1249,7 +1249,7 @@ def resample(x, num, t=None, axis=0, window=None, fft=False):
         Specifies the window applied to the signal in the Fourier
         domain.  See below for details.
     fft : bool, optional
-        If True, consider `x` as an FFT. Default is False.
+        If True, consider frequency domain `x`. Default is False.
 
     Returns
     -------

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1226,7 +1226,7 @@ def cmplx_sort(p):
     return take(p, indx, 0), indx
 
 
-def resample(x, num, t=None, axis=0, window=None):
+def resample(x, num, t=None, axis=0, window=None, fft=False):
     """
     Resample `x` to `num` samples using Fourier method along the given axis.
 
@@ -1248,6 +1248,8 @@ def resample(x, num, t=None, axis=0, window=None):
     window : array_like, callable, string, float, or tuple, optional
         Specifies the window applied to the signal in the Fourier
         domain.  See below for details.
+    fft : bool, optional
+        If True, consider `x` as an FFT. Default is False. 
 
     Returns
     -------
@@ -1307,8 +1309,11 @@ def resample(x, num, t=None, axis=0, window=None):
     >>> plt.legend(['data', 'resampled'], loc='best')
     >>> plt.show()
     """
-    x = asarray(x)
-    X = fftpack.fft(x, axis=axis)
+    X = asarray(x)
+    
+    if not fft:
+        X = fftpack.fft(x, axis=axis)
+    
     Nx = x.shape[axis]
     if window is not None:
         if callable(window):
@@ -1638,7 +1643,6 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
         olddims = vals[:axis] + [0] + vals[axis:]
         ret = transpose(ret, tuple(cp.asnumpy(olddims)))
         return ret
-
 
 def freq_shift(x, freq, fs):
     """

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1310,11 +1310,11 @@ def resample(x, num, t=None, axis=0, window=None, fft=False):
     >>> plt.show()
     """
     X = asarray(x)
+    Nx = X.shape[axis]
 
     if not fft:
-        X = fftpack.fft(x, axis=axis)
+        X = fftpack.fft(X, axis=axis)
 
-    Nx = x.shape[axis]
     if window is not None:
         if callable(window):
             W = window(fftpack.fftfreq(Nx))

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1226,7 +1226,7 @@ def cmplx_sort(p):
     return take(p, indx, 0), indx
 
 
-def resample(x, num, t=None, axis=0, window=None, fft=False):
+def resample(x, num, t=None, axis=0, window=None, domain='time'):
     """
     Resample `x` to `num` samples using Fourier method along the given axis.
 
@@ -1248,8 +1248,13 @@ def resample(x, num, t=None, axis=0, window=None, fft=False):
     window : array_like, callable, string, float, or tuple, optional
         Specifies the window applied to the signal in the Fourier
         domain.  See below for details.
-    fft : bool, optional
-        If True, consider frequency domain `x`. Default is False.
+    domain : string, optional
+        A string indicating the domain of the input `x`:
+
+        ``time``
+           Consider the input `x` as time-domain. (Default)
+        ``freq``
+           Consider the input `x` as frequency-domain.
 
     Returns
     -------
@@ -1309,11 +1314,15 @@ def resample(x, num, t=None, axis=0, window=None, fft=False):
     >>> plt.legend(['data', 'resampled'], loc='best')
     >>> plt.show()
     """
-    X = asarray(x)
-    Nx = X.shape[axis]
+    x = asarray(x)
+    Nx = x.shape[axis]
 
-    if not fft:
-        X = fftpack.fft(X, axis=axis)
+    if domain == 'time':
+        X = fftpack.fft(x, axis=axis)
+    elif domain == 'freq':
+        X = x
+    else:
+        raise NotImplementedError("domain should be 'time' or 'freq'")
 
     if window is not None:
         if callable(window):

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1249,7 +1249,7 @@ def resample(x, num, t=None, axis=0, window=None, fft=False):
         Specifies the window applied to the signal in the Fourier
         domain.  See below for details.
     fft : bool, optional
-        If True, consider `x` as an FFT. Default is False. 
+        If True, consider `x` as an FFT. Default is False.
 
     Returns
     -------
@@ -1310,10 +1310,10 @@ def resample(x, num, t=None, axis=0, window=None, fft=False):
     >>> plt.show()
     """
     X = asarray(x)
-    
+
     if not fft:
         X = fftpack.fft(x, axis=axis)
-    
+
     Nx = x.shape[axis]
     if window is not None:
         if callable(window):
@@ -1643,6 +1643,7 @@ def detrend(data, axis=-1, type='linear', bp=0, overwrite_data=False):
         olddims = vals[:axis] + [0] + vals[axis:]
         ret = transpose(ret, tuple(cp.asnumpy(olddims)))
         return ret
+
 
 def freq_shift(x, freq, fs):
     """


### PR DESCRIPTION
The original `resample` function receives a time-domain signal and converts it to the frequency domain to perform the resampling. This pull request proposes to add an option to pass a signal in the frequency domain format. This will reduce the computational load of workloads that require several resamples of the same signal. If the function is called with the `fft` option set to `True` it will skip the `fft` function.