### PR TITLE
[REVIEW] Update API Guide Notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.
 - PR #45 - Refactor `_signaltools.py` to use new Numba/CuPy framework
+- PR #54 - Update notebooks to use timeit instead of time
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 

--- a/notebooks/api_guide/acoustics_examples.ipynb
+++ b/notebooks/api_guide/acoustics_examples.ipynb
@@ -251,7 +251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/bspline_examples.ipynb
+++ b/notebooks/api_guide/bspline_examples.ipynb
@@ -45,7 +45,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cspline = signal.gauss_spline(cx, N)"
    ]
   },
@@ -64,7 +64,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gspline = cusignal.gauss_spline(gx, N)"
    ]
   },
@@ -90,7 +90,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "ccspline = signal.cubic(cx)"
    ]
   },
@@ -109,7 +109,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gcspline = cusignal.cubic(gx)"
    ]
   },
@@ -135,7 +135,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cqspline = signal.quadratic(cx)"
    ]
   },
@@ -154,7 +154,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gqspline = cusignal.quadratic(gx)"
    ]
   }
@@ -175,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/peak_finding_examples.ipynb
+++ b/notebooks/api_guide/peak_finding_examples.ipynb
@@ -44,7 +44,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cmin = signal.argrelmin(csig)"
    ]
   },
@@ -63,7 +63,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gmin = cusignal.argrelmin(gsig)"
    ]
   },
@@ -89,7 +89,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cmax = signal.argrelmax(csig)"
    ]
   },
@@ -108,7 +108,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gmax = cusignal.argrelmax(gsig)"
    ]
   },
@@ -134,7 +134,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cex = signal.argrelextrema(csig, np.less)"
    ]
   },
@@ -153,7 +153,7 @@
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gex = cusignal.argrelextrema(gsig, cp.less)"
    ]
   }
@@ -174,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/signaltools_examples.ipynb
+++ b/notebooks/api_guide/signaltools_examples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14.1 s ± 272 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "14.3 s ± 438 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -71,7 +71,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "71.7 ms ± 4.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "71.1 ms ± 2.45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -112,7 +112,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.4 s ± 1.21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.41 s ± 10 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -140,7 +140,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "32.4 ms ± 101 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "32.3 ms ± 110 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -158,7 +158,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "17.3 ms ± 26.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "17.3 ms ± 14.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -193,7 +193,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "13.5 s ± 28.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "13.5 s ± 20.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -211,7 +211,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "149 ms ± 230 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "149 ms ± 21.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -246,7 +246,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.39 s ± 1.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "5.06 s ± 5.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -274,7 +274,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "72.9 ms ± 30.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "73.1 ms ± 418 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -309,7 +309,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "16.7 s ± 1.11 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "15.7 s ± 119 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -337,7 +337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "73.1 ms ± 10.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "72.9 ms ± 20.9 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -371,7 +371,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "27.7 s ± 420 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "27.3 s ± 171 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -398,7 +398,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "128 ms ± 487 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "128 ms ± 192 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -432,7 +432,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.59 s ± 8.47 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "3.57 s ± 3.69 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -459,7 +459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "255 ms ± 42.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "256 ms ± 43.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -493,7 +493,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11.1 s ± 63.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "11.2 s ± 79 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -520,7 +520,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "71.2 ms ± 1.24 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "71.3 ms ± 1.49 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -554,7 +554,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6.28 s ± 9.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "6.26 s ± 6.31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -581,7 +581,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "86 ms ± 2.39 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "84.5 ms ± 2.02 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -616,41 +616,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8.23 s ± 5.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "8.26 s ± 41.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "grad = signal.convolve2d(csig, filt, boundary='symm', mode='same')"
+    "grad = signal.convolve2d(csig, filt)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 40,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.17 s ± 20.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%timeit\n",
-    "grad = signal.correlate2d(csig, filt, boundary='symm', mode='same')"
+    "gsig = cp.random.rand(int(1e4), int(1e4))\n",
+    "gfilt = cp.random.rand(5,5)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 41,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45.8 ms ± 811 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
    "source": [
-    "gsig = cp.random.rand(int(1e4), int(1e4))\n",
-    "gfilt = cp.random.rand(5,5)"
+    "%%timeit\n",
+    "ggrad = cusignal.convolve2d(gsig, gfilt, use_numba=True)"
    ]
   },
   {
@@ -662,13 +662,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "45.4 ms ± 381 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "27.1 ms ± 376 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "ggrad = cusignal.convolve2d(gsig, gfilt, boundary='symm', mode='same', use_numba=True)"
+    "ggrad = cusignal.convolve2d(gsig, gfilt, use_numba=False)"
    ]
   },
   {
@@ -680,13 +680,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "46.6 ms ± 686 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "8.29 s ± 21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "ggrad = cusignal.convolve2d(gsig, gfilt, boundary='symm', mode='same', use_numba=False)"
+    "grad = signal.correlate2d(csig, filt)"
    ]
   },
   {
@@ -698,13 +698,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26 ms ± 250 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "46 ms ± 1e+03 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "ggrad = cusignal.correlate2d(gsig, gfilt, boundary='symm', mode='same', use_numba=True)"
+    "ggrad = cusignal.correlate2d(gsig, gfilt, use_numba=True)"
    ]
   },
   {
@@ -716,13 +716,74 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "51.7 ms ± 608 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "27.1 ms ± 471 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "ggrad = cusignal.correlate2d(gsig, gfilt, boundary='symm', mode='same', use_numba=False)"
+    "ggrad = cusignal.correlate2d(gsig, gfilt, use_numba=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Decimate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csig = np.random.rand(int(1e8))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.13 s ± 2.73 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "cdecimate = signal.decimate(csig, 3, ftype='fir')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gsig = cp.random.rand(int(1e8))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15.9 ms ± 44.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "gdecimate = cusignal.decimate(gsig, 3)"
    ]
   }
  ],

