### PR TITLE
[REVIEW] Update README - Reorganize Install Instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.
 - PR #45 - Refactor `_signaltools.py` to use new Numba/CuPy framework
+- PR #50 - Update README to reorganize install instructions
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 

--- a/README.md
+++ b/README.md
@@ -94,22 +94,103 @@ gf = cusignal.resample_poly(cp.asarray(cy), resample_up, resample_down, window=(
 ```
 This code executes on an NVIDIA V100 in 637 ms.
 
-## Dependencies
-* NVIDIA GPU (Maxwell or Newer GeForce/Tesla/Quadro)
-* CUDA Divers
-* Anaconda/Miniconda (3.7 version)
-* CuPy >= 6.2.0
-* Optional: RTL-SDR or other SDR Driver/Packaging. Find more information and follow the instructions for setup [here](https://github.com/osmocom/rtl-sdr). 
+## Installation
 
-NOTE: [pyrtlsdr](https://github.com/roger-/pyrtlsdr) is not automatically installed with the default cusignal environment. To make use of some of the examples in the Notebooks, you'll need to buy/install an rtl-sdr and necessary software packages.
+### Conda, Linux OS
+cuSignal can be installed with conda([miniconda](https://docs.conda.io/en/latest/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/distribution/)) from the `rapidsai` channel). If you're using a Jetson GPU, please follow the build instructions [below](https://github.com/rapidsai/cusignal#conda-jetson-nano-tk1-tx2-xavier-linux-os)
 
-NOTE: if used with other portions of RAPIDS, then GPU needs to be Pascal or later, and CUDA 10+
+For `cusignal version == 0.13`:
 
-## Install cuSignal, Linux OS with Anaconda
+```
+# For CUDA 10.0
+conda install -c rapidsai -c nvidia -c conda-forge \
+    -c defaults cusignal=0.13 python=3.6 cudatoolkit=10.0
 
-`conda install -c rapidsai-nightly -c conda-forge cusignal`
+# or, for CUDA 10.1.2
+conda install -c rapidsai -c nvidia -c numba -c conda-forge \
+    cudf=0.13 python=3.6 cudatoolkit=10.1
 
-## Install cuSignal, Linux OS
+# or, for CUDA 10.2
+conda install -c rapidsai -c nvidia -c numba -c conda-forge \
+    cudf=0.13 python=3.6 cudatoolkit=10.2
+```
+
+For the nightly verison of `cusignal`:
+
+```
+# For CUDA 10.0
+conda install -c rapidsai-nightly -c nvidia -c conda-forge \
+    -c defaults cusignal=0.13 python=3.6 cudatoolkit=10.0
+
+# or, for CUDA 10.1.2
+conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
+    cudf=0.13 python=3.6 cudatoolkit=10.1
+
+# or, for CUDA 10.2
+conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
+    cudf=0.13 python=3.6 cudatoolkit=10.2
+```
+
+cuSignal has been tested and confirmed to work with Python 3.6, 3.7, and 3.8.
+
+See the [Get RAPIDS versoin picker](https://rapids.ai/start.html) for more OS and version info
+
+### Conda - Jetson Nano, TK1, TX2, Xavier, Linux OS
+
+While there are many versions of Anaconda for AArch64 platforms, cuSignal has been tested and supports [conda4aarch64](https://github.com/jjhelmus/conda4aarch64/releases). Conda4aarch64 is also described in the [Numba aarch64 installation instructions](http://numba.pydata.org/numba-doc/latest/user/installing.html#installing-on-linux-armv8-aarch64-platforms). Further, it's assumed that your Jetson device is running a current edition of [JetPack](https://developer.nvidia.com/embedded/jetpack) and contains the CUDA Toolkit.
+
+1. Clone the repository
+
+    ```bash
+    # Set the localtion to cuSignal in an environment variable CUSIGNAL_HOME
+    export CUSIGNAL_HOME=$(pwd)/cusignal
+
+    # Download the cuSignal repo
+    git clone https://github.com/rapidsai/cusignal.git $CUSIGNAL_HOME
+    ```
+
+2. Install [conda4aarch64](https://github.com/jjhelmus/conda4aarch64/releases) and create the cuSignal conda environment:
+
+    ```bash
+    cd $CUSIGNAL_HOME
+    conda env create -f conda/environments/cusignal_jetson_base.yml
+    ```
+
+3. Activate conda environment
+
+    `conda activate cusignal`
+
+4. Install cuSignal module
+
+    ```bash
+    cd $CUSIGNAL_HOME/python
+    python setup.py install
+    ```
+
+    or
+
+    ```bash
+    cd $CUSIGNAL_HOME
+    ./build.sh  # install cuSignal to $PREFIX if set, otherwise $CONDA_PREFIX
+                # run ./build.sh -h to print the supported command line options.
+    ```
+
+5. Once installed, periodically update environment
+
+    ```bash
+    cd $CUSIGNAL_HOME
+    conda env update -f conda/environments/cusignal_jetson_base.yml
+    ```
+
+6. Also, confirm unit testing via PyTest
+
+    ```bash
+    cd $CUSIGNAL_HOME/python
+    pytest -v  # for verbose mode
+    pytest -v -k <function name>  # for more select testing
+    ```
+
+### Source, Linux OS
 
 1. Clone the repository
 
@@ -171,62 +252,7 @@ NOTE: if used with other portions of RAPIDS, then GPU needs to be Pascal or late
     pytest -v -k <function name>  # for more select testing
     ```
 
-## Install cuSignal, Linux OS, Jetson Nano, Xavier, TX1, TX2
-
-While there are many versions of Anaconda for AArch64 platforms, cuSignal has been tested and supports [conda4aarch64](https://github.com/jjhelmus/conda4aarch64/releases). Conda4aarch64 is also described in the [Numba aarch64 installation instructions](http://numba.pydata.org/numba-doc/latest/user/installing.html#installing-on-linux-armv8-aarch64-platforms). Further, it's assumed that your Jetson device is running a current edition of [JetPack](https://developer.nvidia.com/embedded/jetpack) and contains the CUDA Toolkit.
-
-1. Clone the repository
-
-    ```bash
-    # Set the localtion to cuSignal in an environment variable CUSIGNAL_HOME
-    export CUSIGNAL_HOME=$(pwd)/cusignal
-
-    # Download the cuSignal repo
-    git clone https://github.com/rapidsai/cusignal.git $CUSIGNAL_HOME
-    ```
-
-2. Install [conda4aarch64](https://github.com/jjhelmus/conda4aarch64/releases) and create the cuSignal conda environment:
-
-    ```bash
-    cd $CUSIGNAL_HOME
-    conda env create -f conda/environments/cusignal_jetson_base.yml
-    ```
-
-3. Activate conda environment
-
-    `conda activate cusignal`
-
-4. Install cuSignal module
-
-    ```bash
-    cd $CUSIGNAL_HOME/python
-    python setup.py install
-    ```
-
-    or
-
-    ```bash
-    cd $CUSIGNAL_HOME
-    ./build.sh  # install cuSignal to $PREFIX if set, otherwise $CONDA_PREFIX
-                # run ./build.sh -h to print the supported command line options.
-    ```
-
-5. Once installed, periodically update environment
-
-    ```bash
-    cd $CUSIGNAL_HOME
-    conda env update -f conda/environments/cusignal_jetson_base.yml
-    ```
-
-6. Also, confirm unit testing via PyTest
-
-    ```bash
-    cd $CUSIGNAL_HOME/python
-    pytest -v  # for verbose mode
-    pytest -v -k <function name>  # for more select testing
-    ```
-
-## Install cuSignal on Windows OS
+### Source, Windows OS [Expiremental]
 
 1. Download and install [Andaconda](https://www.anaconda.com/distribution/) for Windows. In an Anaconda Prompt, navigate to your checkout of cuSignal.
 
@@ -260,6 +286,13 @@ In the cuSignal top level directory:
     pip install pytest
     pytest
     ```
+
+## Dependencies
+* NVIDIA GPU (Maxwell Architecture or newer; Pascal if using cuSignal with other RAPIDS libraries)
+* CUDA Divers
+* Anaconda/Miniconda (3.7 version)
+* CuPy >= 6.2.0
+* Optional: RTL-SDR or other SDR Driver/Packaging. Find more information and follow the instructions for setup [here](https://github.com/osmocom/rtl-sdr). We have also tested cuSignal integration with [SoapySDR](https://github.com/pothosware/SoapySDR/wiki)
 
 ## Contributing Guide
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
 
 cuSignal has been tested and confirmed to work with Python 3.6, 3.7, and 3.8.
 
-See the [Get RAPIDS versoin picker](https://rapids.ai/start.html) for more OS and version info
+See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info.
 
 ### Conda - Jetson Nano, TK1, TX2, Xavier, Linux OS
 
@@ -287,12 +287,29 @@ In the cuSignal top level directory:
     pytest
     ```
 
-## Dependencies
-* NVIDIA GPU (Maxwell Architecture or newer; Pascal if using cuSignal with other RAPIDS libraries)
-* CUDA Divers
-* Anaconda/Miniconda (3.7 version)
-* CuPy >= 6.2.0
-* Optional: RTL-SDR or other SDR Driver/Packaging. Find more information and follow the instructions for setup [here](https://github.com/osmocom/rtl-sdr). We have also tested cuSignal integration with [SoapySDR](https://github.com/pothosware/SoapySDR/wiki)
+### Docker - All RAPIDS Libraries, including cuSignal
+
+For `cusignal version == 0.13`:
+
+```
+# For CUDA 10.0
+docker pull rapidsai/rapidsai:cuda10.0-runtime-ubuntu18.04
+docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+    rapidsai/rapidsai:cuda10.0-runtime-ubuntu18.04
+```
+
+For the nightly version of `cusignal`
+```
+docker pull rapidsai/rapidsai-nightly:cuda10.0-runtime-ubuntu18.04
+docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+    rapidsai/rapidsai-nightly:cuda10.0-runtime-ubuntu18.04
+```
+
+Please see the [RAPIDS Release Selector](https://rapids.ai/start.html) for more information on supported Python, Linux, and CUDA versions.
+
+## Optional Dependencies
+* [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) if using Docker 
+* RTL-SDR or other SDR Driver/Packaging. Find more information and follow the instructions for setup [here](https://github.com/osmocom/rtl-sdr). We have also tested cuSignal integration with [SoapySDR](https://github.com/pothosware/SoapySDR/wiki)
 
 ## Contributing Guide
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cusignal/job/branches/job/cusignal-branch-pipeline/badge/icon)](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cusignal/job/branches/job/cusignal-branch-pipeline/)
 
-The [RAPIDS](https://rapids.ai) **cuSignal** project leverages [CuPy](https://github.com/cupy/cupy), [Numba](https://github.com/numba/numba), and the RAPIDS ecosystem for GPU accelerated signal processing. In some cases, cuSignal is a direct port of [Scipy Signal](https://github.com/scipy/scipy/tree/master/scipy/signal) to leverage GPU compute resources via CuPy but also contains Numba CUDA kernels for additional speedups for selected functions. cuSignal achieves its best gains on large signals and compute intensive functions but stresses online processing with zero-copy memory (pinned, mapped) between CPU and GPU.
+The [RAPIDS](https://rapids.ai) **cuSignal** project leverages [CuPy](https://github.com/cupy/cupy), [Numba](https://github.com/numba/numba), and the RAPIDS ecosystem for GPU accelerated signal processing. In some cases, cuSignal is a direct port of [Scipy Signal](https://github.com/scipy/scipy/tree/master/scipy/signal) to leverage GPU compute resources via CuPy but also contains Numba CUDA and Raw CuPy CUDA kernels for additional speedups for selected functions. cuSignal achieves its best gains on large signals and compute intensive functions but stresses online processing with zero-copy memory (pinned, mapped) between CPU and GPU.
 
 **NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cusignal/blob/master/README.md) ensure you are on the latest branch.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This code executes on an NVIDIA V100 in 637 ms.
 ## Installation
 
 ### Conda, Linux OS
-cuSignal can be installed with conda([miniconda](https://docs.conda.io/en/latest/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/distribution/)) from the `rapidsai` channel). If you're using a Jetson GPU, please follow the build instructions [below](https://github.com/rapidsai/cusignal#conda-jetson-nano-tk1-tx2-xavier-linux-os)
+cuSignal can be installed with conda ([miniconda](https://docs.conda.io/en/latest/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/distribution/)) from the `rapidsai` channel). If you're using a Jetson GPU, please follow the build instructions [below](https://github.com/rapidsai/cusignal#conda-jetson-nano-tk1-tx2-xavier-linux-os)
 
 For `cusignal version == 0.13`:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This code executes on an NVIDIA V100 in 637 ms.
 ## Installation
 
 ### Conda, Linux OS
-cuSignal can be installed with conda ([miniconda](https://docs.conda.io/en/latest/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/distribution/)) from the `rapidsai` channel). If you're using a Jetson GPU, please follow the build instructions [below](https://github.com/rapidsai/cusignal#conda-jetson-nano-tk1-tx2-xavier-linux-os)
+cuSignal can be installed with conda ([Miniconda](https://docs.conda.io/en/latest/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/distribution/)) from the `rapidsai` channel). If you're using a Jetson GPU, please follow the build instructions [below](https://github.com/rapidsai/cusignal#conda-jetson-nano-tk1-tx2-xavier-linux-os)
 
 For `cusignal version == 0.13`:
 


### PR DESCRIPTION
This PR updates the `README` to fall inline with [cuDF](https://github.com/rapidsai/cudf). Now that RAPIDS has official Docker/Conda packaging, the README was updated to reflect these instructions. A list of changes:
* Added explicit conda install instructions
* Added Docker install instructions
* Updated dependencies to focus on optional packages
* Added blurb about raw cupy cuda kernels