### PR TITLE
[REVIEW] Added CuPy for lombscargle, along with tests/benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 - PR #43 - Add pytest-benchmarks tests
 - PR #49 - Add CuPy Module for convolve2d and correlate2d
+- PR #51 - Add CuPy Module for lombscargle, along with tests/benchmarks
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.
@@ -10,7 +11,6 @@
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests
-- PR #51 - Added missing lombscargle tests/benchmarks
 
 # cuSignal 0.13 (31 Mar 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - PR #45 - Refactor `_signaltools.py` to use new Numba/CuPy framework
 
 ## Bug Fixes
-- PR #44 - Fix issues in pytests 
+- PR #44 - Fix issues in pytests
+- PR #51 - Added missing lombscargle tests/benchmarks
 
 # cuSignal 0.13 (31 Mar 2020)
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -11,14 +11,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import cuda
-
-# These cupy math functions aren't yet supported in numba
 from math import sin, cos, atan2
 
+from string import Template
 
-@cuda.jit(fastmath=True)
-def _lombscargle(x, y, freqs, pgram):
+import cupy as cp
+from numba import (
+    cuda,
+    float64,
+    void,
+)
+
+
+_numba_kernel_cache = {}
+_cupy_kernel_cache = {}
+
+# Numba type supported and corresponding C type
+_SUPPORTED_TYPES = {
+    float64: "double",
+}
+
+
+# Use until functionality provided in Numba 0.49/0.50 available
+def stream_cupy_to_numba(cp_stream):
+    """
+    Notes:
+        1. The lifetime of the returned Numba stream should be as
+           long as the CuPy one, which handles the deallocation
+           of the underlying CUDA stream.
+        2. The returned Numba stream is assumed to live in the same
+           CUDA context as the CuPy one.
+        3. The implementation here closely follows that of
+           cuda.stream() in Numba.
+    """
+    from ctypes import c_void_p
+    import weakref
+
+    # get the pointer to actual CUDA stream
+    raw_str = cp_stream.ptr
+
+    # gather necessary ingredients
+    ctx = cuda.devices.get_context()
+    handle = c_void_p(raw_str)
+
+    # create a Numba stream
+    nb_stream = cuda.cudadrv.driver.Stream(
+        weakref.proxy(ctx), handle, finalizer=None
+    )
+
+    return nb_stream
+
+
+def _numba_lombscargle(x, y, freqs, pgram, y_dot):
     """
     _lombscargle(x, y, freqs)
     Computes the Lomb-Scargle periodogram.
@@ -46,89 +90,21 @@ def _lombscargle(x, y, freqs, pgram):
     F = cuda.grid(1)
     strideF = cuda.gridsize(1)
 
-    for i in range(F, freqs.shape[0], strideF):
-
-        freq = freqs[i]
-
-        xc = 0.0
-        xs = 0.0
-        cc = 0.0
-        ss = 0.0
-        cs = 0.0
-
-        for j in range(x.shape[0]):
-
-            c = cos(freq * x[j])
-            s = sin(freq * x[j])
-
-            xc += y[j] * c
-            xs += y[j] * s
-            cc += c * c
-            ss += s * s
-            cs += c * s
-
-        tau = atan2(2.0 * cs, cc - ss) / (2.0 * freq)
-        c_tau = cos(freq * tau)
-        s_tau = sin(freq * tau)
-        c_tau2 = c_tau * c_tau
-        s_tau2 = s_tau * s_tau
-        cs_tau = 2.0 * c_tau * s_tau
-
-        pgram[i] = 0.5 * (
-            (
-                (c_tau * xc + s_tau * xs) ** 2
-                / (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)
-            )
-            + (
-                (c_tau * xs - s_tau * xc) ** 2
-                / (c_tau2 * ss - cs_tau * cs + s_tau2 * cc)
-            )
-        )
-
-
-@cuda.jit(fastmath=True)
-def _lombscargle_norm(x, y, freqs, pgram, y_dot):
-    """
-    _lombscargle(x, y, freqs)
-    Computes the Lomb-Scargle periodogram.
-    Parameters
-    ----------
-    x : array_like
-        Sample times.
-    y : array_like
-        Measurement values (must be registered so the mean is zero).
-    freqs : array_like
-        Angular frequencies for output periodogram.
-    Returns
-    -------
-    pgram : array_like
-        Lomb-Scargle periodogram.
-    Raises
-    ------
-    ValueError
-        If the input arrays `x` and `y` do not have the same shape.
-    See also
-    --------
-    lombscargle
-    """
-
-    F = cuda.grid(1)
-    strideF = cuda.gridsize(1)
+    if not y_dot[0]:
+        yD = 1.0
+    else:
+        yD = 2.0 / y_dot[0]
 
     for i in range(F, freqs.shape[0], strideF):
 
         # Copy data to registers
-        temp = 0.0
         freq = freqs[i]
-        yD = 2.0 / y_dot[0]
 
         xc = 0.0
         xs = 0.0
         cc = 0.0
         ss = 0.0
         cs = 0.0
-
-        # cuda.syncthreads()
 
         for j in range(x.shape[0]):
 
@@ -148,38 +124,183 @@ def _lombscargle_norm(x, y, freqs, pgram, y_dot):
         s_tau2 = s_tau * s_tau
         cs_tau = 2.0 * c_tau * s_tau
 
-        temp = 0.5 * (
-            (
-                (c_tau * xc + s_tau * xs) ** 2
-                / (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)
+        pgram[i] = (
+            0.5
+            * (
+                (
+                    (c_tau * xc + s_tau * xs) ** 2
+                    / (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)
+                )
+                + (
+                    (c_tau * xs - s_tau * xc) ** 2
+                    / (c_tau2 * ss - cs_tau * cs + s_tau2 * cc)
+                )
             )
-            + (
-                (c_tau * xs - s_tau * xc) ** 2
-                / (c_tau2 * ss - cs_tau * cs + s_tau2 * cc)
-            )
+        ) * yD
+
+
+def _numba_lombscargle_signature(ty):
+    return void(
+        ty[:], ty[:], ty[:], ty[:], ty[:],  # x  # y  # freqs  # pgram  # y_dot
+    )
+
+
+# Custom Cupy raw kernel implementing lombscargle operation
+# Matthew Nicely - mnicely@nvidia.com
+loaded_from_source = Template(
+    """
+extern "C" {
+    __global__ void _cupy_lombscargle(
+            const int x_shape,
+            const int freqs_shape,
+            const ${datatype} * __restrict__ x,
+            const ${datatype} * __restrict__ y,
+            const ${datatype} * __restrict__ freqs,
+            ${datatype} * __restrict__ pgram,
+            const ${datatype} * __restrict__ y_dot
+            ) {
+
+        const int tx {
+            static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+        const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+        ${datatype} yD {};
+        if ( y_dot[0] == 0 ) {
+            yD = 1.0f;
+        } else {
+            yD = 2.0f / y_dot[0];
+        }
+
+        for ( int tid = tx; tid < freqs_shape; tid += stride ) {
+
+            ${datatype} freq { freqs[tid] };
+
+            ${datatype} xc {};
+            ${datatype} xs {};
+            ${datatype} cc {};
+            ${datatype} ss {};
+            ${datatype} cs {};
+            ${datatype} c {};
+            ${datatype} s {};
+
+            for ( int j = 0; j < x_shape; j++ ) {
+                c = cos( freq * x[j] );
+                s = sin( freq * x[j] );
+
+                xc += y[j] * c;
+                xs += y[j] * s;
+                cc += c * c;
+                ss += s * s;
+                cs += c * s;
+            }
+
+            ${datatype} tau { atan2( 2.0f * cs, cc - ss ) / ( 2.0f * freq ) };
+            ${datatype} c_tau { cos(freq * tau) };
+            ${datatype} s_tau { sin(freq * tau) };
+            ${datatype} c_tau2 { c_tau * c_tau };
+            ${datatype} s_tau2 { s_tau * s_tau };
+            ${datatype} cs_tau { 2.0f * c_tau * s_tau };
+
+            pgram[tid] = (
+                0.5f * (
+                   (
+                       ( c_tau * xc + s_tau * xs )
+                       * ( c_tau * xc + s_tau * xs )
+                       / ( c_tau2 * cc + cs_tau * cs + s_tau2 * ss )
+                    )
+                   + (
+                       ( c_tau * xs - s_tau * xc )
+                       * ( c_tau * xs - s_tau * xc )
+                       / ( c_tau2 * ss - cs_tau * cs + s_tau2 * cc )
+                    )
+                )
+            ) * yD;
+        }
+    }
+}
+"""
+)
+
+
+class _cupy_lombscargle_wrapper(object):
+    def __init__(self, grid, block, stream, kernel):
+        if isinstance(grid, int):
+            grid = (grid,)
+        if isinstance(block, int):
+            block = (block,)
+
+        self.grid = grid
+        self.block = block
+        self.stream = stream
+        self.kernel = kernel
+
+    def __call__(
+        self, x, y, freqs, pgram, y_dot,
+    ):
+
+        kernel_args = (
+            x.shape[0],
+            freqs.shape[0],
+            x,
+            y,
+            freqs,
+            pgram,
+            y_dot,
         )
 
-        pgram[i] = temp * yD
+        self.stream.use()
+        self.kernel(self.grid, self.block, kernel_args)
 
 
-"""
-import cupy as np
-import cusignal
-nin = 5
-nout = 10
-x = np.linspace(1, 10, nin)
-y = np.sin(x)
-f = np.linspace(1, 10, nout)
-pgram = cusignal.lombscargle(x, y, f, normalize=True)
-"""
+def _get_backend_kernel(dtype, grid, block, stream, use_numba):
 
-"""
-for j in range(x.shape[0]):
-    c = cos(freqs[i] * x[j])
-    s = sin(freqs[i] * x[j])
-    xc += y[j] * c
-    xs += y[j] * s
-    cc += c * c
-    ss += s * s
-    cs += c * s
-"""
+    if use_numba:
+        nb_stream = stream_cupy_to_numba(stream)
+        kernel = _numba_kernel_cache[(dtype.name)]
+
+        if kernel:
+            return kernel[grid, block, nb_stream]
+    else:
+        kernel = _cupy_kernel_cache[(dtype.name)]
+        if kernel:
+            return _cupy_lombscargle_wrapper(grid, block, stream, kernel)
+
+    raise NotImplementedError(
+        "No kernel found for datatype {}".format(dtype.name)
+    )
+
+
+def _populate_kernel_cache():
+    for numba_type, c_type in _SUPPORTED_TYPES.items():
+        # JIT compile the numba kernels
+        sig = _numba_lombscargle_signature(numba_type)
+        _numba_kernel_cache[(str(numba_type))] = cuda.jit(sig, fastmath=True)(
+            _numba_lombscargle
+        )
+
+        # Instantiate the cupy kernel for this type and compile
+        src = loaded_from_source.substitute(datatype=c_type)
+        module = cp.RawModule(
+            code=src, options=("-std=c++11", "-use_fast_math")
+        )
+        _cupy_kernel_cache[(str(numba_type))] = module.get_function(
+            "_cupy_lombscargle"
+        )
+
+
+def _lombscargle(x, y, freqs, pgram, y_dot, cp_stream, use_numba):
+
+    device_id = cp.cuda.Device()
+    numSM = device_id.attributes["MultiProcessorCount"]
+    threadsperblock = 256
+    blockspergrid = numSM * 20
+
+    kernel = _get_backend_kernel(
+        pgram.dtype, blockspergrid, threadsperblock, cp_stream, use_numba,
+    )
+
+    kernel(x, y, freqs, pgram, y_dot)
+
+
+# 1) Load and compile upfirdn kernels for each supported data type.
+_populate_kernel_cache()

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -50,11 +50,11 @@ def _lombscargle(x, y, freqs, pgram):
 
         freq = freqs[i]
 
-        xc = 0.
-        xs = 0.
-        cc = 0.
-        ss = 0.
-        cs = 0.
+        xc = 0.0
+        xs = 0.0
+        cc = 0.0
+        ss = 0.0
+        cs = 0.0
 
         for j in range(x.shape[0]):
 
@@ -75,10 +75,14 @@ def _lombscargle(x, y, freqs, pgram):
         cs_tau = 2.0 * c_tau * s_tau
 
         pgram[i] = 0.5 * (
-            ((c_tau * xc + s_tau * xs)**2 /
-             (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)) +
-            ((c_tau * xs - s_tau * xc)**2 /
-             (c_tau2 * ss - cs_tau * cs + s_tau2 * cc))
+            (
+                (c_tau * xc + s_tau * xs) ** 2
+                / (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)
+            )
+            + (
+                (c_tau * xs - s_tau * xc) ** 2
+                / (c_tau2 * ss - cs_tau * cs + s_tau2 * cc)
+            )
         )
 
 
@@ -118,11 +122,11 @@ def _lombscargle_norm(x, y, freqs, pgram, y_dot):
         freq = freqs[i]
         yD = 2.0 / y_dot[0]
 
-        xc = 0.
-        xs = 0.
-        cc = 0.
-        ss = 0.
-        cs = 0.
+        xc = 0.0
+        xs = 0.0
+        cc = 0.0
+        ss = 0.0
+        cs = 0.0
 
         # cuda.syncthreads()
 
@@ -145,10 +149,14 @@ def _lombscargle_norm(x, y, freqs, pgram, y_dot):
         cs_tau = 2.0 * c_tau * s_tau
 
         temp = 0.5 * (
-            ((c_tau * xc + s_tau * xs)**2 /
-             (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)) +
-            ((c_tau * xs - s_tau * xc)**2 /
-             (c_tau2 * ss - cs_tau * cs + s_tau2 * cc))
+            (
+                (c_tau * xc + s_tau * xs) ** 2
+                / (c_tau2 * cc + cs_tau * cs + s_tau2 * ss)
+            )
+            + (
+                (c_tau * xs - s_tau * xc) ** 2
+                / (c_tau2 * ss - cs_tau * cs + s_tau2 * cc)
+            )
         )
 
         pgram[i] = temp * yD

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -32,27 +32,27 @@ class BenchResample:
     # bench_ is required in function name to be searchable with -k parameter
     def bench_resample_cpu(
         self,
-        resample_data_gen,
+        linspace_data_gen,
         benchmark,
         num_samps,
         resample_num_samps,
         window,
     ):
-        cpu_sig, _ = resample_data_gen(0, 10, num_samps, endpoint=False)
+        cpu_sig, _ = linspace_data_gen(0, 10, num_samps, endpoint=False)
         benchmark(
             self.cpu_version, cpu_sig, resample_num_samps, window,
         )
 
     def bench_resample_gpu(
         self,
-        resample_data_gen,
+        linspace_data_gen,
         benchmark,
         num_samps,
         resample_num_samps,
         window,
     ):
 
-        cpu_sig, gpu_sig = resample_data_gen(0, 10, num_samps, endpoint=False)
+        cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)
         # Variable output holds result from final cusignal.resample
         # It is not copied back until assert to so timing is not impacted
         output = benchmark(
@@ -74,9 +74,9 @@ class BenchResamplePoly:
         return signal.resample_poly(cpu_sig, up, down, window=window)
 
     def bench_resample_poly_cpu(
-        self, resample_data_gen, benchmark, num_samps, up, down, window
+        self, linspace_data_gen, benchmark, num_samps, up, down, window
     ):
-        cpu_sig, _ = resample_data_gen(0, 10, num_samps, endpoint=False)
+        cpu_sig, _ = linspace_data_gen(0, 10, num_samps, endpoint=False)
         benchmark(
             self.cpu_version, cpu_sig, up, down, window,
         )
@@ -86,7 +86,7 @@ class BenchResamplePoly:
     @pytest.mark.parametrize("use_numba", [True, False])
     def bench_resample_poly_gpu(
         self,
-        resample_data_gen,
+        linspace_data_gen,
         benchmark,
         num_samps,
         up,
@@ -95,7 +95,7 @@ class BenchResamplePoly:
         use_numba,
     ):
 
-        cpu_sig, gpu_sig = resample_data_gen(0, 10, num_samps, endpoint=False)
+        cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)
         # Variable output holds result from final cusignal.resample
         # It is not copied back until assert to so timing is not impacted
         output = benchmark(

--- a/python/cusignal/benchmark/bench_spectral.py
+++ b/python/cusignal/benchmark/bench_spectral.py
@@ -341,8 +341,8 @@ class BenchSTFTComplex:
 @pytest.mark.benchmark(group="LombScargle")
 @pytest.mark.parametrize("num_in_samps", [2 ** 10])
 @pytest.mark.parametrize("num_out_samps", [2 ** 16, 2 ** 18])
-@pytest.mark.parametrize("precenter", ["True"])
-@pytest.mark.parametrize("normalize", ["True", "False"])
+@pytest.mark.parametrize("precenter", [True, False])
+@pytest.mark.parametrize("normalize", [True, False])
 class BenchLombScargle:
     def cpu_version(self, x, y, f, precenter, normalize):
         return signal.lombscargle(x, y, f, precenter, normalize)
@@ -372,6 +372,7 @@ class BenchLombScargle:
 
         benchmark(self.cpu_version, x, y, f, precenter, normalize)
 
+    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_lombscargle_gpu(
         self,
         linspace_data_gen,
@@ -381,6 +382,7 @@ class BenchLombScargle:
         num_out_samps,
         precenter,
         normalize,
+        use_numba,
     ):
         A = 2.0
         w = 1.0
@@ -397,7 +399,13 @@ class BenchLombScargle:
         d_y = cp.asarray(y)
 
         output = benchmark(
-            cusignal.lombscargle, d_x, d_y, d_f, precenter, normalize
+            cusignal.lombscargle,
+            d_x,
+            d_y,
+            d_f,
+            precenter,
+            normalize,
+            use_numba=use_numba,
         )
 
         key = self.cpu_version(x, y, f, precenter, normalize)

--- a/python/cusignal/benchmark/bench_spectral.py
+++ b/python/cusignal/benchmark/bench_spectral.py
@@ -13,6 +13,7 @@
 
 import pytest
 import cupy as cp
+import numpy as np
 from cusignal.test.utils import array_equal
 import cusignal
 from scipy import signal
@@ -334,4 +335,70 @@ class BenchSTFTComplex:
         _, _, output = benchmark(cusignal.stft, gpu_sig, fs, nperseg=nperseg)
 
         _, _, key = self.cpu_version(cpu_sig, fs, nperseg)
+        assert array_equal(cp.asnumpy(output), key)
+
+
+@pytest.mark.benchmark(group="LombScargle")
+@pytest.mark.parametrize("num_in_samps", [2 ** 10])
+@pytest.mark.parametrize("num_out_samps", [2 ** 16, 2 ** 18])
+@pytest.mark.parametrize("precenter", ["True"])
+@pytest.mark.parametrize("normalize", ["True", "False"])
+class BenchLombScargle:
+    def cpu_version(self, x, y, f, precenter, normalize):
+        return signal.lombscargle(x, y, f, precenter, normalize)
+
+    def bench_lombscargle_cpu(
+        self,
+        linspace_data_gen,
+        rand_data_gen,
+        benchmark,
+        num_in_samps,
+        num_out_samps,
+        precenter,
+        normalize,
+    ):
+        A = 2.0
+        w = 1.0
+        phi = 0.5 * np.pi
+        frac_points = 0.9  # Fraction of points to select
+
+        r, _ = rand_data_gen(num_in_samps)
+        x, _ = linspace_data_gen(0.01, 10 * np.pi, num_in_samps)
+        x = x[r >= frac_points]
+
+        y = A * np.sin(w * x + phi)
+
+        f, _ = linspace_data_gen(0.01, 10, num_out_samps)
+
+        benchmark(self.cpu_version, x, y, f, precenter, normalize)
+
+    def bench_lombscargle_gpu(
+        self,
+        linspace_data_gen,
+        rand_data_gen,
+        benchmark,
+        num_in_samps,
+        num_out_samps,
+        precenter,
+        normalize,
+    ):
+        A = 2.0
+        w = 1.0
+        phi = 0.5 * np.pi
+        frac_points = 0.9  # Fraction of points to select
+
+        r, _ = rand_data_gen(num_in_samps)
+        x, _ = linspace_data_gen(0.01, 10 * np.pi, num_in_samps)
+        x = x[r >= frac_points]
+        y = A * np.sin(w * x + phi)
+        f, d_f = linspace_data_gen(0.01, 10, num_out_samps)
+
+        d_x = cp.asarray(x)
+        d_y = cp.asarray(y)
+
+        output = benchmark(
+            cusignal.lombscargle, d_x, d_y, d_f, precenter, normalize
+        )
+
+        key = self.cpu_version(x, y, f, precenter, normalize)
         assert array_equal(cp.asnumpy(output), key)

--- a/python/cusignal/benchmark/conftest.py
+++ b/python/cusignal/benchmark/conftest.py
@@ -18,10 +18,10 @@ import numpy as np
 # Fixtures with (scope="session") will execute once
 # and be shared will all tests that need it.
 
-# Generate data for resample and resample_poly
+# Generate data for using linspace
 @pytest.fixture(scope="session")
-def resample_data_gen():
-    def _generate(start, stop, num_samps, endpoint):
+def linspace_data_gen():
+    def _generate(start, stop, num_samps, endpoint=False):
 
         cpu_time = np.linspace(start, stop, num_samps, endpoint)
         cpu_sig = np.cos(-(cpu_time ** 2) / 6.0)

--- a/python/cusignal/test/test_spectral.py
+++ b/python/cusignal/test/test_spectral.py
@@ -202,9 +202,12 @@ def test_stft_complex(num_samps, fs, nperseg):
 
 @pytest.mark.parametrize("num_in_samps", [2 ** 10])
 @pytest.mark.parametrize("num_out_samps", [2 ** 16, 2 ** 18])
-@pytest.mark.parametrize("precenter", ["True", "False"])
-@pytest.mark.parametrize("normalize", ["True", "False"])
-def test_lombscargle(num_in_samps, num_out_samps, precenter, normalize):
+@pytest.mark.parametrize("precenter", [True, False])
+@pytest.mark.parametrize("normalize", [True, False])
+@pytest.mark.parametrize("use_numba", [True, False])
+def test_lombscargle(
+    num_in_samps, num_out_samps, precenter, normalize, use_numba
+):
     A = 2.0
     w = 1.0
     phi = 0.5 * np.pi
@@ -214,7 +217,7 @@ def test_lombscargle(num_in_samps, num_out_samps, precenter, normalize):
     x = np.linspace(0.01, 10 * np.pi, num_in_samps)
     x = x[r >= frac_points]
 
-    y = A * np.sin(w * x + phi)
+    y = A * np.cos(w * x + phi)
 
     f = np.linspace(0.01, 10, num_out_samps)
 
@@ -225,7 +228,9 @@ def test_lombscargle(num_in_samps, num_out_samps, precenter, normalize):
     d_f = cp.asarray(f)
 
     gpu_lombscargle = cp.asnumpy(
-        cusignal.lombscargle(d_x, d_y, d_f, precenter, normalize)
+        cusignal.lombscargle(
+            d_x, d_y, d_f, precenter, normalize, use_numba=use_numba,
+        )
     )
 
     assert array_equal(cpu_lombscargle, gpu_lombscargle)

--- a/python/cusignal/test/test_spectral.py
+++ b/python/cusignal/test/test_spectral.py
@@ -19,9 +19,9 @@ import numpy as np
 from scipy import signal
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_csd(num_samps, fs, nperseg):
     cpu_x = np.random.rand(num_samps)
     cpu_y = np.random.rand(num_samps)
@@ -34,9 +34,9 @@ def test_csd(num_samps, fs, nperseg):
     assert array_equal(cpu_csd, gpu_csd)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_csd_complex(num_samps, fs, nperseg):
     cpu_x = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
     cpu_y = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
@@ -49,16 +49,17 @@ def test_csd_complex(num_samps, fs, nperseg):
     assert array_equal(cpu_csd, gpu_csd)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('window', ['flattop', 'nuttall'])
-@pytest.mark.parametrize('scaling', ['spectrum', 'density'])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("window", ["flattop", "nuttall"])
+@pytest.mark.parametrize("scaling", ["spectrum", "density"])
 def test_periodogram(num_samps, fs, window, scaling):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
-    cpu_periodogram = signal.periodogram(cpu_sig, fs, window=window,
-                                         scaling=scaling)
+    cpu_periodogram = signal.periodogram(
+        cpu_sig, fs, window=window, scaling=scaling
+    )
     gpu_periodogram = cp.asnumpy(
         cusignal.periodogram(gpu_sig, fs, window=window, scaling=scaling)
     )
@@ -66,10 +67,10 @@ def test_periodogram(num_samps, fs, window, scaling):
     assert array_equal(cpu_periodogram, gpu_periodogram)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('window', ['flattop', 'nuttall'])
-@pytest.mark.parametrize('scaling', ['spectrum', 'density'])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("window", ["flattop", "nuttall"])
+@pytest.mark.parametrize("scaling", ["spectrum", "density"])
 def test_periodogram_complex(num_samps, fs, window, scaling):
     cpu_sig = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -85,9 +86,9 @@ def test_periodogram_complex(num_samps, fs, window, scaling):
     assert array_equal(cpu_periodogram, gpu_periodogram)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_welch(num_samps, fs, nperseg):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -99,9 +100,9 @@ def test_welch(num_samps, fs, nperseg):
     assert array_equal(cPxx_spec, gPxx_spec)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_welch_complex(num_samps, fs, nperseg):
     cpu_sig = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -113,8 +114,8 @@ def test_welch_complex(num_samps, fs, nperseg):
     assert array_equal(cPxx_spec, gPxx_spec)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
 def test_spectrogram(num_samps, fs):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -126,8 +127,8 @@ def test_spectrogram(num_samps, fs):
     assert array_equal(cPxx_spec, gPxx_spec)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
 def test_spectrogram_complex(num_samps, fs):
     cpu_sig = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -139,9 +140,9 @@ def test_spectrogram_complex(num_samps, fs):
     assert array_equal(cPxx_spec, gPxx_spec)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_coherence(num_samps, fs, nperseg):
     cpu_x = np.random.rand(num_samps)
     cpu_y = np.random.rand(num_samps)
@@ -155,9 +156,9 @@ def test_coherence(num_samps, fs, nperseg):
     assert array_equal(cpu_coherence, gpu_coherence)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_coherence_complex(num_samps, fs, nperseg):
     cpu_x = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
     cpu_y = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
@@ -171,9 +172,9 @@ def test_coherence_complex(num_samps, fs, nperseg):
     assert array_equal(cpu_coherence, gpu_coherence)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_stft(num_samps, fs, nperseg):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -185,9 +186,9 @@ def test_stft(num_samps, fs, nperseg):
     assert array_equal(cpu_stft, gpu_stft)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('fs', [1.0, 1e6])
-@pytest.mark.parametrize('nperseg', [1024, 2048])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("fs", [1.0, 1e6])
+@pytest.mark.parametrize("nperseg", [1024, 2048])
 def test_stft_complex(num_samps, fs, nperseg):
     cpu_sig = np.random.rand(num_samps) + 1j * np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -197,3 +198,34 @@ def test_stft_complex(num_samps, fs, nperseg):
     gpu_stft = cp.asnumpy(gpu_stft)
 
     assert array_equal(cpu_stft, gpu_stft)
+
+
+@pytest.mark.parametrize("num_in_samps", [2 ** 10])
+@pytest.mark.parametrize("num_out_samps", [2 ** 16, 2 ** 18])
+@pytest.mark.parametrize("precenter", ["True", "False"])
+@pytest.mark.parametrize("normalize", ["True", "False"])
+def test_lombscargle(num_in_samps, num_out_samps, precenter, normalize):
+    A = 2.0
+    w = 1.0
+    phi = 0.5 * np.pi
+    frac_points = 0.9  # Fraction of points to select
+
+    r = np.random.rand(num_in_samps)
+    x = np.linspace(0.01, 10 * np.pi, num_in_samps)
+    x = x[r >= frac_points]
+
+    y = A * np.sin(w * x + phi)
+
+    f = np.linspace(0.01, 10, num_out_samps)
+
+    cpu_lombscargle = signal.lombscargle(x, y, f, precenter, normalize)
+
+    d_x = cp.asarray(x)
+    d_y = cp.asarray(y)
+    d_f = cp.asarray(f)
+
+    gpu_lombscargle = cp.asnumpy(
+        cusignal.lombscargle(d_x, d_y, d_f, precenter, normalize)
+    )
+
+    assert array_equal(cpu_lombscargle, gpu_lombscargle)


### PR DESCRIPTION
Recently noticed we didn't have any tests or benchmarks for `cusignal.lombscargle`

This PR does the following
1. Updates `test_spectral.py` to include `test_lombscargle`
2. Updates `bench_spectral.py to include `BenchLombScargle`
3. Updates `_spectral.py` to new Numba/CuPy framework
4. Combine **_lombscargle()** and **_lombscargle_norm()** into one Numba kernel - **_numba_lombscargle()**
5. Adds CuPy Module **_cupy_lombscargle()**
6. Renames **resample_data_gen** in `conftest.py` to **linspace_data_gen**.

Note: Only float64 is implemented in Numba/CuPy kernels because **lombscargle()** in `spectral.py` is creating float64 arrays

Benchmarks show `cusignal.lombscargle` Numba/CuPy kernels are ~1600x/~7900x faster, respectively, than `signal.lombscargle`, for large test cases.
```bash
---------------------------------------------------------------------------------------------------------- benchmark 'LombScargle': 24 tests ----------------------------------------------------------------------------------------------------------
Name (time in us)                                                 Min                     Max                    Mean                 StdDev                  Median                    IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_lombscargle_gpu[False-False-False-262144-1024]          25.5090 (1.0)       57,721.7080 (4.33)       5,138.9063 (4.38)      1,586.5799 (3.91)       5,210.4740 (4.28)          4.1410 (1.0)     1580;7337  194.5939 (0.23)      37064           1
bench_lombscargle_gpu[False-False-False-65536-1024]           26.1690 (1.03)      73,544.8380 (5.51)       1,314.1503 (1.12)        869.8119 (2.14)       1,339.8920 (1.10)          4.5330 (1.09)    1562;9290  760.9480 (0.89)      37064           1
bench_lombscargle_gpu[False-True-False-262144-1024]           49.4190 (1.94)      61,455.4330 (4.61)       5,252.4475 (4.48)      1,521.6047 (3.75)       5,326.2120 (4.38)        213.2187 (51.49)     849;977  190.3874 (0.22)      19661           1
bench_lombscargle_gpu[False-True-False-65536-1024]            50.3880 (1.98)      76,890.8100 (5.76)       1,197.9058 (1.02)        956.3073 (2.36)       1,216.7410 (1.0)          13.4430 (3.25)     995;2252  834.7902 (0.98)      19530           1
bench_lombscargle_gpu[False-False-True-262144-1024]           50.6060 (1.98)      48,329.3650 (3.62)       4,887.3250 (4.17)      1,414.8842 (3.49)       4,975.3850 (4.09)         30.8430 (7.45)     771;4357  204.6109 (0.24)      19347           1
bench_lombscargle_gpu[False-False-True-65536-1024]            51.5940 (2.02)      38,826.3100 (2.91)       1,255.4878 (1.07)        688.6169 (1.70)       1,277.8300 (1.05)         49.5030 (11.95)    825;1224  796.5032 (0.93)      19252           1
bench_lombscargle_gpu[False-True-True-262144-1024]            70.9490 (2.78)      54,910.1390 (4.12)       4,606.5883 (3.93)      1,582.9334 (3.90)       4,664.9150 (3.83)         12.8668 (3.11)     583;3609  217.0804 (0.25)      13941           1
bench_lombscargle_gpu[False-True-True-65536-1024]             71.7680 (2.81)      45,556.7630 (3.42)       1,327.9690 (1.13)        790.8464 (1.95)       1,346.8100 (1.11)          7.2510 (1.75)     626;2773  753.0296 (0.88)      13662           1
bench_lombscargle_gpu[True-False-False-262144-1024]          290.7320 (11.40)     41,805.3930 (3.13)       4,263.3776 (3.63)      2,164.3511 (5.34)       4,992.7610 (4.10)          4.5932 (1.11)      594;841  234.5558 (0.28)       3389           1
bench_lombscargle_gpu[True-False-False-65536-1024]           291.3800 (11.42)     22,346.1810 (1.68)       1,190.1890 (1.01)        611.0163 (1.51)       1,395.4430 (1.15)          7.2935 (1.76)      676;825  840.2027 (0.99)       3376           1
bench_lombscargle_gpu[True-True-False-65536-1024]            314.9020 (12.34)     29,454.9880 (2.21)       1,257.6035 (1.07)        789.2399 (1.95)       1,402.7940 (1.15)         17.9888 (4.34)      433;806  795.1632 (0.93)       3131           1
bench_lombscargle_gpu[True-True-False-262144-1024]           316.3740 (12.40)     37,513.1790 (2.81)       4,598.2662 (3.92)      1,917.2551 (4.73)       5,109.5660 (4.20)         47.2935 (11.42)     418;672  217.4733 (0.26)       3131           1
bench_lombscargle_gpu[True-False-True-65536-1024]            320.4400 (12.56)     13,339.3690 (1.0)        1,173.1719 (1.0)         405.6362 (1.0)        1,272.7685 (1.05)         12.4720 (3.01)      394;668  852.3900 (1.0)        3054           1
bench_lombscargle_gpu[True-False-True-262144-1024]           321.4760 (12.60)     22,388.1150 (1.68)       3,826.7991 (3.26)      1,693.8814 (4.18)       4,424.7560 (3.64)         50.3083 (12.15)     300;432  261.3150 (0.31)       1761           1
bench_lombscargle_gpu[True-True-True-262144-1024]            345.2690 (13.54)     36,545.1590 (2.74)       4,066.2470 (3.47)      1,647.4772 (4.06)       4,352.3070 (3.58)         37.5298 (9.06)      279;655  245.9270 (0.29)       2847           1
bench_lombscargle_gpu[True-True-True-65536-1024]             349.1290 (13.69)     15,032.4830 (1.13)       1,208.3499 (1.03)        484.0571 (1.19)       1,271.5395 (1.05)         23.7990 (5.75)      384;762  827.5749 (0.97)       2778           1
bench_lombscargle_cpu[True-True-65536-1024]              120,876.3750 (>1000.0)  177,365.4180 (13.30)    125,008.4340 (106.56)   12,525.6800 (30.88)    121,029.3340 (99.47)       865.0422 (208.90)        2;4    7.9995 (0.01)         25           1
bench_lombscargle_cpu[False-False-65536-1024]            123,406.1330 (>1000.0)  208,585.4650 (15.64)    130,926.7683 (111.60)   20,737.8170 (51.12)    123,750.2990 (101.71)    1,811.6968 (437.50)        2;6    7.6379 (0.01)         25           1
bench_lombscargle_cpu[False-True-65536-1024]             124,884.6130 (>1000.0)  210,538.8160 (15.78)    134,378.4824 (114.54)   21,468.9698 (52.93)    125,851.4250 (103.43)    6,940.0838 (>1000.0)       2;2    7.4417 (0.01)         25           1
bench_lombscargle_cpu[True-False-65536-1024]             127,845.1000 (>1000.0)  212,645.4010 (15.94)    136,384.9820 (116.25)   20,988.8997 (51.74)    128,914.0810 (105.95)    4,069.7560 (982.80)        2;4    7.3322 (0.01)         25           1
bench_lombscargle_cpu[False-True-262144-1024]            475,803.5040 (>1000.0)  575,848.7410 (43.17)    502,716.5231 (428.51)   40,700.2681 (100.34)   477,808.6350 (392.70)   81,656.1722 (>1000.0)       7;0    1.9892 (0.00)         25           1
bench_lombscargle_cpu[True-False-262144-1024]            498,611.6370 (>1000.0)  638,338.9140 (47.85)    532,163.6843 (453.61)   43,832.2857 (108.06)   510,633.4910 (419.67)   80,003.3487 (>1000.0)       7;0    1.8791 (0.00)         25           1
bench_lombscargle_cpu[False-False-262144-1024]           538,381.8730 (>1000.0)  640,534.3360 (48.02)    568,059.8687 (484.21)   37,884.9215 (93.40)    544,906.8610 (447.84)   70,740.2727 (>1000.0)       8;0    1.7604 (0.00)         25           1
bench_lombscargle_cpu[True-True-262144-1024]             554,326.7240 (>1000.0)  674,997.3890 (50.60)    582,991.0743 (496.94)   39,093.4188 (96.38)    561,399.6430 (461.40)   73,711.4145 (>1000.0)       7;0    1.7153 (0.00)         25           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
