### PR TITLE
[REVIEW] Added CuPy raw kernels for correlate2d and convolve2d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 - PR #43 - Add pytest-benchmarks tests
+- PR #49 - Add CuPy Module for convolve2d and correlate2d
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -12,18 +12,31 @@
 # limitations under the License.
 
 import math
-import warnings
+from string import Template
 
 import numpy as np
 import cupy as cp
-from numba import complex64, complex128, cuda, float32, float64, int64, void
+from numba import (
+    complex64,
+    complex128,
+    cuda,
+    float32,
+    float64,
+    int32,
+    int64,
+    void,
+)
+from numba.types.scalars import Complex
 
 from .fir_filter_design import firwin
 
 _numba_kernel_cache = {}
+_cupy_kernel_cache = {}
 
 # Numba type supported and corresponding C type
 _SUPPORTED_TYPES = {
+    int32: "int",
+    int64: "long int",
     float32: "float",
     float64: "double",
     complex64: "complex<float>",
@@ -104,13 +117,18 @@ def stream_cupy_to_numba(cp_stream):
     return nb_stream
 
 
-def _numba_correlate2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
+def _numba_correlate_2d(
+    inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick
+):
 
     x, y = cuda.grid(2)
     j = cp.int32(x + S0)
-    i = cp.int32(y + S0)
+    if pick != 3:  # non-square
+        i = cp.int32(y + S0)
+    else:
+        i = cp.int32(y + S1)
 
-    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
+    if (x < outW) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
@@ -120,6 +138,7 @@ def _numba_correlate2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
                     iPixelPos = (cp.int32(i + k), cp.int32(j + l))
                     coefPos = (cp.int32(k + S0), cp.int32(l + S0))
                     temp += inp[iPixelPos] * kernel[coefPos]
+                    # temp = x
 
         elif pick == 2:  # even
             for k in range(cp.int32(-S0), cp.int32(S0)):
@@ -141,14 +160,16 @@ def _numba_correlate2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
         out[oPixelPos] = temp
 
 
-# For square/odd kernels
-def _numba_convolve2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
+def _numba_convolve_2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
 
     x, y = cuda.grid(2)
     j = cp.int32(x + S0)
-    i = cp.int32(y + S0)
+    if pick != 3:  # non-square
+        i = cp.int32(y + S0)
+    else:
+        i = cp.int32(y + S1)
 
-    if (x >= 0) and (x < outW) and (y >= 0) and (y < outH):
+    if (x < outW) and (y < outH):
         oPixelPos = (y, x)
         temp: out.dtype = 0
 
@@ -181,11 +202,12 @@ def _numba_convolve2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
                         cp.int32(cp.int32(-l + S1) - 1),
                     )
                     temp += inp[iPixelPos] * kernel[coefPos]
+                    # temp = inp[iPixelPos]
 
         out[oPixelPos] = temp
 
 
-def _numba_signature(ty):
+def _numba_convolve_2d_signature(ty):
     return void(
         ty[:, :],  # inp
         int64,  # inpW
@@ -200,14 +222,188 @@ def _numba_signature(ty):
     )
 
 
