### PR TITLE
[REVIEW] Fixed errors in test_wavelets and test_windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - PR #40 - Ability to specify time/freq domain for resample.
 
 ## Bug Fixes
-
+- PR #44 - Fix issues in pytests 
 
 # cuSignal 0.13 (Date TBD)
 

--- a/python/cusignal/test/test_wavelets.py
+++ b/python/cusignal/test/test_wavelets.py
@@ -11,31 +11,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import cupy as cp
-from cusignal.test.utils import array_equal
-import cusignal
 import numpy as np
+import pytest
 from scipy import signal
 
+import cusignal
+from cusignal.test.utils import array_equal
 
-@pytest.mark.parametrize('num_samps', [2**14])
+
+@pytest.mark.parametrize("num_samps", [2 ** 14])
 def test_morlet(num_samps):
     cpu_window = signal.morlet(num_samps)
     gpu_window = cp.asnumpy(cusignal.morlet(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('a', [10, 1000])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("a", [10, 1000])
 def test_ricker(num_samps, a):
-    cpu_window = signal.morlet(num_samps)
-    gpu_window = cp.asnumpy(cusignal.morlet(num_samps))
+    cpu_window = signal.ricker(num_samps, a)
+    gpu_window = cp.asnumpy(cusignal.ricker(num_samps, a))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('widths', [31, 127])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("widths", [31, 127])
 def test_cwt(num_samps, widths):
     cpu_signal = np.random.rand(int(num_samps))
     gpu_signal = cp.asarray(cpu_signal)
@@ -48,11 +49,11 @@ def test_cwt(num_samps, widths):
     assert array_equal(cpu_cwt, gpu_cwt)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('widths', [31, 127])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("widths", [31, 127])
 def test_cwt_complex(num_samps, widths):
-    cpu_signal = (
-        np.random.rand(int(num_samps)) + 1j * np.random.rand(int(num_samps))
+    cpu_signal = np.random.rand(int(num_samps)) + 1j * np.random.rand(
+        int(num_samps)
     )
     gpu_signal = cp.asarray(cpu_signal)
 

--- a/python/cusignal/test/test_windows.py
+++ b/python/cusignal/test/test_windows.py
@@ -11,14 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import cupy as cp
-from cusignal.test.utils import array_equal
-import cusignal
+import pytest
 from scipy import signal
 
+import cusignal
+from cusignal.test.utils import array_equal
 
-@pytest.mark.parametrize('num_samps', [2**15])
+
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_general_cosine(num_samps):
     HFT90D = [1, 1.942604, 1.340318, 0.440811, 0.043097]
     cpu_window = signal.windows.general_cosine(num_samps, HFT90D, sym=False)
@@ -28,86 +29,86 @@ def test_general_cosine(num_samps):
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_boxcar(num_samps):
     cpu_window = signal.windows.boxcar(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.boxcar(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_triang(num_samps):
     cpu_window = signal.windows.triang(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.triang(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_bohman(num_samps):
     cpu_window = signal.windows.bohman(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.bohman(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_blackman(num_samps):
     cpu_window = signal.windows.blackman(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.blackman(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_nuttall(num_samps):
     cpu_window = signal.windows.nuttall(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.nuttall(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_blackmanharris(num_samps):
     cpu_window = signal.windows.blackmanharris(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.blackmanharris(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_flattop(num_samps):
     cpu_window = signal.windows.flattop(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.flattop(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_barlett(num_samps):
     cpu_window = signal.windows.bartlett(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.bartlett(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_hann(num_samps):
     cpu_window = signal.windows.hann(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.hann(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('alpha', [0.25, 0.5])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("alpha", [0.25, 0.5])
 def test_tukey(num_samps, alpha):
     cpu_window = signal.windows.tukey(num_samps, alpha, sym=True)
     gpu_window = cp.asnumpy(cusignal.windows.tukey(num_samps, alpha, sym=True))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_barthann(num_samps):
     cpu_window = signal.windows.barthann(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.barthann(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('alpha', [0.25, 0.5])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("alpha", [0.25, 0.5])
 def test_general_hamming(num_samps, alpha):
     cpu_window = signal.windows.general_hamming(num_samps, alpha, sym=True)
     gpu_window = cp.asnumpy(
@@ -116,47 +117,49 @@ def test_general_hamming(num_samps, alpha):
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_hamming(num_samps):
     cpu_window = signal.windows.hamming(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.hamming(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('beta', [0.25, 0.5])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("beta", [0.25, 0.5])
 def test_kaiser(num_samps, beta):
     cpu_window = signal.windows.kaiser(num_samps, beta, sym=True)
     gpu_window = cp.asnumpy(cusignal.windows.kaiser(num_samps, beta, sym=True))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('p', [0.75, 1.5])
-@pytest.mark.parametrize('std', [3, 7])
-def test_gaussian(num_samps, p, std):
-    cpu_window = signal.windows.gaussian(num_samps, p, std)
-    gpu_window = cp.asnumpy(cusignal.windows.gaussian(num_samps, p, std))
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("std", [3, 7])
+def test_gaussian(num_samps, std):
+    cpu_window = signal.windows.gaussian(num_samps, std)
+    gpu_window = cp.asnumpy(cusignal.windows.gaussian(num_samps, std))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('std', [3, 7])
-def test_general_gaussian(num_samps, std):
-    cpu_window = signal.windows.general_hamming(num_samps, std)
-    gpu_window = cp.asnumpy(cusignal.windows.general_hamming(num_samps, std))
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("p", [0.75, 1.5])
+@pytest.mark.parametrize("std", [3, 7])
+def test_general_gaussian(num_samps, p, std):
+    cpu_window = signal.windows.general_gaussian(num_samps, p, std)
+    gpu_window = cp.asnumpy(
+        cusignal.windows.general_gaussian(num_samps, p, std)
+    )
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_cosine(num_samps):
     cpu_window = signal.windows.cosine(num_samps)
     gpu_window = cp.asnumpy(cusignal.windows.cosine(num_samps))
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('tau', [1.5, 3.0])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("tau", [1.5, 3.0])
 def test_exponential(num_samps, tau):
     cpu_window = signal.windows.exponential(num_samps, tau=tau)
     gpu_window = cp.asnumpy(cusignal.windows.exponential(num_samps, tau=tau))


### PR DESCRIPTION
NOTE: I think a have a different black formatter configuration causing a few differences.

In `test_wavelets.py`, modifed `test_ricker`

Change
```
@pytest.mark.parametrize('num_samps', [2**14])
@pytest.mark.parametrize('a', [10, 1000])
def test_ricker(num_samps, a):
    cpu_window = signal.morlet(num_samps)
    gpu_window = cp.asnumpy(cusignal.morlet(num_samps))
    assert array_equal(cpu_window, gpu_window)
```
to 
```
@pytest.mark.parametrize("num_samps", [2 ** 14])
@pytest.mark.parametrize("a", [10, 1000])
def test_ricker(num_samps, a):
    cpu_window = signal.ricker(num_samps, a)
    gpu_window = cp.asnumpy(cusignal.ricker(num_samps, a))
    assert array_equal(cpu_window, gpu_window)
```

In `test_waveforms.py, modified `test_gaussian` and `test_general_gaussian`
```
@pytest.mark.parametrize('num_samps', [2**15])
@pytest.mark.parametrize('p', [0.75, 1.5])
@pytest.mark.parametrize('std', [3, 7])
def test_gaussian(num_samps, p, std):
    cpu_window = signal.windows.gaussian(num_samps, p, std)
    gpu_window = cp.asnumpy(cusignal.windows.gaussian(num_samps, p, std))
    assert array_equal(cpu_window, gpu_window)


@pytest.mark.parametrize('num_samps', [2**15])
@pytest.mark.parametrize('std', [3, 7])
def test_general_gaussian(num_samps, std):
    cpu_window = signal.windows.general_hamming(num_samps, std)
    gpu_window = cp.asnumpy(cusignal.windows.general_hamming(num_samps, std))
    assert array_equal(cpu_window, gpu_window)
```
to
```
@pytest.mark.parametrize("num_samps", [2 ** 15])
@pytest.mark.parametrize("std", [3, 7])
def test_gaussian(num_samps, std):
    cpu_window = signal.windows.gaussian(num_samps, std)
    gpu_window = cp.asnumpy(cusignal.windows.gaussian(num_samps, std))
    assert array_equal(cpu_window, gpu_window)


@pytest.mark.parametrize("num_samps", [2 ** 15])
@pytest.mark.parametrize("p", [0.75, 1.5])
@pytest.mark.parametrize("std", [3, 7])
def test_general_gaussian(num_samps, p, std):
    cpu_window = signal.windows.general_gaussian(num_samps, p, std)
    gpu_window = cp.asnumpy(
        cusignal.windows.general_gaussian(num_samps, p, std)
    )
    assert array_equal(cpu_window, gpu_window)
```