--- a/notebooks/api_guide/signaltools_examples.ipynb
+++ b/notebooks/api_guide/signaltools_examples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,13 +43,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13.7 s, sys: 3.87 s, total: 17.5 s\n",
-      "Wall time: 17.5 s\n"
+      "14.1 s ± 272 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf = signal.resample(cy, resample_num, window=('kaiser', 0.5))"
    ]
   },
@@ -72,13 +71,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 195 ms, sys: 114 ms, total: 310 ms\n",
-      "Wall time: 321 ms\n"
+      "71.7 ms ± 4.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gf = cusignal.resample(gy, resample_num, window=('kaiser',0.5))"
    ]
   },
@@ -91,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,26 +105,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.45 s, sys: 232 ms, total: 2.68 s\n",
-      "Wall time: 2.68 s\n"
+      "2.4 s ± 1.21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf = signal.resample_poly(cy, resample_up, resample_down, window=('kaiser', 0.5))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,43 +140,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.81 ms, sys: 7.99 ms, total: 15.8 ms\n",
-      "Wall time: 14.4 ms\n"
+      "32.4 ms ± 101 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf = cusignal.resample_poly(gy, resample_up, resample_down, window=('kaiser', 0.5), use_numba=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 28.8 ms, sys: 261 µs, total: 29.1 ms\n",
-      "Wall time: 27.2 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "cf = cusignal.resample_poly(gy, resample_up, resample_down, window=('kaiser', 0.5), use_numba=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17.3 ms ± 26.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
    "source": [
-    "gpu_signal = cusignal.get_shared_mem(num, dtype=np.complex128)\n",
-    "gpu_signal[:] = cy"
+    "%%timeit\n",
+    "cf = cusignal.resample_poly(gy, resample_up, resample_down, window=('kaiser', 0.5), use_numba=False)"
    ]
   },
   {
@@ -191,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,39 +186,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11 s, sys: 4.98 s, total: 16 s\n",
-      "Wall time: 16 s\n"
+      "13.5 s ± 28.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cfirwin = signal.firwin(numtaps, [f1, f2], pass_zero=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 214 ms, sys: 20.8 ms, total: 235 ms\n",
-      "Wall time: 233 ms\n"
+      "149 ms ± 230 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gfirwin = cusignal.firwin(numtaps, [f1, f2], pass_zero=False)"
    ]
   },
