### PR TITLE
[REVIEW] Addition of decimation for FIR ftypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # cuSignal 0.14 (Date TBD)
 
 ## New Features
-- PR #46 - Addition of decimate for FIR ftypes
+- PR #48 - Addition of decimate for FIR ftypes
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuSignal 0.14 (Date TBD)
 
 ## New Features
+- PR #46 - Addition of decimate for FIR ftypes
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -32,7 +32,8 @@ from cusignal.signaltools import (
     resample_poly,
     vectorstrength,
     detrend,
-    freq_shift
+    freq_shift,
+    decimate
 )
 from cusignal.windows import (
     general_cosine,

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1750,15 +1750,14 @@ def decimate(x, q, n=None, axis=-1, zero_phase=True):
     sl = [slice(None)] * x.ndim
     a = cp.asarray(a)
 
-    if a.size == 1:  # FIR case
-        b = b / a
-        if zero_phase:
-            y = resample_poly(x, 1, q, axis=axis, window=b)
-        else:
-            # upfirdn is generally faster than lfilter by a factor equal to the
-            # downsampling factor, since it only calculates the needed outputs
-            n_out = x.shape[axis] // q + bool(x.shape[axis] % q)
-            y = upfirdn(b, x, up=1, down=q, axis=axis)
-            sl[axis] = slice(None, n_out, None)
+    b = b / a
+    if zero_phase:
+        y = resample_poly(x, 1, q, axis=axis, window=b)
+    else:
+        # upfirdn is generally faster than lfilter by a factor equal to the
+        # downsampling factor, since it only calculates the needed outputs
+        n_out = x.shape[axis] // q + bool(x.shape[axis] % q)
+        y = upfirdn(b, x, up=1, down=q, axis=axis)
+        sl[axis] = slice(None, n_out, None)
 
     return y[tuple(sl)]

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -170,3 +170,20 @@ def test_correlate2d(num_samps, num_taps, boundary, mode):
         cusignal.correlate2d(gpu_sig, gpu_filt, boundary=boundary, mode=mode)
     )
     assert array_equal(cpu_correlate2d, gpu_correlate2d)
+
+
+@pytest.mark.parametrize('num_samps', [2**14])
+@pytest.mark.parametrize('downsample_factor', [2, 3, 4, 8, 64])
+@pytest.mark.parametrize('zero_phase', [True, False])
+def test_decimate(num_samps, downsample_factor, zero_phase):
+    cpu_time = np.linspace(0, 10, num_samps, endpoint=False)
+    cpu_sig = np.cos(-cpu_time ** 2 / 6.0)
+    gpu_sig = cp.asarray(cpu_sig)
+
+    cpu_decimate = signal.decimate(cpu_sig, downsample_factor,
+                                   ftype='fir', zero_phase=zero_phase)
+    gpu_decimate = cp.asnumpy(
+        cusignal.decimate(gpu_sig, downsample_factor, zero_phase=zero_phase)
+    )
+
+    assert array_equal(cpu_decimate, gpu_decimate)


### PR DESCRIPTION
Closes https://github.com/rapidsai/cusignal/issues/47

This PR adds `decimate` support for FIR filters. IIR filters are still not yet supported. This PR leverages the recent improvements to `resample_poly` and `upfirdn` (raw CuPy CUDA kernels, CUDA streams, etc).

I've added a decimate test to the pytests as well, but we may benefit from some more performance benchmarking.

CC @boonedoggle