-def _get_backend_kernel(flip, dtype, grid, block, stream, use_numba):
-    if not use_numba:
-        warnings.warn(
-            "CuPy backend is not implemented \
-                Running with Numba CUDA backend",
-            UserWarning,
+# Custom Cupy raw kernel implementing upsample, filter, downsample operation
+# Matthew Nicely - mnicely@nvidia.com
+loaded_from_source = Template(
+    """
+$header
+
+extern "C" {
+    __global__ void _cupy_correlate_2d(
+            const ${datatype} * __restrict__ inp,
+            const int inpW,
+            const int inpH,
+            const ${datatype} * __restrict__ kernel,
+            const int kerW,
+            const int kerH,
+            const int S0,
+            const int S1,
+            ${datatype} * __restrict__ out,
+            const int outW,
+            const int outH,
+            const int pick) {
+
+        const int ty {
+            static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x) };
+        const int tx {
+            static_cast<int>(blockIdx.y * blockDim.y + threadIdx.y) };
+
+        int i {};
+        if ( pick != 3 ) {
+            i = tx + S0;
+        } else {
+            i = tx + S1;
+        }
+        int j { ty + S0 };
+
+        int2 oPixelPos {tx, ty};
+        if ( (tx < outH) && (ty < outW) ) {
+            ${datatype} temp {};
+
+            // Odd
+            if ( pick == 1) {
+                for (int k = -S0; k < (S0 + 1); k++){
+                    for (int l = -S0; l < (S0 + 1); l++) {
+                        int2 iPixelPos {(i + k), (j + l)};
+                        int2 coefPos {(k + S0), (l + S0)};
+                        temp += inp[iPixelPos.x * inpW + iPixelPos.y] *
+                            kernel[coefPos.x * kerW + coefPos.y];
+                    }
+                }
+
+            // Even
+            } else if (pick == 2) {
+                for (int k = -S0; k < S0; k++){
+                    for (int l = -S0; l < S0; l++) {
+                        int2 iPixelPos {(i + k), (j + l)}; // iPixelPos[1], [0]
+                        int2 coefPos {(k + S0), (l + S0)};
+                        temp += inp[iPixelPos.x * inpW + iPixelPos.y] *
+                            kernel[coefPos.x * kerW + coefPos.y];
+                    }
+                }
+
+            // Non-squares
+            } else {
+                for (int k = 0; k < S0; k++){
+                    for (int l = 0; l < S1; l++) {
+                        int2 iPixelPos {(i + k - S1), (j + l - S0)};
+                        int2 coefPos {k, l};
+                        temp += inp[iPixelPos.x * inpW + iPixelPos.y] *
+                            kernel[coefPos.x * kerH + coefPos.y];
+                    }
+                }
+            }
+            out[oPixelPos.x * outW + oPixelPos.y] = temp;
+        }
+    }
+
+    __global__ void _cupy_convolve_2d(
+            const ${datatype} * __restrict__ inp,
+            const int inpW,
+            const int inpH,
+            const ${datatype} * __restrict__ kernel,
+            const int kerW,
+            const int kerH,
+            const int S0,
+            const int S1,
+            ${datatype} * __restrict__ out,
+            const int outW,
+            const int outH,
+            const int pick) {
+
+        const int ty {
+            static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x) };
+        const int tx {
+            static_cast<int>(blockIdx.y * blockDim.y + threadIdx.y) };
+
+        int i {};
+        if ( pick != 3 ) {
+            i = tx + S0;
+        } else {
+            i = tx + S1;
+        }
+        int j { ty + S0 };
+
+        int2 oPixelPos {tx, ty};
+        if ( (tx < outH) && (ty < outW) ) {
+            ${datatype} temp {};
+
+            // Odd kernel
+            if ( pick == 1) {
+                for (int k = -S0; k < (S0 + 1); k++){
+                    for (int l = -S0; l < (S0 + 1); l++) {
+                        int2 iPixelPos {(i + k), (j + l)};
+                        int2 coefPos {(-k + S0), (-l + S0)};
+                        temp += inp[iPixelPos.x * inpW + iPixelPos.y] *
+                            kernel[coefPos.x * kerW + coefPos.y];
+                    }
+                }
+            // Even kernel
+            } else if (pick == 2) {
+                for (int k = -S0; k < S0; k++){
+                    for (int l = -S0; l < S0; l++) {
+                        int2 iPixelPos {(i + k), (j + l)};
+                        int2 coefPos {(-k + S0 - 1), (-l + S0 - 1)};
+                        temp += inp[iPixelPos.x * inpW + iPixelPos.y] *
+                            kernel[coefPos.x * kerW + coefPos.y];
+                    }
+                }
+
+            // Non-squares kernel
+            } else {
+                for (int k = 0; k < S0; k++){
+                    for (int l = 0; l < S1; l++) {
+                        int2 iPixelPos {(i + k - S1), (j + l - S0)};
+                        int2 coefPos {(-k + S0 - 1), (-l + S1 - 1)};
+                        temp += inp[iPixelPos.x * inpW + iPixelPos.y] *
+                            kernel[coefPos.x * kerH + coefPos.y];
+                    }
+                }
+            }
+            out[oPixelPos.x * outW + oPixelPos.y] = temp;
+        }
+    }
+}
+"""
+)
+
+
+class _cupy_convolve_2d_wrapper(object):
+    def __init__(self, grid, block, stream, kernel):
+        if isinstance(grid, int):
+            grid = (grid,)
+        if isinstance(block, int):
+            block = (block,)
+
+        self.grid = grid
+        self.block = block
+        self.stream = stream
+        self.kernel = kernel
+
+    def __call__(
+        self, d_inp, paddedW, paddedH, d_kernel, S0, S1, out, outW, outH, pick,
+    ):
+
+        kernel_args = (
+            d_inp,
+            paddedW,
+            paddedH,
+            d_kernel,
+            d_kernel.shape[0],
+            d_kernel.shape[1],
+            S0,
+            S1,
+            out,
+            outW,
+            outH,
+            pick,
         )
-        use_numba = True
+
+        self.stream.use()
+        self.kernel(self.grid, self.block, kernel_args)
+
+
+def _get_backend_kernel(flip, dtype, grid, block, stream, use_numba):
 
     if use_numba:
         nb_stream = stream_cupy_to_numba(stream)
@@ -215,6 +411,10 @@ def _get_backend_kernel(flip, dtype, grid, block, stream, use_numba):
 
         if kernel:
             return kernel[grid, block, nb_stream]
+    else:
+        kernel = _cupy_kernel_cache[(flip, dtype.name)]
+        if kernel:
+            return _cupy_convolve_2d_wrapper(grid, block, stream, kernel)
 
     raise NotImplementedError(
         "No kernel found for flip {}, datatype {}".format(flip, dtype.name)
@@ -222,15 +422,31 @@ def _get_backend_kernel(flip, dtype, grid, block, stream, use_numba):
 
 
 def _populate_kernel_cache():
-    for numba_type, _ in _SUPPORTED_TYPES.items():
+    for numba_type, c_type in _SUPPORTED_TYPES.items():
         # JIT compile the numba kernels, flip = 0/1 (correlate/convolve)
-        sig = _numba_signature(numba_type)
+        sig = _numba_convolve_2d_signature(numba_type)
         _numba_kernel_cache[(0, str(numba_type))] = cuda.jit(
             sig, fastmath=True
-        )(_numba_correlate2d)
+        )(_numba_correlate_2d)
         _numba_kernel_cache[(1, str(numba_type))] = cuda.jit(
             sig, fastmath=True
-        )(_numba_convolve2d)
+        )(_numba_convolve_2d)
+
+        # Instantiate the cupy kernel for this type and compile
+        if isinstance(numba_type, Complex):
+            header = "#include <cupy/complex.cuh>"
+        else:
+            header = ""
+        src = loaded_from_source.substitute(datatype=c_type, header=header)
+        module2 = cp.RawModule(
+            code=src, options=("-std=c++11", "-use_fast_math")
+        )
+        _cupy_kernel_cache[(0, str(numba_type))] = module2.get_function(
+            "_cupy_correlate_2d"
+        )
+        _cupy_kernel_cache[(1, str(numba_type))] = module2.get_function(
+            "_cupy_convolve_2d"
+        )
 
 
 def _convolve2d_gpu(
@@ -321,14 +537,25 @@ def _convolve2d_gpu(
         _iDivUp(outH, threadsperblock[1]),
     )
 
-    kernel = _get_backend_kernel(
+    kernell = _get_backend_kernel(
         flip, out.dtype, blockspergrid, threadsperblock, cp_stream, use_numba,
     )
 
-    kernel(
+    # print(
+    #     paddedW,
+    #     paddedH,
+    #     d_inp.strides,
+    #     S[0],
+    #     S[1],
+    #     outW,
+    #     outH,
+    #     out.strides,
+    #     pick,
+    # )
+
+    kernell(
         d_inp, paddedW, paddedH, d_kernel, S[0], S[1], out, outW, outH, pick
     )
-
     return out
 
 
@@ -389,7 +616,15 @@ def _convolve2d(
     out = cp.empty(out_dimens.tolist(), in1.dtype)
 
     out = _convolve2d_gpu(
-        in1, out, in2, mode, boundary, flip, fill, cp_stream, use_numba
+        in1,
+        out,
+        in2,
+        mode,
+        boundary,
+        flip,
+        fill,
+        cp_stream=cp_stream,
+        use_numba=use_numba,
     )
 
     return out

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -287,8 +287,16 @@ class BenchConvolve2d:
         cpu_filt, _ = rand_2d_data_gen(num_taps)
         benchmark(self.cpu_version, cpu_sig, cpu_filt, boundary, mode)
 
+    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_convolve2d_gpu(
-        self, rand_2d_data_gen, benchmark, num_samps, num_taps, boundary, mode
+        self,
+        rand_2d_data_gen,
+        benchmark,
+        num_samps,
+        num_taps,
+        boundary,
+        mode,
+        use_numba,
     ):
 
         cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
@@ -299,6 +307,7 @@ class BenchConvolve2d:
             gpu_filt,
             boundary=boundary,
             mode=mode,
+            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, cpu_filt, boundary, mode)
@@ -323,8 +332,16 @@ class BenchCorrelate2d:
         cpu_filt, _ = rand_2d_data_gen(num_taps)
         benchmark(self.cpu_version, cpu_sig, cpu_filt, boundary, mode)
 
+    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_correlate2d_gpu(
-        self, rand_2d_data_gen, benchmark, num_samps, num_taps, boundary, mode
+        self,
+        rand_2d_data_gen,
+        benchmark,
+        num_samps,
+        num_taps,
+        boundary,
+        mode,
+        use_numba,
     ):
 
         cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
@@ -335,6 +352,7 @@ class BenchCorrelate2d:
             gpu_filt,
             boundary=boundary,
             mode=mode,
+            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, cpu_filt, boundary, mode)

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -1573,7 +1573,7 @@ def resample_poly(
 
     # filter then remove excess
     y = upfirdn(h, x, up, down, axis=axis, use_numba=use_numba)
-    keep = [slice(None),] * x.ndim
+    keep = [slice(None)] * x.ndim
     keep[axis] = slice(n_pre_remove, n_pre_remove_end)
     return y[tuple(keep)]
 

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -19,12 +19,12 @@ import numpy as np
 from scipy import signal
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('resample_num_samps', [2**12, 2**16])
-@pytest.mark.parametrize('window', [('kaiser', 0.5)])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("resample_num_samps", [2 ** 12, 2 ** 16])
+@pytest.mark.parametrize("window", [("kaiser", 0.5)])
 def test_resample(num_samps, resample_num_samps, window):
     cpu_time = np.linspace(0, 10, num_samps, endpoint=False)
-    cpu_sig = np.cos(-cpu_time ** 2 / 6.0)
+    cpu_sig = np.cos(-(cpu_time ** 2) / 6.0)
     gpu_sig = cp.asarray(cpu_sig)
 
     cpu_resample = signal.resample(cpu_sig, resample_num_samps, window=window)
@@ -35,28 +35,29 @@ def test_resample(num_samps, resample_num_samps, window):
     assert array_equal(cpu_resample, gpu_resample)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('up', [2, 3, 7])
-@pytest.mark.parametrize('down', [1, 2, 9])
-@pytest.mark.parametrize('window', [('kaiser', 0.5)])
-@pytest.mark.parametrize('use_numba', [True, False])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("up", [2, 3, 7])
+@pytest.mark.parametrize("down", [1, 2, 9])
+@pytest.mark.parametrize("window", [("kaiser", 0.5)])
+@pytest.mark.parametrize("use_numba", [True, False])
 def test_resample_poly(num_samps, up, down, window, use_numba):
     cpu_time = np.linspace(0, 10, num_samps, endpoint=False)
-    cpu_sig = np.cos(-cpu_time ** 2 / 6.0)
+    cpu_sig = np.cos(-(cpu_time ** 2) / 6.0)
     gpu_sig = cp.asarray(cpu_sig)
 
     cpu_resample = signal.resample_poly(cpu_sig, up, down, window=window)
     gpu_resample = cp.asnumpy(
-        cusignal.resample_poly(gpu_sig, up, down, window=window,
-                               use_numba=use_numba)
+        cusignal.resample_poly(
+            gpu_sig, up, down, window=window, use_numba=use_numba
+        )
     )
 
     assert array_equal(cpu_resample, gpu_resample)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('f1', [0.1, 0.15])
-@pytest.mark.parametrize('f2', [0.2, 0.4])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("f1", [0.1, 0.15])
+@pytest.mark.parametrize("f2", [0.2, 0.4])
 def test_firwin(num_samps, f1, f2):
     cpu_window = signal.firwin(num_samps, [f1, f2], pass_zero=False)
     gpu_window = cp.asnumpy(
@@ -65,9 +66,9 @@ def test_firwin(num_samps, f1, f2):
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('num_taps', [128, 2**8, 2**15])
-def test_correlate(num_samps, num_taps, mode='same'):
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
+def test_correlate(num_samps, num_taps, mode="same"):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
@@ -78,9 +79,9 @@ def test_correlate(num_samps, num_taps, mode='same'):
     assert array_equal(cpu_corr, gpu_corr)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-@pytest.mark.parametrize('num_taps', [128, 2**8, 2**15])
-def test_convolve(num_samps, num_taps, mode='same'):
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
+def test_convolve(num_samps, num_taps, mode="same"):
     cpu_sig = np.random.rand(num_samps)
     cpu_win = signal.windows.hann(num_taps)
 
@@ -92,8 +93,8 @@ def test_convolve(num_samps, num_taps, mode='same'):
     assert array_equal(cpu_conv, gpu_conv)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
-def test_fftconvolve(num_samps, mode='full'):
+@pytest.mark.parametrize("num_samps", [2 ** 15])
+def test_fftconvolve(num_samps, mode="full"):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
@@ -104,7 +105,7 @@ def test_fftconvolve(num_samps, mode='full'):
     assert array_equal(cpu_autocorr, gpu_autocorr)
 
 
-@pytest.mark.parametrize('num_samps', [2**15, 2**24])
+@pytest.mark.parametrize("num_samps", [2 ** 15, 2 ** 24])
 def test_wiener(num_samps):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -114,7 +115,7 @@ def test_wiener(num_samps):
     assert array_equal(cpu_wfilt, gpu_wfilt)
 
 
-@pytest.mark.parametrize('num_samps', [2**15])
+@pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_hilbert(num_samps):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -124,7 +125,7 @@ def test_hilbert(num_samps):
     assert array_equal(cpu_hilbert, gpu_hilbert)
 
 
-@pytest.mark.parametrize('num_samps', [2**8])
+@pytest.mark.parametrize("num_samps", [2 ** 8])
 def test_hilbert2(num_samps):
     cpu_sig = np.random.rand(num_samps, num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -134,11 +135,12 @@ def test_hilbert2(num_samps):
     assert array_equal(cpu_hilbert2, gpu_hilbert2)
 
 
-@pytest.mark.parametrize('num_samps', [2**8])
-@pytest.mark.parametrize('num_taps', [5, 100])
-@pytest.mark.parametrize('boundary', ['symm'])
-@pytest.mark.parametrize('mode', ['same'])
-def test_convolve2d(num_samps, num_taps, boundary, mode):
+@pytest.mark.parametrize("num_samps", [2 ** 8])
+@pytest.mark.parametrize("num_taps", [5, 100])
+@pytest.mark.parametrize("boundary", ["symm"])
+@pytest.mark.parametrize("mode", ["same"])
+@pytest.mark.parametrize("use_numba", [True, False])
+def test_convolve2d(num_samps, num_taps, boundary, mode, use_numba):
     cpu_sig = np.random.rand(num_samps, num_samps)
     cpu_filt = np.random.rand(num_taps, num_taps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -148,16 +150,23 @@ def test_convolve2d(num_samps, num_taps, boundary, mode):
         cpu_sig, cpu_filt, boundary=boundary, mode=mode
     )
     gpu_convolve2d = cp.asnumpy(
-        cusignal.convolve2d(gpu_sig, gpu_filt, boundary=boundary, mode=mode)
+        cusignal.convolve2d(
+            gpu_sig,
+            gpu_filt,
+            boundary=boundary,
+            mode=mode,
+            use_numba=use_numba,
+        )
     )
     assert array_equal(cpu_convolve2d, gpu_convolve2d)
 
 
-@pytest.mark.parametrize('num_samps', [2**8])
-@pytest.mark.parametrize('num_taps', [5, 100])
-@pytest.mark.parametrize('boundary', ['symm'])
-@pytest.mark.parametrize('mode', ['same'])
-def test_correlate2d(num_samps, num_taps, boundary, mode):
+@pytest.mark.parametrize("num_samps", [2 ** 8])
+@pytest.mark.parametrize("num_taps", [5, 100])
+@pytest.mark.parametrize("boundary", ["symm"])
+@pytest.mark.parametrize("mode", ["same"])
+@pytest.mark.parametrize("use_numba", [True, False])
+def test_correlate2d(num_samps, num_taps, boundary, mode, use_numba):
     cpu_sig = np.random.rand(num_samps, num_samps)
     cpu_filt = np.random.rand(num_taps, num_taps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -167,6 +176,12 @@ def test_correlate2d(num_samps, num_taps, boundary, mode):
         cpu_sig, cpu_filt, boundary=boundary, mode=mode
     )
     gpu_correlate2d = cp.asnumpy(
-        cusignal.correlate2d(gpu_sig, gpu_filt, boundary=boundary, mode=mode)
+        cusignal.correlate2d(
+            gpu_sig,
+            gpu_filt,
+            boundary=boundary,
+            mode=mode,
+            use_numba=use_numba,
+        )
     )
     assert array_equal(cpu_correlate2d, gpu_correlate2d)


### PR DESCRIPTION
This PR does the following
1. Updates **correlate2d** and **convolve2d** in `signaltools.py` to accept _cp_stream_ and _use_numba_ arguments.
2. Updates bench_correlate2d_gpu and bench_convolve2d_gpu in `bench_signaltools.py` to accept _use_numba_ arguments.
3. Updates `_signaltools.py` to utilizes cupy.pad(symm/wrap) versus numpy.pad(symm/wrap), which was not available during initial development. Up to 20x-30x performance improvement to large test cases by eliminated data transfers.
4. Updates Numba kernel indexing to match CuPy raw kernel indexing. Indexing in 2d making much more sense now.
5. Finally, CuPy raw kernels and framework have been added to `_signaltools.py`.

Below are benchmark results using `pytest -v --benchmark-only -k "2d"`. There are 116 tests performed. The takeaway is that for small test cases CuPy raw kernels are **49x** faster than SciPy and for large test cases they are up to **13K** times faster. Most CuPy raw kernels are 2-3x faster than Numba kernels. These tests are with floats. In the future we plan to add multiple types to our tests.

```bash
------------------------------------------------------------------------------------------------------------- benchmark 'Convolve2d': 54 tests -------------------------------------------------------------------------------------------------------------
Name (time in us)                                             Min                       Max                      Mean                 StdDev                    Median                    IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_convolve2d_gpu[False-valid-symm-5-256]              88.2280 (1.0)          3,566.0960 (10.21)           96.3137 (1.02)         67.2665 (24.85)           90.4750 (1.0)           1.2490 (1.0)       80;1401  10,382.7364 (0.98)      11138           1
bench_convolve2d_gpu[False-valid-wrap-5-256]              88.4730 (1.00)           349.3750 (1.0)             94.1941 (1.0)          12.1950 (4.51)            90.9930 (1.01)          1.4040 (1.12)     717;1365  10,616.3748 (1.0)       10698           1
bench_convolve2d_gpu[False-valid-wrap-100-256]            88.8200 (1.01)        56,940.4050 (162.98)       1,548.0026 (16.43)       976.9051 (360.89)       1,570.8775 (17.36)        61.6995 (49.40)     536;724     645.9937 (0.06)      11176           1
bench_convolve2d_gpu[False-valid-fill-5-256]              89.0790 (1.01)        21,302.8110 (60.97)          102.6392 (1.09)        222.6592 (82.26)           93.6100 (1.03)          1.6090 (1.29)      22;1742   9,742.8645 (0.92)      10759           1
bench_convolve2d_gpu[False-valid-fill-100-256]            89.2360 (1.01)        43,277.1140 (123.87)       1,533.3923 (16.28)       762.2519 (281.60)       1,550.2570 (17.13)        43.1375 (34.54)     483;891     652.1488 (0.06)      11164           1
bench_convolve2d_gpu[False-valid-symm-100-256]            89.3340 (1.01)        38,076.8890 (108.99)       1,557.7684 (16.54)       815.6222 (301.31)       1,593.7320 (17.62)        55.7890 (44.67)     502;708     641.9439 (0.06)      10874           1
bench_convolve2d_gpu[False-same-fill-5-256]              188.6260 (2.14)        13,453.4790 (38.51)          212.3684 (2.25)        252.7120 (93.36)          192.3660 (2.13)          3.4627 (2.77)       27;822   4,708.7987 (0.44)       5201           1
bench_convolve2d_gpu[False-full-fill-5-256]              190.0430 (2.15)           356.1140 (1.02)           195.3859 (2.07)          9.1075 (3.36)           193.5235 (2.14)          2.1935 (1.76)      249;481   5,118.0769 (0.48)       5048           1
bench_convolve2d_gpu[False-same-fill-100-256]            190.2750 (2.16)        32,570.0070 (93.22)        3,156.8849 (33.51)     1,204.4737 (444.96)       3,215.1895 (35.54)        11.3360 (9.08)     251;1194     316.7680 (0.03)       5182           1
bench_convolve2d_gpu[False-full-fill-100-256]            191.4630 (2.17)        56,385.4660 (161.39)       5,984.6797 (63.54)     1,845.1563 (681.65)       6,044.3625 (66.81)        56.5275 (45.26)     265;872     167.0933 (0.02)       5168           1
bench_convolve2d_gpu[False-same-wrap-100-256]            219.7670 (2.49)        38,199.4540 (109.34)       3,176.2016 (33.72)     1,178.3281 (435.30)       3,219.8220 (35.59)        11.9402 (9.56)      215;830     314.8415 (0.03)       4495           1
bench_convolve2d_gpu[False-same-wrap-5-256]              219.9380 (2.49)           385.8700 (1.10)           225.1953 (2.39)          5.6534 (2.09)           224.4470 (2.48)          2.4110 (1.93)      140;232   4,440.5892 (0.42)       4437           1
bench_convolve2d_gpu[False-full-wrap-5-256]              221.8810 (2.51)           399.0400 (1.14)           228.6230 (2.43)         12.2655 (4.53)           226.7480 (2.51)          2.6695 (2.14)      168;342   4,374.0133 (0.41)       4404           1
bench_convolve2d_gpu[False-full-wrap-100-256]            222.6170 (2.52)        33,059.4300 (94.62)        6,166.7856 (65.47)     1,521.0888 (561.93)       6,319.3290 (69.85)       242.2765 (193.98)    203;244     162.1590 (0.02)       4412           1
bench_convolve2d_gpu[False-full-symm-5-256]              227.0670 (2.57)           813.0900 (2.33)           235.4677 (2.50)         23.7584 (8.78)           231.7165 (2.56)          2.9575 (2.37)      107;453   4,246.8666 (0.40)       4300           1
bench_convolve2d_gpu[False-same-symm-5-256]              228.9090 (2.59)        16,766.6790 (47.99)          254.8483 (2.71)        372.4616 (137.60)         233.4280 (2.58)          3.9472 (3.16)       10;592   3,923.9037 (0.37)       4281           1
bench_convolve2d_gpu[False-full-symm-100-256]            229.1290 (2.60)        58,783.6100 (168.25)       6,200.6746 (65.83)     1,749.0673 (646.15)       6,344.3580 (70.12)       142.6477 (114.21)    210;294     161.2728 (0.02)       4323           1
bench_convolve2d_gpu[False-same-symm-100-256]            231.5940 (2.62)        57,611.4960 (164.90)       3,178.2010 (33.74)     1,609.8245 (594.71)       3,219.8950 (35.59)        10.2178 (8.18)      190;928     314.6434 (0.03)       4303           1
bench_convolve2d_gpu[True-valid-fill-5-256]              293.6840 (3.33)        17,642.0150 (50.50)          324.3900 (3.44)        326.5524 (120.64)         299.8085 (3.31)          3.0435 (2.44)       30;385   3,082.7095 (0.29)       3328           1
bench_convolve2d_gpu[True-valid-wrap-5-256]              297.4650 (3.37)         6,958.0100 (19.92)          329.6253 (3.50)        223.8209 (82.69)          302.3000 (3.34)          3.9218 (3.14)      100;521   3,033.7474 (0.29)       3297           1
bench_convolve2d_gpu[True-valid-wrap-100-256]            298.5810 (3.38)        11,187.7950 (32.02)        1,474.5404 (15.65)       474.7056 (175.37)       1,560.8545 (17.25)        17.0030 (13.61)     310;541     678.1774 (0.06)       3298           1
bench_convolve2d_gpu[True-valid-fill-100-256]            298.7340 (3.39)        25,687.0670 (73.52)        1,482.2442 (15.74)       674.7791 (249.28)       1,559.2240 (17.23)        12.5700 (10.06)     320;587     674.6527 (0.06)       3297           1
bench_convolve2d_gpu[True-valid-symm-5-256]              300.4750 (3.41)           360.5790 (1.03)           305.7166 (3.25)          2.7069 (1.0)            305.3010 (3.37)          2.2623 (1.81)      509;179   3,271.0034 (0.31)       3275           1
bench_convolve2d_gpu[True-valid-symm-100-256]            300.8040 (3.41)        32,984.6010 (94.41)        1,479.3513 (15.71)       807.7429 (298.40)       1,567.2870 (17.32)        20.1153 (16.11)     354;596     675.9719 (0.06)       3277           1
bench_convolve2d_gpu[True-same-fill-100-256]             420.4760 (4.77)        30,035.9950 (85.97)        3,143.5142 (33.37)     1,191.2670 (440.08)       3,259.9480 (36.03)        42.5380 (34.06)     188;378     318.1153 (0.03)       2351           1
bench_convolve2d_gpu[True-same-fill-5-256]               421.8430 (4.78)           457.6150 (1.31)           427.3395 (4.54)          2.8604 (1.06)           426.7540 (4.72)          2.7335 (2.19)      478;109   2,340.0599 (0.22)       2331           1
bench_convolve2d_gpu[True-full-fill-5-256]               427.0130 (4.84)           734.8490 (2.10)           437.3063 (4.64)         12.8720 (4.76)           435.5190 (4.81)          8.0065 (6.41)        85;69   2,286.7265 (0.22)       2247           1
bench_convolve2d_gpu[True-full-fill-100-256]             428.1410 (4.85)        39,500.2700 (113.06)       5,944.2712 (63.11)     1,783.9324 (659.03)       6,148.5270 (67.96)        78.1130 (62.54)     155;321     168.2292 (0.02)       2323           1
bench_convolve2d_gpu[True-same-wrap-5-256]               444.2880 (5.04)           850.1060 (2.43)           451.9880 (4.80)         16.2129 (5.99)           449.8325 (4.97)          3.1230 (2.50)       44;165   2,212.4479 (0.21)       2238           1
bench_convolve2d_gpu[True-same-symm-5-256]               449.4240 (5.09)           886.1010 (2.54)           459.4341 (4.88)         30.7212 (11.35)          454.7570 (5.03)          3.6680 (2.94)       42;230   2,176.5908 (0.21)       2186           1
bench_convolve2d_gpu[True-same-wrap-100-256]             449.4690 (5.09)        24,661.4580 (70.59)        3,206.8272 (34.04)     1,044.1615 (385.74)       3,274.5315 (36.19)        47.4140 (37.96)     197;457     311.8347 (0.03)       2218           1
bench_convolve2d_gpu[True-same-symm-100-256]             449.8800 (5.10)        23,285.8100 (66.65)        3,198.5065 (33.96)       960.3781 (354.79)       3,281.8730 (36.27)        41.9390 (33.58)     147;467     312.6459 (0.03)       2210           1
bench_convolve2d_gpu[True-full-symm-5-256]               451.2910 (5.12)         4,946.4010 (14.16)          500.3624 (5.31)        226.7847 (83.78)          457.7850 (5.06)          7.3670 (5.90)      114;370   1,998.5515 (0.19)       2198           1
bench_convolve2d_gpu[True-full-symm-100-256]             451.9400 (5.12)        44,651.5150 (127.80)       6,160.2549 (65.40)     1,662.2336 (614.07)       6,334.0715 (70.01)        82.7175 (66.23)     139;245     162.3309 (0.02)       2196           1
bench_convolve2d_gpu[True-full-wrap-5-256]               452.1900 (5.13)         5,114.1820 (14.64)          506.0747 (5.37)        237.6961 (87.81)          459.3410 (5.08)          9.2823 (7.43)      110;397   1,975.9930 (0.19)       2173           1
bench_convolve2d_gpu[True-full-wrap-100-256]             452.3680 (5.13)        44,795.5120 (128.22)       6,090.5436 (64.66)     1,946.7647 (719.18)       6,259.1990 (69.18)        65.1367 (52.15)     147;390     164.1890 (0.02)       2199           1
bench_convolve2d_cpu[valid-symm-5-256]                 4,264.8160 (48.34)       32,840.1550 (94.00)        4,699.0542 (49.89)     2,700.4698 (997.62)       4,288.4545 (47.40)        41.8890 (33.54)        7;41     212.8088 (0.02)        234           1
bench_convolve2d_cpu[valid-fill-5-256]                 4,267.6970 (48.37)        4,327.1190 (12.39)        4,288.1193 (45.52)        14.9040 (5.51)         4,287.3235 (47.39)        18.0370 (14.44)        79;2     233.2025 (0.02)        234           1
bench_convolve2d_cpu[valid-wrap-5-256]                 4,267.8920 (48.37)        5,310.2700 (15.20)        4,312.6594 (45.78)       103.7801 (38.34)        4,296.6220 (47.49)        24.6745 (19.76)         7;8     231.8755 (0.02)        235           1
bench_convolve2d_cpu[same-fill-5-256]                  4,337.3140 (49.16)       23,299.3240 (66.69)        4,718.5394 (50.09)     1,606.0350 (593.31)       4,358.0540 (48.17)        33.0008 (26.42)       14;45     211.9300 (0.02)        231           1
bench_convolve2d_cpu[same-symm-5-256]                  4,362.3880 (49.44)        4,449.6430 (12.74)        4,382.5485 (46.53)        12.1317 (4.48)         4,380.5125 (48.42)        14.8090 (11.86)        57;3     228.1777 (0.02)        218           1
bench_convolve2d_cpu[full-fill-5-256]                  4,414.9490 (50.04)       25,648.9220 (73.41)        4,792.6512 (50.88)     1,676.4890 (619.34)       4,467.0600 (49.37)        52.7360 (42.22)       10;43     208.6528 (0.02)        227           1
bench_convolve2d_cpu[same-wrap-5-256]                  4,477.9480 (50.75)       34,387.4500 (98.43)        5,003.1394 (53.12)     2,376.5333 (877.95)       4,518.5960 (49.94)       208.8675 (167.23)       9;28     199.8745 (0.02)        223           1
bench_convolve2d_cpu[full-symm-5-256]                  4,488.9750 (50.88)       23,474.8020 (67.19)        4,879.5293 (51.80)     1,665.3208 (615.21)       4,507.3610 (49.82)        21.6563 (17.34)       13;46     204.9378 (0.02)        223           1
bench_convolve2d_cpu[full-wrap-5-256]                  4,573.5400 (51.84)        4,813.4170 (13.78)        4,586.8750 (48.70)        16.9397 (6.26)         4,584.8350 (50.68)        10.1135 (8.10)          6;2     218.0134 (0.02)        219           1
bench_convolve2d_cpu[valid-fill-100-256]             569,405.4800 (>1000.0)    668,356.0370 (>1000.0)    596,032.5669 (>1000.0)  37,794.1012 (>1000.0)    570,678.4730 (>1000.0)  71,919.0050 (>1000.0)       8;0       1.6778 (0.00)         25           1
bench_convolve2d_cpu[valid-symm-100-256]             569,510.6600 (>1000.0)    675,764.1600 (>1000.0)    594,474.4848 (>1000.0)  35,879.9468 (>1000.0)    570,562.6210 (>1000.0)  67,230.5070 (>1000.0)       7;0       1.6822 (0.00)         25           1
bench_convolve2d_cpu[valid-wrap-100-256]             570,231.4560 (>1000.0)    661,471.1650 (>1000.0)    596,022.9789 (>1000.0)  35,044.6845 (>1000.0)    572,832.7450 (>1000.0)  67,796.6002 (>1000.0)       7;0       1.6778 (0.00)         25           1
bench_convolve2d_cpu[same-fill-100-256]            1,422,293.2450 (>1000.0)  1,588,259.0170 (>1000.0)  1,487,852.0514 (>1000.0)  42,498.8375 (>1000.0)  1,492,502.4690 (>1000.0)  50,556.1483 (>1000.0)       9;2       0.6721 (0.00)         25           1
bench_convolve2d_cpu[same-symm-100-256]            1,533,951.0090 (>1000.0)  1,683,763.8330 (>1000.0)  1,606,233.4429 (>1000.0)  33,644.2230 (>1000.0)  1,609,883.6860 (>1000.0)  26,244.8115 (>1000.0)       7;5       0.6226 (0.00)         25           1
bench_convolve2d_cpu[same-wrap-100-256]            1,545,952.4430 (>1000.0)  1,726,427.2780 (>1000.0)  1,621,744.9806 (>1000.0)  39,581.9835 (>1000.0)  1,624,397.7470 (>1000.0)  27,364.9265 (>1000.0)       8;5       0.6166 (0.00)         25           1
bench_convolve2d_cpu[full-fill-100-256]            2,471,686.2520 (>1000.0)  2,610,182.0620 (>1000.0)  2,534,652.5689 (>1000.0)  41,005.0121 (>1000.0)  2,521,181.5240 (>1000.0)  68,768.0450 (>1000.0)      11;0       0.3945 (0.00)         25           1
bench_convolve2d_cpu[full-symm-100-256]            3,030,613.0290 (>1000.0)  3,148,713.7800 (>1000.0)  3,093,898.7896 (>1000.0)  40,134.8230 (>1000.0)  3,104,818.0770 (>1000.0)  77,516.5555 (>1000.0)      12;0       0.3232 (0.00)         25           1
bench_convolve2d_cpu[full-wrap-100-256]            3,079,358.6780 (>1000.0)  3,210,768.3780 (>1000.0)  3,151,387.9058 (>1000.0)  38,462.0122 (>1000.0)  3,163,712.0350 (>1000.0)  58,369.3598 (>1000.0)       8;0       0.3173 (0.00)         25           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------------------ benchmark 'Correlate2d': 54 tests -------------------------------------------------------------------------------------------------------------
Name (time in us)                                              Min                       Max                      Mean                 StdDev                    Median                    IQR            Outliers         OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_correlate2d_gpu[False-valid-symm-5-256]              88.5420 (1.0)         14,937.5740 (58.72)          100.3623 (1.0)         226.5278 (109.31)          90.8750 (1.0)           1.3560 (1.0)       19;1484  9,963.8978 (1.0)       11079           1
bench_correlate2d_gpu[False-valid-symm-100-256]            89.7130 (1.01)        27,990.2900 (110.04)       1,543.0825 (15.38)       651.3355 (314.30)       1,571.5085 (17.29)        10.2615 (7.57)     473;1906    648.0535 (0.07)      10976           1
bench_correlate2d_gpu[False-valid-wrap-5-256]              90.5330 (1.02)         4,828.6950 (18.98)          100.5467 (1.00)         78.0050 (37.64)           93.0290 (1.02)          1.5543 (1.15)      43;1792  9,945.6293 (1.00)      10857           1
bench_correlate2d_gpu[False-valid-fill-5-256]              91.1680 (1.03)         7,093.0720 (27.88)          103.0725 (1.03)        142.0065 (68.53)           93.9790 (1.03)          1.3880 (1.02)      22;1499  9,701.9115 (0.97)      10678           1
bench_correlate2d_gpu[False-valid-wrap-100-256]            92.1100 (1.04)        46,497.0720 (182.79)       1,531.9799 (15.26)       869.9346 (419.79)       1,568.8905 (17.26)        38.0350 (28.05)     495;833    652.7501 (0.07)      10710           1
bench_correlate2d_gpu[False-valid-fill-100-256]            94.0470 (1.06)        31,403.5580 (123.45)       1,542.1359 (15.37)       850.9460 (410.62)       1,570.8610 (17.29)        13.6800 (10.09)    558;2074    648.4513 (0.07)      10628           1
bench_correlate2d_gpu[False-same-fill-5-256]              191.8440 (2.17)           891.4130 (3.50)           199.6919 (1.99)         25.3617 (12.24)          195.2950 (2.15)          2.5150 (1.85)      167;615  5,007.7156 (0.50)       5068           1
bench_correlate2d_gpu[False-same-fill-100-256]            193.6160 (2.19)        48,435.7440 (190.41)       3,185.7738 (31.74)     1,126.9637 (543.82)       3,244.3030 (35.70)        12.6855 (9.36)     236;1175    313.8955 (0.03)       5089           1
bench_correlate2d_gpu[False-full-fill-5-256]              196.0380 (2.21)         5,111.2880 (20.09)          215.2902 (2.15)        133.1801 (64.27)          199.3390 (2.19)          3.4765 (2.56)      111;770  4,644.8926 (0.47)       5035           1
bench_correlate2d_gpu[False-full-fill-100-256]            196.6670 (2.22)        67,839.6790 (266.69)       6,105.6060 (60.84)     1,899.7141 (916.71)       6,208.0050 (68.31)       254.2722 (187.52)    237;295    163.7839 (0.02)       5057           1
bench_correlate2d_gpu[False-same-wrap-5-256]              218.1650 (2.46)           346.6790 (1.36)           223.0877 (2.22)          5.0886 (2.46)           221.9205 (2.44)          2.3210 (1.71)      273;379  4,482.5419 (0.45)       4502           1
bench_correlate2d_gpu[False-same-wrap-100-256]            221.3020 (2.50)        38,362.8920 (150.81)       3,210.9325 (31.99)     1,228.8295 (592.97)       3,249.3200 (35.76)        15.1180 (11.15)     206;932    311.4360 (0.03)       4498           1
bench_correlate2d_gpu[False-full-wrap-5-256]              222.8150 (2.52)           254.3750 (1.0)            227.3935 (2.27)          2.0723 (1.0)            227.0120 (2.50)          2.0418 (1.51)      986;252  4,397.6637 (0.44)       4385           1
bench_correlate2d_gpu[False-full-wrap-100-256]            224.4300 (2.53)        47,882.7710 (188.24)       6,208.6813 (61.86)     1,625.5464 (784.41)       6,327.2050 (69.63)        52.9025 (39.01)     201;982    161.0648 (0.02)       4409           1
bench_correlate2d_gpu[False-full-symm-5-256]              224.7280 (2.54)         1,838.4820 (7.23)           242.8794 (2.42)         57.8002 (27.89)          229.3630 (2.52)          6.3825 (4.71)      117;442  4,117.2699 (0.41)       2460           1
bench_correlate2d_gpu[False-full-symm-100-256]            226.0860 (2.55)        47,769.4260 (187.79)       6,237.2545 (62.15)     1,708.9792 (824.67)       6,330.6180 (69.66)        20.2987 (14.97)     189;812    160.3270 (0.02)       4369           1
bench_correlate2d_gpu[False-same-symm-5-256]              227.5270 (2.57)         4,606.1270 (18.11)          256.0498 (2.55)        157.0057 (75.76)          232.0700 (2.55)          5.4360 (4.01)       83;520  3,905.4900 (0.39)       2929           1
bench_correlate2d_gpu[False-same-symm-100-256]            228.0210 (2.58)        61,981.7720 (243.66)       3,211.2726 (32.00)     1,308.4382 (631.39)       3,250.8590 (35.77)        18.4702 (13.62)     173;978    311.4030 (0.03)       4345           1
bench_correlate2d_gpu[True-valid-wrap-5-256]              298.2490 (3.37)           601.1540 (2.36)           312.7470 (3.12)         38.6737 (18.66)          303.0200 (3.33)          2.5290 (1.87)      184;356  3,197.4722 (0.32)       3210           1
bench_correlate2d_gpu[True-valid-wrap-100-256]            300.0910 (3.39)        64,796.5100 (254.73)       1,470.8078 (14.65)     1,363.6869 (658.05)       1,556.7575 (17.13)        25.7230 (18.97)      15;742    679.8985 (0.07)       3292           1
bench_correlate2d_gpu[True-valid-fill-5-256]              300.9070 (3.40)        10,457.8440 (41.11)          340.9964 (3.40)        253.1337 (122.15)         308.9740 (3.40)          6.3400 (4.68)       75;468  2,932.5820 (0.29)       3197           1
bench_correlate2d_gpu[True-valid-fill-100-256]            301.2160 (3.40)        41,712.7130 (163.98)       1,485.5179 (14.80)       870.1552 (419.89)       1,550.8380 (17.07)        19.8073 (14.61)     299;658    673.1659 (0.07)       3277           1
bench_correlate2d_gpu[True-valid-symm-5-256]              302.1560 (3.41)           633.4230 (2.49)           310.9745 (3.10)         17.4412 (8.42)           307.7600 (3.39)          2.8920 (2.13)      117;333  3,215.6977 (0.32)       3240           1
bench_correlate2d_gpu[True-valid-symm-100-256]            304.1500 (3.44)        37,200.0670 (146.24)       1,474.1300 (14.69)       983.5177 (474.60)       1,563.0125 (17.20)        20.5185 (15.13)     255;740    678.3662 (0.07)       3256           1
bench_correlate2d_gpu[True-full-fill-5-256]               421.3830 (4.76)         6,035.7600 (23.73)          467.2064 (4.66)        249.7901 (120.54)         426.9505 (4.70)          6.3670 (4.70)      103;402  2,140.3818 (0.21)       2338           1
bench_correlate2d_gpu[True-full-fill-100-256]             425.7400 (4.81)        46,427.0810 (182.51)       5,901.1982 (58.80)     1,836.8626 (886.38)       6,094.2725 (67.06)        65.0555 (47.98)     158;369    169.4571 (0.02)       2348           1
bench_correlate2d_gpu[True-same-fill-5-256]               427.0170 (4.82)         8,791.3830 (34.56)          474.1390 (4.72)        280.4725 (135.34)         432.8020 (4.76)          4.9690 (3.66)      101;340  2,109.0863 (0.21)       2303           1
bench_correlate2d_gpu[True-same-fill-100-256]             430.6660 (4.86)        27,446.0850 (107.90)       3,111.9292 (31.01)     1,103.5970 (532.54)       3,226.5020 (35.50)        41.6625 (30.72)     167;328    321.3441 (0.03)       2324           1
bench_correlate2d_gpu[True-full-wrap-5-256]               446.0540 (5.04)           960.9620 (3.78)           454.1232 (4.52)         17.6431 (8.51)           452.1170 (4.98)          3.1650 (2.33)       27;127  2,202.0455 (0.22)       2205           1
bench_correlate2d_gpu[True-full-wrap-100-256]             448.4700 (5.07)        41,434.2680 (162.89)       6,050.2601 (60.28)     1,682.1091 (811.70)       6,203.9755 (68.27)        54.4445 (40.15)     136;358    165.2822 (0.02)       2196           1
bench_correlate2d_gpu[True-full-symm-5-256]               457.7830 (5.17)           830.8760 (3.27)           470.6223 (4.69)         35.3696 (17.07)          464.3515 (5.11)          3.7700 (2.78)       43;234  2,124.8464 (0.21)       2158           1
bench_correlate2d_gpu[True-same-wrap-5-256]               459.5510 (5.19)         4,288.1800 (16.86)          501.3521 (5.00)        173.4545 (83.70)          466.0340 (5.13)          4.6040 (3.40)      122;283  1,994.6062 (0.20)       2149           1
bench_correlate2d_gpu[True-full-symm-100-256]             462.4790 (5.22)        28,450.2840 (111.84)       6,105.8598 (60.84)     1,532.7079 (739.61)       6,282.5895 (69.13)        78.0620 (57.57)     131;256    163.7771 (0.02)       2152           1
bench_correlate2d_gpu[True-same-symm-5-256]               462.7770 (5.23)           831.3480 (3.27)           486.6369 (4.85)         50.2340 (24.24)          470.4490 (5.18)          9.5543 (7.05)      162;294  2,054.9200 (0.21)       2145           1
bench_correlate2d_gpu[True-same-wrap-100-256]             464.5020 (5.25)        25,835.4300 (101.56)       3,153.6475 (31.42)       987.2096 (476.38)       3,237.1120 (35.62)        31.4250 (23.17)     142;323    317.0931 (0.03)       2142           1
bench_correlate2d_gpu[True-same-symm-100-256]             465.2530 (5.25)        45,480.0460 (178.79)       3,159.2083 (31.48)     1,401.5135 (676.30)       3,243.5305 (35.69)        37.1345 (27.39)     159;412    316.5350 (0.03)       2136           1
bench_correlate2d_cpu[valid-fill-5-256]                 4,216.1240 (47.62)        5,158.3300 (20.28)        4,266.0071 (42.51)        79.9298 (38.57)        4,255.7060 (46.83)        31.7505 (23.41)        8;10    234.4112 (0.02)        237           1
bench_correlate2d_cpu[valid-symm-5-256]                 4,216.8240 (47.63)       14,831.2750 (58.30)        4,554.5156 (45.38)     1,033.6002 (498.76)       4,270.6620 (46.99)        95.5505 (70.46)       16;40    219.5623 (0.02)        237           1
bench_correlate2d_cpu[valid-wrap-5-256]                 4,219.4290 (47.65)       16,413.4890 (64.52)        4,590.2772 (45.74)     1,151.2203 (555.52)       4,278.3810 (47.08)       113.0170 (83.35)       15;36    217.8518 (0.02)        234           1
bench_correlate2d_cpu[same-fill-5-256]                  4,344.0120 (49.06)       17,826.1850 (70.08)        4,735.1344 (47.18)     1,461.4367 (705.22)       4,373.3270 (48.12)        77.8302 (57.40)       11;41    211.1872 (0.02)        231           1
bench_correlate2d_cpu[same-wrap-5-256]                  4,363.4700 (49.28)       19,903.7140 (78.25)        4,761.8770 (47.45)     1,462.0902 (705.53)       4,389.4600 (48.30)       121.0823 (89.29)       12;39    210.0012 (0.02)        229           1
bench_correlate2d_cpu[same-symm-5-256]                  4,369.9990 (49.36)       13,904.0240 (54.66)        4,726.5389 (47.09)     1,268.7184 (612.22)       4,406.3600 (48.49)        33.8465 (24.96)       12;45    211.5713 (0.02)        229           1
bench_correlate2d_cpu[full-fill-5-256]                  4,426.7960 (50.00)        8,330.9930 (32.75)        4,520.1081 (45.04)       370.0144 (178.55)       4,452.4150 (48.99)        19.4880 (14.37)        9;26    221.2336 (0.02)        220           1
bench_correlate2d_cpu[full-wrap-5-256]                  4,480.8200 (50.61)       15,037.4100 (59.12)        4,958.0763 (49.40)     1,270.2598 (612.96)       4,560.5280 (50.18)       111.1240 (81.95)       20;40    201.6911 (0.02)        223           1
bench_correlate2d_cpu[full-symm-5-256]                  4,493.0920 (50.75)       10,739.7730 (42.22)        4,822.4620 (48.05)     1,049.2695 (506.33)       4,515.7330 (49.69)        25.0190 (18.45)       14;49    207.3630 (0.02)        222           1
bench_correlate2d_cpu[valid-wrap-100-256]             571,082.3750 (>1000.0)    649,425.2010 (>1000.0)    594,013.4407 (>1000.0)  31,761.7687 (>1000.0)    574,354.0480 (>1000.0)  66,294.7297 (>1000.0)       7;0      1.6835 (0.00)         25           1
bench_correlate2d_cpu[valid-symm-100-256]             571,297.6460 (>1000.0)    654,215.3930 (>1000.0)    593,197.8560 (>1000.0)  30,303.8339 (>1000.0)    574,774.5900 (>1000.0)  53,554.6598 (>1000.0)       6;0      1.6858 (0.00)         25           1
bench_correlate2d_cpu[valid-fill-100-256]             571,579.3150 (>1000.0)    655,046.0760 (>1000.0)    595,198.1471 (>1000.0)  31,030.5429 (>1000.0)    574,276.3460 (>1000.0)  59,298.7310 (>1000.0)       7;0      1.6801 (0.00)         25           1
bench_correlate2d_cpu[same-fill-100-256]            1,423,693.2250 (>1000.0)  1,510,801.8920 (>1000.0)  1,479,057.2632 (>1000.0)  31,663.2070 (>1000.0)  1,495,992.4850 (>1000.0)  62,843.0458 (>1000.0)       8;0      0.6761 (0.00)         25           1
bench_correlate2d_cpu[same-wrap-100-256]            1,542,737.6140 (>1000.0)  1,652,268.2090 (>1000.0)  1,606,347.4829 (>1000.0)  30,410.8652 (>1000.0)  1,616,977.5830 (>1000.0)  20,103.9315 (>1000.0)       6;5      0.6225 (0.00)         25           1
bench_correlate2d_cpu[same-symm-100-256]            1,544,693.5830 (>1000.0)  1,618,169.9340 (>1000.0)  1,594,527.4406 (>1000.0)  23,358.0936 (>1000.0)  1,603,076.7360 (>1000.0)  10,510.7257 (>1000.0)       6;5      0.6271 (0.00)         25           1
bench_correlate2d_cpu[full-fill-100-256]            2,481,161.6040 (>1000.0)  2,670,552.4380 (>1000.0)  2,531,572.2095 (>1000.0)  45,222.5019 (>1000.0)  2,522,751.7750 (>1000.0)  67,997.4310 (>1000.0)       6;1      0.3950 (0.00)         25           1
bench_correlate2d_cpu[full-symm-100-256]            3,050,022.6270 (>1000.0)  3,190,984.2970 (>1000.0)  3,110,552.0167 (>1000.0)  37,977.6949 (>1000.0)  3,117,930.2480 (>1000.0)  58,385.4532 (>1000.0)      10;0      0.3215 (0.00)         25           1
bench_correlate2d_cpu[full-wrap-100-256]            3,076,865.4750 (>1000.0)  3,193,522.8730 (>1000.0)  3,137,322.0003 (>1000.0)  34,580.5973 (>1000.0)  3,153,491.4600 (>1000.0)  65,811.7367 (>1000.0)      13;0      0.3187 (0.00)         25           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
================================================================================================================================================================ 108 passed, 8 skipped, 409 deselected in 1803.16s (0:30:03) =================================
```