@@ -246,12 +229,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "sig = np.random.rand(int(1e8))\n",
     "sig_noise = sig + np.random.randn(len(sig))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.39 s ± 1.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "ccorr = signal.correlate(sig_noise, np.ones(128), mode='same') / 1e6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sig = cp.random.rand(int(1e8))\n",
+    "sig_noise = sig + cp.random.randn(len(sig))"
    ]
   },
   {
@@ -263,42 +274,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 15 s, sys: 5.1 s, total: 20.1 s\n",
-      "Wall time: 20 s\n"
+      "72.9 ms ± 30.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "ccorr = signal.correlate(sig_noise, np.ones(128), mode='same') / 1e6"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sig = cp.random.rand(int(1e8))\n",
-    "sig_noise = sig + cp.random.randn(len(sig))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 74.2 ms, sys: 12.8 ms, total: 87 ms\n",
-      "Wall time: 85.2 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gcorr = cusignal.correlate(sig_noise, cp.ones(128), mode='same') / 1e6"
    ]
   },
@@ -311,12 +292,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
     "sig = np.random.rand(int(1e8))\n",
     "win = signal.windows.hann(int(1e3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16.7 s ± 1.11 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "cconv = signal.convolve(sig, win, mode='same') / np.sum(sig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sig = cp.random.rand(int(1e8))\n",
+    "win = cusignal.hann(int(1e3))"
    ]
   },
   {
@@ -328,34 +337,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 14.9 s, sys: 5.29 s, total: 20.2 s\n",
-      "Wall time: 20.2 s\n"
+      "73.1 ms ± 10.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "cconv = signal.convolve(sig, win, mode='same') / np.sum(sig)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 60.4 ms, sys: 35.3 ms, total: 95.7 ms\n",
-      "Wall time: 93.8 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "sig = cp.random.rand(int(1e8))\n",
-    "win = cusignal.hann(int(1e3))\n",
+    "%%timeit\n",
     "gconv = cusignal.convolve(sig, win, mode='same') / cp.sum(win)"
    ]
   },
@@ -368,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,26 +364,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 24 s, sys: 9.43 s, total: 33.4 s\n",
-      "Wall time: 33.4 s\n"
+      "27.7 s ± 420 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cautocorr = signal.fftconvolve(csig, csig[::-1], mode='full')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,20 +391,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 101 ms, sys: 28.4 ms, total: 129 ms\n",
-      "Wall time: 132 ms\n"
+      "128 ms ± 487 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gautocorr = cusignal.fftconvolve(gsig, gsig[::-1], mode='full')"
    ]
   },
@@ -431,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,26 +425,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 31.9 s, sys: 11.9 s, total: 43.9 s\n",
-      "Wall time: 43.8 s\n"
+      "3.59 s ± 8.47 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cfilt = signal.wiener(csig)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,20 +452,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 586 ms, sys: 111 ms, total: 697 ms\n",
-      "Wall time: 700 ms\n"
+      "255 ms ± 42.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gfilt = cusignal.wiener(gsig)"
    ]
   },
@@ -494,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,26 +486,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.5 s, sys: 3.54 s, total: 16.1 s\n",
-      "Wall time: 16 s\n"
+      "11.1 s ± 63.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "chtrans = signal.hilbert(csig)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,20 +513,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 45.5 ms, sys: 30.1 ms, total: 75.6 ms\n",
-      "Wall time: 73.7 ms\n"
+      "71.2 ms ± 1.24 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "ghtrans = cusignal.hilbert(gsig)"
    ]
   },
