### PR TITLE
[REVIEW] Use Numba 0.49+ API where required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 
+- PR #52 - Mirror API change in Numba 0.49
 
 # cuSignal 0.13 (31 Mar 2020)
 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -26,7 +26,12 @@ from numba import (
     int64,
     void,
 )
-from numba.core.types.scalars import Complex
+try:
+    # Numba <= 0.49
+    from numba.types.scalars import Complex
+except ImportError:
+    # Numba >= 0.49
+    from numba.core.types.scalars import Complex
 
 from .fir_filter_design import firwin
 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -26,7 +26,7 @@ from numba import (
     int64,
     void,
 )
-from numba.types.scalars import Complex
+from numba.core.types.scalars import Complex
 
 from .fir_filter_design import firwin
 

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -17,7 +17,12 @@ from string import Template
 
 import cupy as cp
 from numba import complex64, complex128, cuda, float32, float64, int64, void
-from numba.core.types.scalars import Complex
+try:
+    # Numba <= 0.49
+    from numba.types.scalars import Complex
+except ImportError:
+    # Numba >= 0.49
+    from numba.core.types.scalars import Complex
 
 _numba_kernel_cache = {}
 _cupy_kernel_cache = {}

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -17,7 +17,7 @@ from string import Template
 
 import cupy as cp
 from numba import complex64, complex128, cuda, float32, float64, int64, void
-from numba.types.scalars import Complex
+from numba.core.types.scalars import Complex
 
 _numba_kernel_cache = {}
 _cupy_kernel_cache = {}


### PR DESCRIPTION
https://github.com/numba/numba/pull/5197 refactors many of Numba's submodules. Mirror the required import changes in cusignal.

This keeps cusignal in sync with numba master and the 0.49 release candidate but breaks compatibility with the current numba release (0.48).

This should go in eventually but also needs to make sure we keep compatibility with whatever version of numba we're getting in the conda channels selected by our packaging (and certainly updates the minimum required version) - need help with this part.
