### PR TITLE
[REVIEW] Remove compile penalty during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #40 - Ability to specify time/freq domain for resample.
 - PR #45 - Refactor `_signaltools.py` to use new Numba/CuPy framework
 - PR #50 - Update README to reorganize install instructions
+- PR #56 - Ability to precompile select Numba/CuPy kernel on import
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -443,7 +443,6 @@ extern "C" {
     }
 
     __global__ void _cupy_convolve(
-
             const ${datatype} * __restrict__ inp,
             const int inpW,
             const ${datatype} * __restrict__ kernel,
@@ -499,7 +498,6 @@ extern "C" {
 
 
 class _cupy_convolve_wrapper(object):
-
     def __init__(self, grid, block, stream, kernel):
         if isinstance(grid, int):
             grid = (grid,)
@@ -708,39 +706,6 @@ def _convolve_gpu(
             False,
             GPUKernel.CORRELATE,
         )
-        _cupy_kernel_cache[(2, str(numba_type))] = module2.get_function(
-            "_cupy_correlate_1d"
-        )
-        _cupy_kernel_cache[(3, str(numba_type))] = module2.get_function(
-            "_cupy_convolve_1d"
-        )
-
-
-def _convolve1d_gpu(
-    inp, out, ker, mode, use_convolve, swapped_inputs, cp_stream,
-):
-
-    d_inp = cp.array(inp)
-    d_kernel = cp.array(ker)
-
-    device_id = cp.cuda.Device()
-    numSM = device_id.attributes["MultiProcessorCount"]
-
-    threadsperblock = 256
-    blockspergrid = numSM * 20
-
-    kernel = _get_backend_kernel(
-        use_convolve + 2,
-        out.dtype,
-        blockspergrid,
-        threadsperblock,
-        cp_stream,
-        use_numba=False,
-    )
-
-    kernel(d_inp, d_kernel, mode, swapped_inputs, out)
-
-    return out
 
     kernel(d_inp, d_kernel, mode, swapped_inputs, out)
 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -662,9 +662,27 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
     dtype : numpy datatype or list of datatypes, optional
         Data types for which kernels should be precompiled. If not
         specified, all supported data types will be precompiled.
+        Specific to this unit
+            np.int32
+            np.int64
+            np.float32
+            np.float64
+            np.complex64
+            np.complex128
     backend : GPUBackend, optional
         Which GPU backend to precompile for. If not specified,
         all supported backends will be precompiled.
+        Specific to this unit
+            GPUBackend.CUPY
+            GPUBackend.NUMBA
+    k_type : GPUKernel, optional
+        Which GPU kernel to compile for. If not specified,
+        all supported kernels will be precompiled.
+        Specific to this unit
+            GPUBackend.CORRELATE
+            GPUBackend.CONVOLVE
+            GPUBackend.CORRELATE2D
+            GPUBackend.CONVOLVE2D
     """
     dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
     backend = list(backend) if backend else list(GPUBackend)

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -733,18 +733,18 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
     >>> cusignal._signaltools.precompile_kernels( dtype=[np.float64],
         k_type=[GPUKernel.CORRELATE],)
     """
-    if not hasattr(dtype, "__iter__"):
+    if dtype is not None and not hasattr(dtype, "__iter__"):
         raise TypeError(
             "dtype ({}) should be in list - e.g [np.float32,]".format(dtype)
         )
 
-    elif not hasattr(backend, "__iter__"):
+    elif backend is not None and not hasattr(backend, "__iter__"):
         raise TypeError(
             "backend ({}) should be in list - e.g [{},]".format(
                 backend, backend
             )
         )
-    elif not hasattr(k_type, "__iter__"):
+    elif k_type is not None and not hasattr(k_type, "__iter__"):
         raise TypeError(
             "k_type ({}) should be in list - e.g [{},]".format(k_type, k_type)
         )
@@ -752,6 +752,7 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
         dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
         backend = list(backend) if backend else list(GPUBackend)
         k_type = list(k_type) if k_type else list(GPUKernel)
+
         for d, b, k in itertools.product(dtype, backend, k_type):
             _populate_kernel_cache(d, b, k)
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -11,17 +11,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cupy as cp
+import itertools
+import numpy as np
+
 from enum import Enum
 from math import sin, cos, atan2
-from string import Template
 from numba import (
     cuda,
     float64,
     void,
 )
-import itertools
-import cupy as cp
-import numpy as np
+from string import Template
 
 
 class GPUBackend(Enum):
@@ -29,6 +30,7 @@ class GPUBackend(Enum):
     NUMBA = 1
 
 
+# Numba type supported and corresponding C type
 _SUPPORTED_TYPES = {
     np.float64: [float64, "double"],
 }
@@ -36,8 +38,6 @@ _SUPPORTED_TYPES = {
 
 _numba_kernel_cache = {}
 _cupy_kernel_cache = {}
-
-# Numba type supported and corresponding C type
 
 
 # Use until functionality provided in Numba 0.49/0.50 available
@@ -334,8 +334,6 @@ def _lombscargle(x, y, freqs, pgram, y_dot, cp_stream, use_numba):
     numSM = device_id.attributes["MultiProcessorCount"]
     threadsperblock = 256
     blockspergrid = numSM * 20
-
-    print(pgram.dtype.type)
 
     _populate_kernel_cache(pgram.dtype.type, use_numba)
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -391,18 +391,18 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
     >>> cusignal._spectral.precompile_kernels( dtype=[np.float64],
         k_type=[GPUKernel.LOMBSCARGLE],)
     """
-    if not hasattr(dtype, "__iter__"):
+    if dtype is not None and not hasattr(dtype, "__iter__"):
         raise TypeError(
             "dtype ({}) should be in list - e.g [np.float32,]".format(dtype)
         )
 
-    elif not hasattr(backend, "__iter__"):
+    elif backend is not None and not hasattr(backend, "__iter__"):
         raise TypeError(
             "backend ({}) should be in list - e.g [{},]".format(
                 backend, backend
             )
         )
-    elif not hasattr(k_type, "__iter__"):
+    elif k_type is not None and not hasattr(k_type, "__iter__"):
         raise TypeError(
             "k_type ({}) should be in list - e.g [{},]".format(k_type, k_type)
         )
@@ -410,6 +410,7 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
         dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
         backend = list(backend) if backend else list(GPUBackend)
         k_type = list(k_type) if k_type else list(GPUKernel)
+
         for d, b, k in itertools.product(dtype, backend, k_type):
             _populate_kernel_cache(d, b, k)
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -284,7 +284,7 @@ def _populate_kernel_cache(np_type, use_numba):
         numba_type, c_type = _SUPPORTED_TYPES[np_type]
 
     except KeyError:
-        "No kernel found for datatype {}".format(np_type.name)
+        raise Exception("No kernel found for datatype {}".format(np_type))
 
     # JIT compile the numba kernels
     if not use_numba:
@@ -302,6 +302,7 @@ def _populate_kernel_cache(np_type, use_numba):
     else:
         if str(numba_type) in _numba_kernel_cache:
             return
+        # JIT compile the numba kernels
         sig = _numba_lombscargle_signature(numba_type)
         _numba_kernel_cache[(str(numba_type))] = cuda.jit(sig, fastmath=True)(
             _numba_lombscargle
@@ -333,6 +334,8 @@ def _lombscargle(x, y, freqs, pgram, y_dot, cp_stream, use_numba):
     numSM = device_id.attributes["MultiProcessorCount"]
     threadsperblock = 256
     blockspergrid = numSM * 20
+
+    print(pgram.dtype.type)
 
     _populate_kernel_cache(pgram.dtype.type, use_numba)
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -329,9 +329,19 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
     dtype : numpy datatype or list of datatypes, optional
         Data types for which kernels should be precompiled. If not
         specified, all supported data types will be precompiled.
+        Specific to this unit
+            np.float64
     backend : GPUBackend, optional
         Which GPU backend to precompile for. If not specified,
         all supported backends will be precompiled.
+        Specific to this unit
+            GPUBackend.CUPY
+            GPUBackend.NUMBA
+    k_type : GPUKernel, optional
+        Which GPU kernel to compile for. If not specified,
+        all supported kernels will be precompiled.
+        Specific to this unit
+            GPUBackend.LOMBSCARGLE
     """
     dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
     backend = list(backend) if backend else list(GPUBackend)

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -277,12 +277,9 @@ class _cupy_upfirdn_wrapper(object):
         self.kernel(self.grid, self.block, kernel_args)
 
 
-def _get_backend_kernel(
-    dtype, grid, block, stream, use_numba, k_type, ndim,
-):
-    if ndim > 2:
-        raise NotImplementedError("upfirdn() requires ndim <= 2")
-    elif ndim > 1 and not use_numba:
+def _get_backend_kernel(dtype, grid, block, stream, use_numba, k_type):
+
+    if k_type == GPUKernel.UPFIRDN2D and not use_numba:
         warnings.warn(
             "CuPy backend is only implemented for ndim == 1 \
                 Running with Numba CUDA backend",
@@ -294,25 +291,56 @@ def _get_backend_kernel(
         kernel = _cupy_kernel_cache[(dtype.name, k_type)]
         if kernel:
             return _cupy_upfirdn_wrapper(grid, block, stream, kernel)
+        else:
+            raise ValueError(
+                "Kernel {} not found in _cupy_kernel_cache".format(k_type)
+            )
 
     else:
         nb_stream = stream_cupy_to_numba(stream)
         kernel = _numba_kernel_cache[(dtype.name, k_type)]
         if kernel:
             return kernel[grid, block, nb_stream]
+        else:
+            raise ValueError(
+                "Kernel {} not found in _numba_kernel_cache".format(k_type)
+            )
 
     raise NotImplementedError(
-        "No kernel found for ndim {}, datatype {}".format(ndim, dtype.name)
+        "No kernel found for k_type {}, datatype {}".format(k_type, dtype.name)
     )
 
 
 def _populate_kernel_cache(np_type, use_numba, k_type):
 
+    # Check in np_type is a supported option
     try:
         numba_type, c_type = _SUPPORTED_TYPES[np_type]
 
-    except KeyError:
-        raise Exception("No kernel found for datatype {}".format(np_type))
+    except ValueError:
+        raise ValueError("No kernel found for datatype {}".format(np_type))
+
+    # Check if use_numba is support
+    try:
+        GPUBackend(use_numba)
+
+    except ValueError:
+        raise
+
+    # Check if use_numba is support
+    try:
+        GPUKernel(k_type)
+
+    except ValueError:
+        raise
+
+    if k_type == GPUKernel.UPFIRDN2D and not use_numba:
+        warnings.warn(
+            "CuPy backend is only implemented for ndim == 1 \
+                Running with Numba CUDA backend",
+            UserWarning,
+        )
+        use_numba = True
 
     if not use_numba:
         if (str(numba_type), k_type) in _cupy_kernel_cache:  # Not work
@@ -336,7 +364,11 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
             # ] = module.get_function("_cupy_upfirdn_2d")
             return
         else:
-            raise Exception("If you see this let the developers know.")
+            raise NotImplementedError(
+                "No kernel found for k_type {}, datatype {}".format(
+                    k_type, str(numba_type)
+                )
+            )
 
     else:
         if (str(numba_type), k_type) in _numba_kernel_cache:
@@ -353,7 +385,11 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
                 sig_2d, fastmath=True
             )(_numba_upfirdn_2d)
         else:
-            raise Exception("If you see this let the developers know.")
+            raise NotImplementedError(
+                "No kernel found for k_type {}, datatype {}".format(
+                    k_type, str(numba_type)
+                )
+            )
 
 
 def precompile_kernels(dtype=None, backend=None, k_type=None):
@@ -380,14 +416,49 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
         Which GPU kernel to compile for. If not specified,
         all supported kernels will be precompiled.
         Specific to this unit
-            GPUBackend.UPFIRDN
-            GPUBackend.UPFIRDN2
+            GPUKernel.UPFIRDN
+            GPUKernel.UPFIRDN2
+    Examples
+    ----------
+    To precompile all kernels in this unit
+    >>> import cusignal
+    >>> from cusignal._upfirdn import GPUBackend, GPUKernel
+    >>> cusignal._upfirdn.precompile_kernels()
+
+    To precompile a specific NumPy datatype, CuPy backend, and kernel type
+    >>> cusignal._upfirdn.precompile_kernels( [np.float64],
+        [GPUBackend.CUPY], [GPUKernel.UPFIRDN],)
+
+
+    To precompile a specific NumPy datatype and kernel type,
+    but both Numba and CuPY variations
+    >>> cusignal._upfirdn.precompile_kernels( dtype=[np.float64],
+        k_type=[GPUKernel.UPFIRDN],)
     """
-    dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
-    backend = list(backend) if backend else list(GPUBackend)
-    k_type = list(k_type) if k_type else list(GPUKernel)
-    for d, b, k in itertools.product(dtype, backend, k_type):
-        _populate_kernel_cache(d, b.value, k)
+
+    # Ensure inputs are a list, if inputs exist
+    if dtype is not None and not hasattr(dtype, "__iter__"):
+        raise TypeError(
+            "dtype ({}) should be in list - e.g [np.float32,]".format(dtype)
+        )
+
+    elif backend is not None and not hasattr(backend, "__iter__"):
+        raise TypeError(
+            "backend ({}) should be in list - e.g [{},]".format(
+                backend, backend
+            )
+        )
+    elif k_type is not None and not hasattr(k_type, "__iter__"):
+        raise TypeError(
+            "k_type ({}) should be in list - e.g [{},]".format(k_type, k_type)
+        )
+    else:
+        dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
+        backend = list(backend) if backend else list(GPUBackend)
+        k_type = list(k_type) if k_type else list(GPUKernel)
+
+        for d, b, k in itertools.product(dtype, backend, k_type):
+            _populate_kernel_cache(d, b, k)
 
 
 class _UpFIRDn(object):
@@ -454,9 +525,8 @@ class _UpFIRDn(object):
                 cp_stream,
                 use_numba,
                 GPUKernel.UPFIRDN,
-                out.ndim,
             )
-        else:
+        elif out.ndim == 2:
             _populate_kernel_cache(
                 out.dtype.type, use_numba, GPUKernel.UPFIRDN2D
             )
@@ -467,8 +537,9 @@ class _UpFIRDn(object):
                 cp_stream,
                 use_numba,
                 GPUKernel.UPFIRDN2D,
-                out.ndim,
             )
+        else:
+            raise NotImplementedError("upfirdn() requires ndim <= 2")
 
         kernel(
             cp.asarray(x, self._output_type),

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -365,9 +365,23 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
     dtype : numpy datatype or list of datatypes, optional
         Data types for which kernels should be precompiled. If not
         specified, all supported data types will be precompiled.
+        Specific to this unit
+            np.float32
+            np.float64
+            np.complex64
+            np.complex128
     backend : GPUBackend, optional
         Which GPU backend to precompile for. If not specified,
         all supported backends will be precompiled.
+        Specific to this unit
+            GPUBackend.CUPY
+            GPUBackend.NUMBA
+    k_type : GPUKernel, optional
+        Which GPU kernel to compile for. If not specified,
+        all supported kernels will be precompiled.
+        Specific to this unit
+            GPUBackend.UPFIRDN
+            GPUBackend.UPFIRDN2
     """
     dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
     backend = list(backend) if backend else list(GPUBackend)

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -18,6 +18,11 @@ from cusignal.test.utils import array_equal
 import cusignal
 from scipy import signal
 
+# Precompile Numba/CuPy kernels
+cusignal._spectral.precompile_kernels()
+cusignal._signaltools.precompile_kernels()
+cusignal._upfirdn.precompile_kernels()
+
 
 @pytest.mark.benchmark(group="Resample")
 @pytest.mark.parametrize("num_samps", [2 ** 14])
@@ -135,58 +140,66 @@ class BenchFirWin:
 
 
 @pytest.mark.benchmark(group="Correlate")
-@pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("num_samps", [2 ** 7, 1025, 2 ** 15])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct"])
 class BenchCorrelate:
-    def cpu_version(self, cpu_sig, num_taps, mode):
-        return signal.correlate(cpu_sig, num_taps, mode=mode)
+    def cpu_version(self, cpu_sig, num_taps, mode, method):
+        return signal.correlate(cpu_sig, num_taps, mode=mode, method=method)
 
-    def bench_correlate_cpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+    def bench_correlate1d_cpu(
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
         cpu_sig, _ = rand_data_gen(num_samps)
-        benchmark(self.cpu_version, cpu_sig, np.ones(num_taps), mode)
+        benchmark(self.cpu_version, cpu_sig, np.ones(num_taps), mode, method)
 
-    def bench_correlate_gpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+    def bench_correlate1d_gpu(
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
 
         cpu_sig, gpu_sig = rand_data_gen(num_samps)
         output = benchmark(
-            cusignal.correlate, gpu_sig, cp.ones(num_taps), mode=mode
+            cusignal.correlate,
+            gpu_sig,
+            cp.ones(num_taps),
+            mode=mode,
+            method=method,
         )
 
-        key = self.cpu_version(cpu_sig, np.ones(num_taps), mode)
+        key = self.cpu_version(cpu_sig, np.ones(num_taps), mode, method)
         assert array_equal(cp.asnumpy(output), key)
 
 
 @pytest.mark.benchmark(group="Convolve")
-@pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("num_samps", [2 ** 7, 1025, 2 ** 15])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct"])
 class BenchConvolve:
-    def cpu_version(self, cpu_sig, cpu_win, mode):
-        return signal.convolve(cpu_sig, cpu_win, mode=mode)
+    def cpu_version(self, cpu_sig, cpu_win, mode, method):
+        return signal.convolve(cpu_sig, cpu_win, mode=mode, method=method)
 
-    def bench_convolve_cpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+    def bench_convolve1d_cpu(
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
         cpu_sig, _ = rand_data_gen(num_samps)
         cpu_win = signal.windows.hann(num_taps)
 
-        benchmark(self.cpu_version, cpu_sig, cpu_win, mode)
+        benchmark(self.cpu_version, cpu_sig, cpu_win, mode, method)
 
-    def bench_convolve_gpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+    def bench_convolve1d_gpu(
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
 
         cpu_sig, gpu_sig = rand_data_gen(num_samps)
         gpu_win = cusignal.windows.hann(num_taps)
-        output = benchmark(cusignal.convolve, gpu_sig, gpu_win, mode=mode)
+        output = benchmark(
+            cusignal.convolve, gpu_sig, gpu_win, mode=mode, method=method
+        )
 
         cpu_win = signal.windows.hann(num_taps)
-        key = self.cpu_version(cpu_sig, cpu_win, mode)
+        key = self.cpu_version(cpu_sig, cpu_win, mode, method)
         assert array_equal(cp.asnumpy(output), key)
 
 

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -66,30 +66,40 @@ def test_firwin(num_samps, f1, f2):
     assert array_equal(cpu_window, gpu_window)
 
 
-@pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
-def test_correlate(num_samps, num_taps, mode="same"):
+@pytest.mark.parametrize("num_samps", [2 ** 7, 1025, 2 ** 15])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
+def test_correlate(num_samps, num_taps, mode, method):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
-    cpu_corr = signal.correlate(cpu_sig, np.ones(num_taps), mode=mode)
+    cpu_corr = signal.correlate(
+        cpu_sig, np.ones(num_taps), mode=mode, method=method
+    )
     gpu_corr = cp.asnumpy(
-        cusignal.correlate(gpu_sig, cp.ones(num_taps), mode=mode)
+        cusignal.correlate(
+            gpu_sig, cp.ones(num_taps), mode=mode, method=method
+        )
     )
     assert array_equal(cpu_corr, gpu_corr)
 
 
-@pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
-def test_convolve(num_samps, num_taps, mode="same"):
+@pytest.mark.parametrize("num_samps", [2 ** 7, 1025, 2 ** 15])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
+def test_convolve(num_samps, num_taps, mode, method):
     cpu_sig = np.random.rand(num_samps)
     cpu_win = signal.windows.hann(num_taps)
 
     gpu_sig = cp.asarray(cpu_sig)
     gpu_win = cusignal.windows.hann(num_taps)
 
-    cpu_conv = signal.convolve(cpu_sig, cpu_win, mode=mode)
-    gpu_conv = cp.asnumpy(cusignal.convolve(gpu_sig, gpu_win, mode=mode))
+    cpu_conv = signal.convolve(cpu_sig, cpu_win, mode=mode, method=method)
+    gpu_conv = cp.asnumpy(
+        cusignal.convolve(gpu_sig, gpu_win, mode=mode, method=method)
+    )
     assert array_equal(cpu_conv, gpu_conv)
 
 
@@ -187,16 +197,17 @@ def test_correlate2d(num_samps, num_taps, boundary, mode, use_numba):
     assert array_equal(cpu_correlate2d, gpu_correlate2d)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('downsample_factor', [2, 3, 4, 8, 64])
-@pytest.mark.parametrize('zero_phase', [True, False])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("downsample_factor", [2, 3, 4, 8, 64])
+@pytest.mark.parametrize("zero_phase", [True, False])
 def test_decimate(num_samps, downsample_factor, zero_phase):
     cpu_time = np.linspace(0, 10, num_samps, endpoint=False)
-    cpu_sig = np.cos(-cpu_time ** 2 / 6.0)
+    cpu_sig = np.cos(-(cpu_time ** 2) / 6.0)
     gpu_sig = cp.asarray(cpu_sig)
 
-    cpu_decimate = signal.decimate(cpu_sig, downsample_factor,
-                                   ftype='fir', zero_phase=zero_phase)
+    cpu_decimate = signal.decimate(
+        cpu_sig, downsample_factor, ftype="fir", zero_phase=zero_phase
+    )
     gpu_decimate = cp.asnumpy(
         cusignal.decimate(gpu_sig, downsample_factor, zero_phase=zero_phase)
     )


### PR DESCRIPTION
### Info
This PR is meant to address Issue https://github.com/rapidsai/cusignal/issues/54, where import time for cusignal is excessive long because all Numba and CuPy kernel are being compile during import.

This PR attempts to solve this issue by allowing users the ability to explicitly precompile desired Numba or CuPy kernel before usage and also allow kernel to be compile on first use.

Currently, this PR focuses on **cusignal.lombscargle** in `_spectral.py` as a testbed. 

1. Remove **_populate_kernel_cache()** from being called on import and move it to **_lombscargle**. This will allow kernels of a specific _dtype_ and _use_numba_ to be compiled on first use. **_populate_kernel_cache()** will now verify if a kernel has already been compiled. If yes, return; if no, compile desired kernel.

```python
def _populate_kernel_cache(np_type, use_numba):

    try:
        numba_type, c_type = _SUPPORTED_TYPES.get(np_type)
    except TypeError:
        print("Data type {} not supported.".format(np_type))
        return
    ...
```

2. Add **_precompile_kernels()** to allow users to precompile desired kernels.
```python
import cusignal
cusignal._spectral._populate_kernel_cache(np.float64, False)
```

### Results
If this technique is applied too Numba/CuPy kernels it reduces import time by 9x on my x86 machine
Before:
```bash
(cusignal) belt@orion:~/workStuff/rapids/cusignal/python$ time python3 -c "import cusignal"

real    0m4.695s
user    0m4.192s
sys     0m0.190s
```
After
```bash
(cusignal) belt@orion:~/workStuff/rapids/cusignal/python$ time python3 -c "import cusignal"

real    0m0.420s
user    0m0.363s
sys     0m0.058s
```

There is a noticeable impact on single run use cases. In this example, a 21x improvement with precompile over no-precompile.

Without precompile:
```bash
Time(%)      Total Time   Instances         Average         Minimum         Maximum  Range             
-------  --------------  ----------  --------------  --------------  --------------  ------------------
  100.0        74123635           1      74123635.0        74123635        74123635  gpu_lombscargle
```

With precompile:
```bash
Time(%)      Total Time   Instances         Average         Minimum         Maximum  Range             
-------  --------------  ----------  --------------  --------------  --------------  ------------------
  100.0         3372422           1       3372422.0         3372422         3372422  gpu_lombscargle
```

There is no visible impact on benchmarks, see below
```bash
Name (time in us)                                             Min                    Max                  Mean                StdDev                Median                IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_lombscargle_gpu[False-False-False-262144-1024]      26.9060 (1.0)      56,899.5480 (2.81)     4,287.2436 (3.87)     1,424.2830 (2.38)     4,348.9110 (3.87)      3.0130 (2.29)    1414;5887  233.2501 (0.26)      35405           1
bench_lombscargle_gpu[False-False-False-65536-1024]       27.0030 (1.00)     39,603.8470 (1.95)     1,106.9343 (1.0)        677.2651 (1.13)     1,123.0970 (1.0)       1.3130 (1.0)     1509;7552  903.3960 (1.0)       35722           1
bench_lombscargle_gpu[False-False-True-262144-1024]       49.8970 (1.85)     64,352.6260 (3.18)     4,867.9718 (4.40)     1,592.3355 (2.66)     4,928.2250 (4.39)     10.3015 (7.85)     767;2721  205.4244 (0.23)      19584           1
bench_lombscargle_gpu[False-True-False-65536-1024]        50.6500 (1.88)     43,811.1860 (2.16)     1,121.7380 (1.01)       717.9696 (1.20)     1,137.9840 (1.01)     40.5930 (30.92)    949;1299  891.4738 (0.99)      19430           1
bench_lombscargle_gpu[False-True-False-262144-1024]       50.9030 (1.89)     54,865.4490 (2.71)     4,733.9890 (4.28)     1,630.7039 (2.73)     4,838.5610 (4.31)     11.4735 (8.74)     851;5062  211.2383 (0.23)      19219           1
bench_lombscargle_gpu[False-False-True-65536-1024]        51.5440 (1.92)     46,816.6060 (2.31)     1,303.1182 (1.18)       848.3968 (1.42)     1,319.8260 (1.18)      3.5898 (2.73)     823;4650  767.3901 (0.85)      19023           1
bench_lombscargle_gpu[False-True-True-65536-1024]         70.0490 (2.60)     26,646.1420 (1.31)     1,387.8114 (1.25)       658.6363 (1.10)     1,406.3755 (1.25)     12.5560 (9.56)     626;2107  720.5590 (0.80)      14066           1
bench_lombscargle_gpu[False-True-True-262144-1024]        71.3590 (2.65)     48,045.3240 (2.37)     4,519.1759 (4.08)     1,503.1672 (2.51)     4,565.3610 (4.06)     70.9170 (54.01)    578;1556  221.2793 (0.24)      13711           1
bench_lombscargle_gpu[True-False-False-262144-1024]      285.0280 (10.59)    28,164.6460 (1.39)     4,243.6270 (3.83)     1,879.3081 (3.14)     4,944.0910 (4.40)     13.8915 (10.58)     577;732  235.6475 (0.26)       3468           1
bench_lombscargle_gpu[True-False-False-65536-1024]       291.9050 (10.85)    21,443.2310 (1.06)     1,164.8023 (1.05)       668.6357 (1.12)     1,361.3015 (1.21)     16.5910 (12.64)     663;802  858.5148 (0.95)       3382           1
bench_lombscargle_gpu[True-True-False-262144-1024]       312.0630 (11.60)    43,368.4600 (2.14)     4,459.1994 (4.03)     1,957.5219 (3.27)     4,958.3820 (4.41)     50.6218 (38.55)     425;659  224.2555 (0.25)       3169           1
bench_lombscargle_gpu[True-True-False-65536-1024]        312.4470 (11.61)    21,014.0490 (1.04)     1,225.7864 (1.11)       623.5198 (1.04)     1,363.5020 (1.21)     31.7132 (24.15)     498;824  815.8028 (0.90)       3173           1
bench_lombscargle_gpu[True-False-True-65536-1024]        323.6380 (12.03)    22,066.5290 (1.09)     1,244.0159 (1.12)       615.7444 (1.03)     1,349.6860 (1.20)     20.1062 (15.31)     379;662  803.8483 (0.89)       3023           1
bench_lombscargle_gpu[True-False-True-262144-1024]       325.8770 (12.11)    35,460.8630 (1.75)     4,050.7925 (3.66)     1,493.7356 (2.50)     4,388.9525 (3.91)     43.5940 (33.20)     325;564  246.8653 (0.27)       3054           1
bench_lombscargle_gpu[True-True-True-262144-1024]        339.3310 (12.61)    28,899.2560 (1.43)     4,503.7586 (4.07)     1,387.3032 (2.32)     4,807.5840 (4.28)     69.5670 (52.98)     251;474  222.0368 (0.25)       2902           1
bench_lombscargle_gpu[True-True-True-65536-1024]         345.1900 (12.83)    20,264.4000 (1.0)      1,310.9682 (1.18)       598.4111 (1.0)      1,384.0260 (1.23)     20.9048 (15.92)     367;718  762.7950 (0.84)       2811           1
```

If there are no issues, I'll apply these changes to the other kernels and submit next week.