@@ -557,7 +538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,26 +547,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11.6 s, sys: 4.37 s, total: 15.9 s\n",
-      "Wall time: 15.9 s\n"
+      "6.28 s ± 9.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "chtrans2d = signal.hilbert2(csig)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,20 +574,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 30.7 ms, sys: 12.9 ms, total: 43.6 ms\n",
-      "Wall time: 41.9 ms\n"
+      "86 ms ± 2.39 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "ghtrans2d = cusignal.hilbert2(gsig)"
    ]
   },
@@ -620,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,45 +609,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.73 s, sys: 366 ms, total: 9.1 s\n",
-      "Wall time: 9 s\n"
+      "8.23 s ± 5.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "grad = signal.convolve2d(csig, filt, boundary='symm', mode='same')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.72 s, sys: 402 ms, total: 9.12 s\n",
-      "Wall time: 9.04 s\n"
+      "8.17 s ± 20.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "grad = signal.correlate2d(csig, filt, boundary='symm', mode='same')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,40 +655,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 791 ms, sys: 1.1 s, total: 1.9 s\n",
-      "Wall time: 1.89 s\n"
+      "45.4 ms ± 381 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "ggrad = cusignal.convolve2d(csig, filt, boundary='symm', mode='same')"
+    "%%timeit\n",
+    "ggrad = cusignal.convolve2d(gsig, gfilt, boundary='symm', mode='same', use_numba=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 755 ms, sys: 635 ms, total: 1.39 s\n",
-      "Wall time: 1.39 s\n"
+      "46.6 ms ± 686 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "ggrad = cusignal.correlate2d(csig, filt, boundary='symm', mode='same')"
+    "%%timeit\n",
+    "ggrad = cusignal.convolve2d(gsig, gfilt, boundary='symm', mode='same', use_numba=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "26 ms ± 250 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "ggrad = cusignal.correlate2d(gsig, gfilt, boundary='symm', mode='same', use_numba=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "51.7 ms ± 608 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "ggrad = cusignal.correlate2d(gsig, gfilt, boundary='symm', mode='same', use_numba=False)"
    ]
   }
  ],
@@ -731,7 +742,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/spectral_examples.ipynb
+++ b/notebooks/api_guide/spectral_examples.ipynb
@@ -39,13 +39,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.9 s, sys: 4.73 s, total: 10.6 s\n",
-      "Wall time: 10.6 s\n"
+      "7.61 s ± 90.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "ccsd = signal.csd(cx, cy, fs, nperseg=1024)"
    ]
   },
@@ -69,13 +68,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 257 ms, sys: 65 ms, total: 322 ms\n",
-      "Wall time: 321 ms\n"
+      "The slowest run took 6.98 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "2.96 ms ± 3.01 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gcsd = cusignal.csd(gx, gy, fs, nperseg=1024)"
    ]
   },
@@ -105,13 +104,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13.7 s, sys: 6.23 s, total: 20 s\n",
-      "Wall time: 20 s\n"
+      "17.1 s ± 80.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "f, Pxx_spec = signal.periodogram(csig, fs, 'flattop', scaling='spectrum')"
    ]
   },
@@ -134,13 +132,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 229 ms, sys: 44.5 ms, total: 273 ms\n",
-      "Wall time: 273 ms\n"
+      "1.6 ms ± 32.9 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gf, gPxx_spec = cusignal.periodogram(gsig, fs, 'flattop', scaling='spectrum')"
    ]
   },
@@ -170,13 +167,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.67 s, sys: 2.98 s, total: 6.65 s\n",
-      "Wall time: 6.64 s\n"
+      "4.91 s ± 15.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf, cPxx_spec = signal.welch(csig, fs, nperseg=1024)"
    ]
   },
@@ -199,13 +195,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 0 ns, sys: 5.69 ms, total: 5.69 ms\n",
-      "Wall time: 5.48 ms\n"
+      "77.8 ms ± 1.05 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gf, gPxx_spec = cusignal.welch(gsig, fs, nperseg=1024)"
    ]
   },
