### PR TITLE
[REVIEW] Refactor _signaltools.py to new Numba/CuPy framework.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.
+- PR #45 - Refactor `_signaltools.py` to use new Numba/CuPy framework
 
 ## Bug Fixes
 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -262,7 +262,6 @@ def _get_backend_kernel(flip, pick, dtype, grid, block, stream, use_numba):
         nb_stream = stream_cupy_to_numba(stream)
         kernel = _numba_kernel_cache[(flip, pick, dtype.name)]
 
-        kernel.inspect_types()
         if kernel:
             return kernel[grid, block, nb_stream]
 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -12,11 +12,23 @@
 # limitations under the License.
 
 import math
-from numba import cuda
+import warnings
 
 import numpy as np
 import cupy as cp
+from numba import complex64, complex128, cuda, float32, float64, int64, void
+
 from .fir_filter_design import firwin
+
+_numba_kernel_cache = {}
+
+# Numba type supported and corresponding C type
+_SUPPORTED_TYPES = {
+    float32: "float",
+    float64: "double",
+    complex64: "complex<float>",
+    complex128: "complex<double>",
+}
 
 FULL = 2
 SAME = 1
@@ -26,88 +38,128 @@ CIRCULAR = 8
 REFLECT = 4
 PAD = 0
 
-_modedict = {'valid': 0, 'same': 1, 'full': 2}
+_modedict = {"valid": 0, "same": 1, "full": 2}
 
-_boundarydict = {'fill': 0, 'pad': 0, 'wrap': 2, 'circular': 2, 'symm': 1,
-                 'symmetric': 1, 'reflect': 4}
+_boundarydict = {
+    "fill": 0,
+    "pad": 0,
+    "wrap": 2,
+    "circular": 2,
+    "symm": 1,
+    "symmetric": 1,
+    "reflect": 4,
+}
 
 
 def _valfrommode(mode):
     try:
         return _modedict[mode]
     except KeyError:
-        raise ValueError("Acceptable mode flags are 'valid',"
-                         " 'same', or 'full'.")
+        raise ValueError(
+            "Acceptable mode flags are 'valid'," " 'same', or 'full'."
+        )
 
 
 def _bvalfromboundary(boundary):
     try:
         return _boundarydict[boundary] << 2
     except KeyError:
-        raise ValueError("Acceptable boundary flags are 'fill', 'circular' "
-                         "(or 'wrap'), and 'symmetric' (or 'symm').")
+        raise ValueError(
+            "Acceptable boundary flags are 'fill', 'circular' "
+            "(or 'wrap'), and 'symmetric' (or 'symm')."
+        )
 
 
 def _iDivUp(a, b):
     return (a // b + 1) if (a % b != 0) else (a // b)
 
 
-@cuda.jit(fastmath=True)
-def _correlate2d_odd(inp, inpW, inpH, kernel, S, out, outW, outH):
+# Use until functionality provided in Numba 0.49/0.50 available
+def stream_cupy_to_numba(cp_stream):
+    """
+    Notes:
+        1. The lifetime of the returned Numba stream should be as
+           long as the CuPy one, which handles the deallocation
+           of the underlying CUDA stream.
+        2. The returned Numba stream is assumed to live in the same
+           CUDA context as the CuPy one.
+        3. The implementation here closely follows that of
+           cuda.stream() in Numba.
+    """
+    from ctypes import c_void_p
+    import weakref
+
+    # get the pointer to actual CUDA stream
+    raw_str = cp_stream.ptr
+
+    # gather necessary ingredients
+    ctx = cuda.devices.get_context()
+    handle = c_void_p(raw_str)
+
+    # create a Numba stream
+    nb_stream = cuda.cudadrv.driver.Stream(
+        weakref.proxy(ctx), handle, finalizer=None
+    )
+
+    return nb_stream
+
+
+def _correlate2d_odd(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
     x, y = cuda.grid(2)
-    j = x + S
-    i = y + S
+    j = cp.int32(x + S)
+    i = cp.int32(y + S)
 
-    if ((x >= 0) and (x < outW) and (y >= 0) and (y < outH)):
+    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
-        for k in range(-S, S + 1):
-            for l in range(-S, S + 1):
-                iPixelPos = ((i + k), (j + l))
-                coefPos = ((k + S), (l + S))
+        for k in range(cp.int32(-S), cp.int32(S + 1)):
+            for l in range(cp.int32(-S), cp.int32(S + 1)):
+                iPixelPos = (cp.int32(i + k), cp.int32(j + l))
+                coefPos = (cp.int32(k + S), cp.int32(l + S))
                 temp += inp[iPixelPos] * kernel[coefPos]
 
         out[oPixelPos] = temp
 
 
 # For square/even kernels
-@cuda.jit(fastmath=True)
-def _correlate2d_even(inp, inpW, inpH, kernel, S, out, outW, outH):
+def _correlate2d_even(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
     x, y = cuda.grid(2)
-    j = x + S
-    i = y + S
+    j = cp.int32(x + S)
+    i = cp.int32(y + S)
 
-    if ((x >= 0) and (x < outW) and (y >= 0) and (y < outH)):
+    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
-        for k in range(-S, S):
-            for l in range(-S, S):
-                iPixelPos = ((i + k), (j + l))
-                coefPos = (k + S, l + S)
+        for k in range(cp.int32(-S), cp.int32(S)):
+            for l in range(cp.int32(-S), cp.int32(S)):
+                iPixelPos = (cp.int32(i + k), cp.int32(j + l))
+                coefPos = (cp.int32(k + S), cp.int32(l + S))
                 temp += inp[iPixelPos] * kernel[coefPos]
 
         out[oPixelPos] = temp
 
 
 # For non-square kernels
-@cuda.jit(fastmath=True)
 def _correlate2d_ns(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
     x, y = cuda.grid(2)
-    j = x + S
-    i = y + S1
+    j = cp.int32(x + S)
+    i = cp.int32(y + S1)
 
-    if ((x >= 0) and (x < outW) and (y >= 0) and (y < outH)):
+    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
-        for k in range(S):
-            for l in range(S1):
-                iPixelPos = ((i + k - S1), (j + l - S))
+        for k in range(cp.int32(S)):
+            for l in range(cp.int32(S1)):
+                iPixelPos = (
+                    cp.int32(cp.int32(i + k) - S1),
+                    cp.int32(cp.int32(j + l) - S),
+                )
                 coefPos = (k, l)
                 temp += inp[iPixelPos] * kernel[coefPos]
 
@@ -115,90 +167,161 @@ def _correlate2d_ns(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
 
 # For square/odd kernels
-@cuda.jit(fastmath=True)
-def _convolve2d_odd(inp, inpW, inpH, kernel, S, out, outW, outH):
+def _convolve2d_odd(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
     x, y = cuda.grid(2)
-    j = x + S
-    i = y + S
+    j = cp.int32(x + S)
+    i = cp.int32(y + S)
 
-    if ((x >= 0) and (x < outW) and (y >= 0) and (y < outH)):
+    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
-        for k in range(-S, S + 1):
-            for l in range(-S, S + 1):
-                iPixelPos = ((i + k), (j + l))
-                coefPos = ((-k + S), (-l + S))
+        for k in range(cp.int32(-S), cp.int32(S + 1)):
+            for l in range(cp.int32(-S), cp.int32(S + 1)):
+                iPixelPos = (cp.int32(i + k), cp.int32(j + l))
+                coefPos = (cp.int32(-k + S), cp.int32(-l + S))
                 temp += inp[iPixelPos] * kernel[coefPos]
 
         out[oPixelPos] = temp
 
 
 # For square/even kernels
-@cuda.jit(fastmath=True)
-def _convolve2d_even(inp, inpW, inpH, kernel, S, out, outW, outH):
+def _convolve2d_even(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
     x, y = cuda.grid(2)
-    j = x + S
-    i = y + S
+    j = cp.int32(x + S)
+    i = cp.int32(y + S)
 
-    if ((x >= 0) and (x < outW) and (y >= 0) and (y < outH)):
+    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
-        for k in range(-S, S):
-            for l in range(-S, S):
-                iPixelPos = ((i + k), (j + l))
-                coefPos = (-k + (S - 1), -l + (S - 1))
+        for k in range(cp.int32(-S), cp.int32(S)):
+            for l in range(cp.int32(-S), cp.int32(S)):
+                iPixelPos = (cp.int32(i + k), cp.int32(j + l))
+                coefPos = (
+                    cp.int32(cp.int32(-k + S) - 1),
+                    cp.int32(cp.int32(-l + S) - 1),
+                )
                 temp += inp[iPixelPos] * kernel[coefPos]
 
         out[oPixelPos] = temp
 
 
 # For non-square kernels
-@cuda.jit(fastmath=True)
 def _convolve2d_ns(inp, inpW, inpH, kernel, S, S1, out, outW, outH):
 
     x, y = cuda.grid(2)
-    j = x + S
-    i = y + S1
+    j = cp.int32(x + S)
+    i = cp.int32(y + S1)
 
-    if ((x >= 0) and (x < outW) and (y >= 0) and (y < outH)):
+    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
-        for k in range(S):
-            for l in range(S1):
-                iPixelPos = ((i + k - S1), (j + l - S))
-                coefPos = (-k + (S - 1), -l + (S1 - 1))
+        for k in range(cp.int32(S)):
+            for l in range(cp.int32(S1)):
+                iPixelPos = (
+                    cp.int32(cp.int32(i + k) - S1),
+                    cp.int32(cp.int32(j + l) - S),
+                )
+                coefPos = (
+                    cp.int32(cp.int32(-k + S) - 1),
+                    cp.int32(cp.int32(-l + S1) - 1),
+                )
                 temp += inp[iPixelPos] * kernel[coefPos]
 
         out[oPixelPos] = temp
 
 
-def _convolve2d_gpu(inp, out, kernel, mode, boundary, flip, fillvalue):
+def _numba_signature(ty):
+    return void(
+        ty[:, :],  # inp
+        int64,  # inpW
+        int64,  # inpH
+        ty[:, :],  # kernel
+        int64,  # S
+        int64,  # S1 - only used by non-squares
+        ty[:, :],  # out
+        int64,  # outW
+        int64,  # outH
+    )
 
-    if ((boundary != PAD) and (boundary != REFLECT) and
-            (boundary != CIRCULAR)):
-        raise Exception('Invalid boundary flag')
+
+def _get_backend_kernel(flip, pick, dtype, grid, block, stream, use_numba):
+    if not use_numba:
+        warnings.warn(
+            "CuPy backend is not implemented \
+                Running with Numba CUDA backend",
+            UserWarning,
+        )
+        use_numba = True
+
+    if use_numba:
+        nb_stream = stream_cupy_to_numba(stream)
+        kernel = _numba_kernel_cache[(flip, pick, dtype.name)]
+
+        kernel.inspect_types()
+        if kernel:
+            return kernel[grid, block, nb_stream]
+
+    raise NotImplementedError(
+        "No kernel found for flip {}, pick {}, datatype {}".format(
+            flip, pick, dtype.name
+        )
+    )
+
+
+def _populate_kernel_cache():
+    for numba_type, _ in _SUPPORTED_TYPES.items():
+        # JIT compile the numba kernels, flip = 0/1, pick = 1/2/3
+        sig = _numba_signature(numba_type)
+        _numba_kernel_cache[(1, 1, str(numba_type))] = cuda.jit(
+            sig, fastmath=True
+        )(_convolve2d_odd)
+        _numba_kernel_cache[(1, 2, str(numba_type))] = cuda.jit(
+            sig, fastmath=True
+        )(_convolve2d_even)
+        _numba_kernel_cache[(1, 3, str(numba_type))] = cuda.jit(
+            sig, fastmath=True
+        )(_convolve2d_ns)
+
+        _numba_kernel_cache[(0, 1, str(numba_type))] = cuda.jit(
+            sig, fastmath=True
+        )(_correlate2d_odd)
+        _numba_kernel_cache[(0, 2, str(numba_type))] = cuda.jit(
+            sig, fastmath=True
+        )(_correlate2d_even)
+        _numba_kernel_cache[(0, 3, str(numba_type))] = cuda.jit(
+            sig, fastmath=True
+        )(_correlate2d_ns)
+
+
+def _convolve2d_gpu(
+    inp, out, kernel, mode, boundary, flip, fillvalue, cp_stream, use_numba,
+):
+
+    if (boundary != PAD) and (boundary != REFLECT) and (boundary != CIRCULAR):
+        raise Exception("Invalid boundary flag")
 
     # If kernel is square and odd
-    if (kernel.shape[0] == kernel.shape[1]):  # square
-        if (kernel.shape[0] % 2 == 1):  # odd
+    if kernel.shape[0] == kernel.shape[1]:  # square
+        S1 = 0  # Not used
+        if kernel.shape[0] % 2 == 1:  # odd
             pick = 1
             S = (kernel.shape[0] - 1) // 2
-            if (mode == 2):  # full
+            if mode == 2:  # full
                 P1 = P2 = P3 = P4 = S * 2
             else:  # same/valid
                 P1 = P2 = P3 = P4 = S
         else:  # even
             pick = 2
             S = kernel.shape[0] // 2
-            if (mode == 2):  # full
+            if mode == 2:  # full
                 P1 = P2 = P3 = P4 = S * 2 - 1
             else:  # same/valid
-                if (flip):
+                if flip:
                     P1 = P2 = P3 = P4 = S
                 else:
                     P1 = P3 = S - 1
@@ -207,13 +330,13 @@ def _convolve2d_gpu(inp, out, kernel, mode, boundary, flip, fillvalue):
         pick = 3
         S = kernel.shape[0]
         S1 = kernel.shape[1]
-        if (mode == 2):  # full
+        if mode == 2:  # full
             P1 = S - 1
             P2 = S - 1
             P3 = S1 - 1
             P4 = S1 - 1
         else:  # same/valid
-            if (flip):
+            if flip:
                 P1 = S // 2
                 P2 = S // 2 if (S % 2) else S // 2 - 1
                 P3 = S1 // 2
@@ -224,26 +347,28 @@ def _convolve2d_gpu(inp, out, kernel, mode, boundary, flip, fillvalue):
                 P3 = S1 // 2 if (S1 % 2) else S1 // 2 - 1
                 P4 = S1 // 2
 
-    if (mode == 1):  # SAME
+    if mode == 1:  # SAME
         pad = ((P1, P2), (P3, P4))  # 4x5
-        if (boundary == REFLECT):
+        if boundary == REFLECT:
             # symmetric not implemented in cupy, move to numpy
-            inp = cp.asarray(np.pad(cp.asnumpy(inp), cp.asnumpy(pad),
-                                    'symmetric'))
-        if (boundary == CIRCULAR):
-            inp = cp.asarray(np.pad(cp.asnumpy(inp), cp.asnumpy(pad), 'wrap'))
-        if (boundary == PAD):
-            inp = cp.pad(inp, pad, 'constant', constant_values=(fillvalue))
+            inp = cp.asarray(
+                np.pad(cp.asnumpy(inp), cp.asnumpy(pad), "symmetric")
+            )
+        if boundary == CIRCULAR:
+            inp = cp.asarray(np.pad(cp.asnumpy(inp), cp.asnumpy(pad), "wrap"))
+        if boundary == PAD:
+            inp = cp.pad(inp, pad, "constant", constant_values=(fillvalue))
 
-    if (mode == 2):  # FULL
+    if mode == 2:  # FULL
         pad = ((P1, P2), (P3, P4))
-        if (boundary == REFLECT):
-            inp = cp.asarray(np.pad(cp.asnumpy(inp), cp.asnumpy(pad),
-                                    'symmetric'))
-        if (boundary == CIRCULAR):
-            inp = cp.asarray(np.pad(cp.asnumpy(inp), cp.asnumpy(pad), 'wrap'))
-        if (boundary == PAD):
-            inp = cp.pad(inp, pad, 'constant', constant_values=(fillvalue))
+        if boundary == REFLECT:
+            inp = cp.asarray(
+                np.pad(cp.asnumpy(inp), cp.asnumpy(pad), "symmetric")
+            )
+        if boundary == CIRCULAR:
+            inp = cp.asarray(np.pad(cp.asnumpy(inp), cp.asnumpy(pad), "wrap"))
+        if boundary == PAD:
+            inp = cp.pad(inp, pad, "constant", constant_values=(fillvalue))
 
     paddedW = inp.shape[1]
     paddedH = inp.shape[0]
@@ -254,96 +379,88 @@ def _convolve2d_gpu(inp, out, kernel, mode, boundary, flip, fillvalue):
     d_inp = cp.array(inp)
     d_kernel = cp.array(kernel)
 
-    threadsPerBlock = (16, 16)
-    blocksPerGrid = (_iDivUp(outW, threadsPerBlock[0]),
-                     _iDivUp(outH, threadsPerBlock[1]))
+    threadsperblock = (16, 16)
+    blockspergrid = (
+        _iDivUp(outW, threadsperblock[0]),
+        _iDivUp(outH, threadsperblock[1]),
+    )
 
-    if (flip):
-        if (pick == 1):
-            _convolve2d_odd[blocksPerGrid, threadsPerBlock](
-                d_inp, paddedW, paddedH, d_kernel, S, out, outW, outH
-            )
-        elif (pick == 2):
-            _convolve2d_even[blocksPerGrid, threadsPerBlock](
-                d_inp, paddedW, paddedH, d_kernel, S, out, outW, outH
-            )
-        elif (pick == 3):
-            _convolve2d_ns[blocksPerGrid, threadsPerBlock](
-                d_inp, paddedW, paddedH, d_kernel, S, S1, out, outW, outH
-            )
-    else:
-        if (pick == 1):
-            _correlate2d_odd[blocksPerGrid, threadsPerBlock](
-                d_inp, paddedW, paddedH, d_kernel, S, out, outW, outH
-            )
-        elif (pick == 2):
-            _correlate2d_even[blocksPerGrid, threadsPerBlock](
-                d_inp, paddedW, paddedH, d_kernel, S, out, outW, outH
-            )
-        elif (pick == 3):
-            _correlate2d_ns[blocksPerGrid, threadsPerBlock](
-                d_inp, paddedW, paddedH, d_kernel, S, S1, out, outW, outH
-            )
+    kernel = _get_backend_kernel(
+        flip,
+        pick,
+        out.dtype,
+        blockspergrid,
+        threadsperblock,
+        cp_stream,
+        use_numba,
+    )
+
+    kernel(
+        d_inp, paddedW, paddedH, d_kernel, S, S1, out, outW, outH,
+    )
 
     return out
 
 
-def _convolve2d(in1, in2, flip, mode='full', boundary='fill', fillvalue=0):
+def _convolve2d(
+    in1,
+    in2,
+    flip,
+    mode="full",
+    boundary="fill",
+    fillvalue=0,
+    cp_stream=cp.cuda.stream.Stream(null=True),
+    use_numba=False,
+):
 
     # Promote inputs
     promType = cp.promote_types(in1.dtype, in2.dtype)
     in1 = in1.astype(promType)
     in2 = in2.astype(promType)
 
-    if ((boundary != PAD) and (boundary != REFLECT) and
-            (boundary != CIRCULAR)):
-        raise Exception('Incorrect boundary value.')
+    if (boundary != PAD) and (boundary != REFLECT) and (boundary != CIRCULAR):
+        raise Exception("Incorrect boundary value.")
 
-    if ((boundary == PAD) and (fillvalue is not None)):
+    if (boundary == PAD) and (fillvalue is not None):
         fill = np.array(fillvalue, in1.dtype)
-        if (fill is None):
-            raise Exception('If you see this let developers know.')
-        if (fill.size != 1):
-            if (fill.size == 0):
-                raise Exception('`fillvalue` cannot be an empty array.')
+        if fill is None:
+            raise Exception("If you see this let developers know.")
+        if fill.size != 1:
+            if fill.size == 0:
+                raise Exception("`fillvalue` cannot be an empty array.")
             raise Exception(
-                '`fillvalue` must be scalar or an array with one element'
+                "`fillvalue` must be scalar or an array with one element"
             )
     else:
         fill = np.zeros(1, in1.dtype)
-        if (fill is None):
-            raise Exception('Unable to create fill array')
+        if fill is None:
+            raise Exception("Unable to create fill array")
 
     # Create empty array to hold number of aout dimensions
     out_dimens = np.empty(in1.ndim, np.int)
-    if (mode == VALID):
+    if mode == VALID:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] - in2.shape[i] + 1
             if out_dimens[i] < 0:
                 raise Exception(
-                    'no part of the output is valid, use option 1 (same) or 2 \
-                     (full) for third argument'
+                    "no part of the output is valid, use option 1 (same) or 2 \
+                     (full) for third argument"
                 )
-    elif (mode == SAME):
+    elif mode == SAME:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i]
-    elif (mode == FULL):
+    elif mode == FULL:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] + in2.shape[i] - 1
     else:
-        raise Exception('mode must be 0 (valid), 1 (same), or 2 (full)')
+        raise Exception("mode must be 0 (valid), 1 (same), or 2 (full)")
 
     # Create empty array out on GPU
     out = cp.empty(out_dimens.tolist(), in1.dtype)
 
     out = _convolve2d_gpu(
-        in1,
-        out,
-        in2,
-        mode,
-        boundary,
-        flip,
-        fill)
+        in1, out, in2, mode, boundary, flip, fill, cp_stream, use_numba
+    )
 
     return out
 
@@ -401,3 +518,7 @@ def _design_resample_poly(up, down, window):
 
     h = firwin(2 * half_len + 1, f_c, window=window)
     return h
+
+
+# 1) Load and compile upfirdn kernels for each supported data type.
+_populate_kernel_cache()


### PR DESCRIPTION
This PR does the following

1. Refactor `_signaltools.py` to utilize the new Numba/CuPy framework we added in `_upfirdn.py`. This will allow us to added CuPy kernels next
2. With (1), added type specialization to all Numba kernels
3. Reduces the number of registers per kernel from 64 to 32. 