@@ -235,13 +230,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.08 s, sys: 1.58 s, total: 3.66 s\n",
-      "Wall time: 3.66 s\n"
+      "2.78 s ± 5.77 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf, ct, cPxx_spec = signal.spectrogram(csig, fs)"
    ]
   },
@@ -264,13 +258,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.16 ms, sys: 3.52 ms, total: 10.7 ms\n",
-      "Wall time: 10.4 ms\n"
+      "40.4 ms ± 329 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gf, gt, gPxx_spec = cusignal.spectrogram(gsig, fs)"
    ]
   },
@@ -301,13 +294,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 13.4 s, sys: 10.3 s, total: 23.7 s\n",
-      "Wall time: 23.7 s\n"
+      "17.4 s ± 233 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf, cCxy = signal.coherence(cx, cy, fs, nperseg=1024)"
    ]
   },
@@ -331,13 +323,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 204 ms, sys: 72.3 ms, total: 277 ms\n",
-      "Wall time: 276 ms\n"
+      "7.61 ms ± 3.01 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gf, gCxy = cusignal.coherence(gx, gy, fs, nperseg=1024)"
    ]
   },
@@ -367,13 +358,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.57 s, sys: 2.2 s, total: 4.77 s\n",
-      "Wall time: 4.77 s\n"
+      "3.26 s ± 2.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cf, ct, cZxx = signal.stft(cx, fs, nperseg=1000)"
    ]
   },
@@ -396,13 +386,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 23.9 ms, sys: 7.94 ms, total: 31.8 ms\n",
-      "Wall time: 31.6 ms\n"
+      "The slowest run took 22.07 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "22.5 ms ± 15.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gf, gt, gZxx = cusignal.stft(gx, fs, nperseg=1024)"
    ]
   }
@@ -423,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/waveform_examples.ipynb
+++ b/notebooks/api_guide/waveform_examples.ipynb
@@ -38,13 +38,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 317 ms, sys: 244 ms, total: 561 ms\n",
-      "Wall time: 559 ms\n"
+      "447 ms ± 565 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpwm = signal.square(ct, duty=0.5)"
    ]
   },
@@ -57,13 +56,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11.7 ms, sys: 7.85 ms, total: 19.6 ms\n",
-      "Wall time: 18.3 ms\n"
+      "8.68 ms ± 2.17 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpwm = cusignal.square(gt, duty=0.5)"
    ]
   },
@@ -83,13 +81,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 585 ms, sys: 144 ms, total: 730 ms\n",
-      "Wall time: 728 ms\n"
+      "645 ms ± 1.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "ci, cq, ce = signal.gausspulse(ct, fc=5, retquad=True, retenv=True)"
    ]
   },
@@ -102,13 +99,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.21 ms, sys: 81 µs, total: 8.29 ms\n",
-      "Wall time: 6.8 ms\n"
+      "3.13 ms ± 417 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gi, gq, ge = cusignal.gausspulse(gt, fc=5, retquad=True, retenv=True)"
    ]
   },
@@ -128,13 +124,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 264 ms, sys: 116 ms, total: 380 ms\n",
-      "Wall time: 379 ms\n"
+      "309 ms ± 1.05 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cw = signal.chirp(ct, f0=6, f1=1, t1=10, method='linear')"
    ]
   },
@@ -147,13 +142,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.2 ms, sys: 0 ns, total: 3.2 ms\n",
-      "Wall time: 2.14 ms\n"
+      "2.37 ms ± 4.48 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gw = cusignal.chirp(gt, f0=6, f1=1, t1=10, method='linear')"
    ]
   },
@@ -166,13 +160,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 710 ms, sys: 108 ms, total: 819 ms\n",
-      "Wall time: 817 ms\n"
+      "735 ms ± 701 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cw = signal.chirp(ct, f0=1500, f1=250, t1=10, method='quadratic')"
    ]
   },
@@ -185,13 +178,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.98 ms, sys: 7 µs, total: 3.99 ms\n",
-      "Wall time: 2.47 ms\n"
+      "2.8 ms ± 10.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gw = cusignal.chirp(gt, f0=1500, f1=250, t1=10, method='quadratic')"
    ]
   },
@@ -211,13 +203,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 282 µs, sys: 0 ns, total: 282 µs\n",
-      "Wall time: 236 µs\n"
+      "21.5 µs ± 38.2 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cimp = signal.unit_impulse(int(1e8), 'mid')"
    ]
   },
@@ -230,13 +221,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.65 ms, sys: 3.54 ms, total: 6.18 ms\n",
-      "Wall time: 5.94 ms\n"
+      "1.35 ms ± 32.9 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gimp = cusignal.unit_impulse(int(1e8), 'mid')"
    ]
   }
@@ -257,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/wavelets_examples.ipynb
+++ b/notebooks/api_guide/wavelets_examples.ipynb
@@ -40,13 +40,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.98 s, sys: 2.19 s, total: 9.17 s\n",
-      "Wall time: 9.16 s\n"
+      "7.64 s ± 1.34 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cmorlet = signal.morlet(M)"
    ]
   },
@@ -59,13 +58,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 597 ms, sys: 16.4 ms, total: 613 ms\n",
-      "Wall time: 616 ms\n"
+      "39.6 ms ± 29.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gmorlet = cusignal.morlet(M)"
    ]
   },
@@ -85,13 +83,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.4 s, sys: 2.32 s, total: 4.72 s\n",
-      "Wall time: 4.71 s\n"
+      "3.6 s ± 53.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cricker = signal.ricker(M, int(1e3))"
    ]
   },
@@ -104,13 +101,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 355 ms, sys: 11.8 ms, total: 367 ms\n",
-      "Wall time: 368 ms\n"
+      "294 µs ± 16.5 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gricker = cusignal.ricker(M, int(1e3))"
    ]
   },
@@ -130,13 +126,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 39.3 s, sys: 16.9 s, total: 56.3 s\n",
-      "Wall time: 56.2 s\n"
+      "14.7 s ± 97.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "ccwt = signal.cwt(csig, signal.ricker, np.arange(1,31))"
    ]
   },
@@ -149,13 +144,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.96 s, sys: 316 ms, total: 7.27 s\n",
-      "Wall time: 7.33 s\n"
+      "291 ms ± 7.75 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gcwt = cusignal.cwt(gsig, cusignal.ricker, cp.arange(1,31))"
    ]
   }
@@ -176,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_guide/windows_examples.ipynb
+++ b/notebooks/api_guide/windows_examples.ipynb
@@ -63,13 +63,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 934 ms, sys: 392 ms, total: 1.33 s\n",
-      "Wall time: 1.33 s\n"
+      "1.07 s ± 2.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "HFT90D = [1, 1.942604, 1.340318, 0.440811, 0.043097]\n",
     "cpu_window = signal.windows.general_cosine(M, HFT90D, sym=False)"
    ]
@@ -83,13 +82,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 139 ms, sys: 306 ms, total: 444 ms\n",
-      "Wall time: 465 ms\n"
+      "6.98 ms ± 337 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "HFT90D = [1, 1.942604, 1.340318, 0.440811, 0.043097]\n",
     "gpu_window = cusignal.windows.general_cosine(M, HFT90D, sym=False)"
    ]
@@ -110,13 +108,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.5 ms, sys: 32.4 ms, total: 44.9 ms\n",
-      "Wall time: 42.6 ms\n"
+      "22.6 ms ± 127 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.boxcar(M)"
    ]
   },
@@ -129,13 +126,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.7 ms, sys: 787 µs, total: 2.49 ms\n",
-      "Wall time: 1.21 ms\n"
+      "135 µs ± 6.67 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.boxcar(M)"
    ]
   },
@@ -155,13 +151,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 32.7 ms, sys: 97 ms, total: 130 ms\n",
-      "Wall time: 129 ms\n"
+      "80.9 ms ± 60.5 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.triang(M)"
    ]
   },
@@ -174,13 +169,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.79 ms, sys: 387 µs, total: 5.18 ms\n",
-      "Wall time: 3.84 ms\n"
+      "820 µs ± 38.2 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.triang(M)"
    ]
   },
@@ -200,13 +194,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 407 ms, sys: 264 ms, total: 671 ms\n",
-      "Wall time: 669 ms\n"
+      "521 ms ± 432 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.bohman(M)"
    ]
   },
@@ -219,13 +212,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 101 µs, sys: 8.11 ms, total: 8.21 ms\n",
-      "Wall time: 6.16 ms\n"
+      "3.44 ms ± 4.43 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.bohman(M)"
    ]
   },
@@ -245,13 +237,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 533 ms, sys: 220 ms, total: 752 ms\n",
-      "Wall time: 751 ms\n"
+      "620 ms ± 6.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.blackman(M)"
    ]
   },
@@ -264,13 +255,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.6 ms, sys: 816 µs, total: 2.41 ms\n",
-      "Wall time: 1.49 ms\n"
+      "4.28 ms ± 741 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.blackman(M)"
    ]
   },
@@ -290,13 +280,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 660 ms, sys: 376 ms, total: 1.04 s\n",
-      "Wall time: 1.03 s\n"
+      "848 ms ± 5.99 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.nuttall(M)"
    ]
   },
@@ -309,13 +298,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.5 ms, sys: 0 ns, total: 2.5 ms\n",
-      "Wall time: 1.46 ms\n"
+      "5.63 ms ± 4.89 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.nuttall(M)"
    ]
   },
@@ -335,13 +323,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 714 ms, sys: 295 ms, total: 1.01 s\n",
-      "Wall time: 1.01 s\n"
+      "849 ms ± 7.69 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.blackmanharris(M)"
    ]
   },
@@ -354,13 +341,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.79 ms, sys: 896 µs, total: 2.68 ms\n",
-      "Wall time: 1.58 ms\n"
+      "5.64 ms ± 973 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.blackmanharris(M)"
    ]
   },
@@ -380,13 +366,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 865 ms, sys: 439 ms, total: 1.3 s\n",
-      "Wall time: 1.3 s\n"
+      "1.08 s ± 6.56 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.flattop(M)"
    ]
   },
@@ -399,13 +384,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.42 ms, sys: 0 ns, total: 2.42 ms\n",
-      "Wall time: 1.47 ms\n"
+      "6.98 ms ± 143 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.flattop(M)"
    ]
   },
@@ -425,13 +409,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 124 ms, sys: 160 ms, total: 285 ms\n",
-      "Wall time: 283 ms\n"
+      "185 ms ± 146 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.bartlett(M)"
    ]
   },
@@ -444,13 +427,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.07 ms, sys: 0 ns, total: 6.07 ms\n",
-      "Wall time: 4.7 ms\n"
+      "2.4 ms ± 6.94 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.bartlett(M)"
    ]
   },
@@ -470,13 +452,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 297 ms, sys: 200 ms, total: 497 ms\n",
-      "Wall time: 495 ms\n"
+      "400 ms ± 1.02 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.hann(M)"
    ]
   },
@@ -489,13 +470,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.35 ms, sys: 0 ns, total: 2.35 ms\n",
-      "Wall time: 1.49 ms\n"
+      "2.95 ms ± 295 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.hann(M)"
    ]
   },
@@ -515,13 +495,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 157 ms, sys: 109 ms, total: 266 ms\n",
-      "Wall time: 265 ms\n"
+      "178 ms ± 405 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.tukey(M, alpha=0.5, sym=True)"
    ]
   },
@@ -534,13 +513,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.41 ms, sys: 404 µs, total: 3.81 ms\n",
-      "Wall time: 2.76 ms\n"
+      "1.78 ms ± 1.74 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.tukey(M, alpha=0.5, sym=True)"
    ]
   },
@@ -560,13 +538,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 331 ms, sys: 247 ms, total: 578 ms\n",
-      "Wall time: 577 ms\n"
+      "366 ms ± 255 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.barthann(M)"
    ]
   },
@@ -579,13 +556,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.26 ms, sys: 139 µs, total: 4.4 ms\n",
-      "Wall time: 2.8 ms\n"
+      "2.97 ms ± 362 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.barthann(M)"
    ]
   },
@@ -605,13 +581,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 366 ms, sys: 181 ms, total: 547 ms\n",
-      "Wall time: 546 ms\n"
+      "400 ms ± 476 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.general_hamming(M, alpha=0.5, sym=True)"
    ]
   },
@@ -624,13 +599,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.31 ms, sys: 0 ns, total: 1.31 ms\n",
-      "Wall time: 966 µs\n"
+      "2.95 ms ± 239 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.general_hamming(M, alpha=0.5, sym=True)"
    ]
   },
@@ -650,13 +624,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 327 ms, sys: 181 ms, total: 508 ms\n",
-      "Wall time: 506 ms\n"
+      "400 ms ± 305 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.hamming(M)"
    ]
   },
@@ -669,13 +642,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.79 ms, sys: 961 µs, total: 2.75 ms\n",
-      "Wall time: 1.9 ms\n"
+      "1.64 ms ± 46 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.hamming(M)"
    ]
   },
@@ -695,13 +667,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 807 ms, sys: 201 ms, total: 1.01 s\n",
-      "Wall time: 1.01 s\n"
+      "858 ms ± 527 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.kaiser(M, beta=0.5)"
    ]
   },
@@ -714,13 +685,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5 ms, sys: 502 µs, total: 5.5 ms\n",
-      "Wall time: 4.57 ms\n"
+      "2.81 ms ± 4.99 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.kaiser(M, beta=0.5)"
    ]
   },
@@ -740,13 +710,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 201 ms, sys: 149 ms, total: 350 ms\n",
-      "Wall time: 349 ms\n"
+      "229 ms ± 409 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.gaussian(M, std=7)"
    ]
   },
@@ -759,13 +728,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.26 ms, sys: 0 ns, total: 3.26 ms\n",
-      "Wall time: 2.38 ms\n"
+      "1.92 ms ± 42.4 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.gaussian(M, std=7)"
    ]
   },
@@ -785,13 +753,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 601 ms, sys: 248 ms, total: 849 ms\n",
-      "Wall time: 848 ms\n"
+      "700 ms ± 950 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.general_gaussian(M, p=1.5, sig=7)"
    ]
   },
@@ -804,13 +771,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 766 µs, sys: 386 µs, total: 1.15 ms\n",
-      "Wall time: 753 µs\n"
+      "2.2 ms ± 36.8 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.general_gaussian(M, p=1.5, sig=7)"
    ]
   },
@@ -830,13 +796,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 180 ms, sys: 96 ms, total: 276 ms\n",
-      "Wall time: 275 ms\n"
+      "205 ms ± 444 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.cosine(M)"
    ]
   },
@@ -849,13 +814,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.28 ms, sys: 770 µs, total: 3.05 ms\n",
-      "Wall time: 2.04 ms\n"
+      "1.04 ms ± 895 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.cosine(M)"
    ]
   },
@@ -875,13 +839,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 163 ms, sys: 172 ms, total: 335 ms\n",
-      "Wall time: 333 ms\n"
+      "229 ms ± 426 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "cpu_window = signal.windows.exponential(M, tau=3.0)"
    ]
   },
@@ -894,13 +857,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.02 ms, sys: 527 µs, total: 1.55 ms\n",
-      "Wall time: 1.13 ms\n"
+      "1.63 ms ± 616 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "gpu_window = cusignal.windows.exponential(M, tau=3.0)"
    ]
   }
@@ -921,7 +883,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the timing in the `notebooks\api` notebooks and shows:
* Numba vs Raw CuPy CUDA Kernel performance for `resample_poly`, `correlate2d`, `convolve2d`
* Update `%%time` to `%%timeit` to provide better performance characterizations
* Show API usage for new `decimate` function