### PR TITLE
[REVIEW] Added CuPy kernels for correlate1d/convolve1d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - PR #48 - Addition of decimate for FIR ftypes
 - PR #49 - Add CuPy Module for convolve2d and correlate2d
 - PR #51 - Add CuPy Module for lombscargle, along with tests/benchmarks
+- PR #62 - Add CuPy Module for 1d convolve and correlate, along with tests/benchmarks
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -378,8 +378,6 @@ extern "C" {
             const int inpW,
             const ${datatype} * __restrict__ kernel,
             const int kerW,
-            const int P1,
-            const int end,
             const int mode,
             const bool swapped_inputs,
             ${datatype} * __restrict__ out,
@@ -395,56 +393,30 @@ extern "C" {
 
             // Valid
             if ( mode == 0 ) {
-                if ( tid >= P1 && tid < outW - P1 ) {
+                if ( tid >= 0 && tid < inpW ) {
                     for ( int j = 0; j < kerW; j++ ) {
-
-                        temp += inp[tid - P1 + j] * kernel[j];
+                        temp += inp[tid + j] * kernel[j];
                     }
                 }
             } else if ( mode == 1 ) {   // Same
-                if (!swapped_inputs){
-                    if ( tid < P1 ) {
-                        for ( int j = 0; j < kerW; j++ ) {
-                            ${datatype} input = (tid < P1 - j) ?
-                                0 : inp[tid - P1 + j];
-
-                            temp += input * kernel[j];
-                        }
-                    } else {
-                        for ( int j = 0; j < kerW; j++ ) {
-                            ${datatype} input = ( tid - (end - P1) ) <
-                                (outW - end + (end - j)) ?
-                                inp[tid - P1 + j] : 0;
-
-                            temp += input * kernel[j];
-                        }
-                    }
+                const int P1 { kerW / 2 };
+                int start {};
+                if ( !swapped_inputs ) {
+                    start = 0 - P1 + tid;
                 } else {
-                    ${datatype} input {};
-                    int start {(inpW/2) - (kerW-1) + tid};
-                    for ( int j = 0; j < kerW; j++ ) {
-                        if ((start + j < 0) || (start + j > inpW)) {
-                            input = 0;
-                        } else {
-                            input = inp[start + j];
-                        }
-                        temp += input * kernel[j];
+                    start = ( ( inpW - 1 ) / 2 ) - ( kerW - 1 ) + tid;
+                }
+                for ( int j = 0; j < kerW; j++ ) {
+                    if ( ( start + j >= 0 ) && ( start + j < inpW ) ) {
+                        temp += inp[start + j] * kernel[j];
                     }
                 }
             } else {    // Full
-                if ( tid < P1 ) {
-                    for ( int j = 0; j < kerW; j++ ) {
-                        ${datatype} input = (tid < P1 - j) ?
-                            0 : inp[tid - P1 + j];
-
-                        temp += input * kernel[j];
-                    }
-                } else {
-                    for ( int j = 0; j < kerW; j++ ) {
-                        ${datatype} input = ( tid - (end - P1) ) <
-                            (outW - end + (end - j)) ? inp[tid - P1 + j] : 0;
-
-                        temp += input * kernel[j];
+                const int P1 { kerW - 1 };
+                int start { 0 - P1 + tid };
+                for ( int j = 0; j < kerW; j++ ) {
+                    if ( ( start + j >= 0 ) && ( start + j < inpW ) ) {
+                        temp += inp[start + j] * kernel[j];
                     }
                 }
             }
@@ -462,8 +434,6 @@ extern "C" {
             const int inpW,
             const ${datatype} * __restrict__ kernel,
             const int kerW,
-            const int P1,
-            const int end,
             const int mode,
             const bool swapped_inputs,
             ${datatype} * __restrict__ out,
@@ -479,54 +449,30 @@ extern "C" {
 
             // Valid
             if ( mode == 0 ) {
-                if ( tid >= P1 && tid < outW - P1 ) {
+                if ( tid >= 0 && tid < inpW ) {
                     for ( int j = 0; j < kerW; j++ ) {
-
-                        temp += inp[tid - P1 + j] * kernel[( kerW - 1 ) - j];
+                        temp += inp[tid + j] * kernel[( kerW - 1 ) - j];
                     }
                 }
             } else if ( mode == 1 ) {   // Same
-                if (!swapped_inputs){
-                    if ( tid < P1 ) {
-                        for ( int j = 0; j < kerW; j++ ) {
-                            ${datatype} input = (tid < P1 - j) ?
-                                0 : inp[tid - P1 + j];
-                            temp += input * kernel[( kerW - 1 ) - j];
-                        }
-                    } else {
-                        for ( int j = 0; j < kerW; j++ ) {
-                            ${datatype} input = ( tid - (end - P1) ) <
-                                (outW - end + (end - j)) ?
-                                inp[tid - P1 + j] : 0;
-                            temp += input * kernel[( kerW - 1 ) - j];
-                        }
-                    }
+                const int P1 { kerW / 2 };
+                int start {};
+                if ( !swapped_inputs ) {
+                    start = 0 - P1 + tid;
                 } else {
-                    ${datatype} input {};
-                    int start { (inpW/2) - (kerW-1) + tid };
-                    if ( inpW % 2 == 0) start--;
-                    for ( int j = 0; j < kerW; j++ ) {
-                        if ((start + j < 0) || (start + j > inpW)) {
-                            input = 0;
-                        } else {
-                            input = inp[start + j];
-                        }
-                        temp += input * kernel[( kerW - 1 ) - j];
+                    start = ( ( inpW - 1 ) / 2 ) - ( kerW - 1 ) + tid;
+                }
+                for ( int j = 0; j < kerW; j++ ) {
+                    if ( ( start + j >= 0 ) && ( start + j < inpW ) ) {
+                        temp += inp[start + j] * kernel[( kerW - 1 ) - j];
                     }
                 }
-
             } else {    // Full
-                if ( tid < P1 ) {
-                    for ( int j = 0; j < kerW; j++ ) {
-                        ${datatype} input = (tid < P1 - j) ?
-                            0 : inp[tid - P1 + j];
-                        temp += input * kernel[( kerW - 1 ) - j];
-                    }
-                } else {
-                    for ( int j = 0; j < kerW; j++ ) {
-                        ${datatype} input = ( tid - (end - P1) ) <
-                            (outW - end + (end - j)) ? inp[tid - P1 + j] : 0;
-                        temp += input * kernel[( kerW - 1 ) - j];
+                const int P1 { kerW - 1 };
+                int start { 0 - P1 + tid };
+                for ( int j = 0; j < kerW; j++ ) {
+                    if ( ( start + j >= 0 ) && ( start + j < inpW ) ) {
+                        temp += inp[start + j] * kernel[( kerW - 1 ) - j];
                     }
                 }
             }
@@ -552,7 +498,7 @@ class _cupy_convolve_1d_wrapper(object):
         self.kernel = kernel
 
     def __call__(
-        self, d_inp, d_kernel, P1, end, mode, swapped_inputs, out,
+        self, d_inp, d_kernel, mode, swapped_inputs, out,
     ):
 
         kernel_args = (
@@ -560,8 +506,6 @@ class _cupy_convolve_1d_wrapper(object):
             d_inp.shape[0],
             d_kernel,
             d_kernel.shape[0],
-            P1,
-            end,
             mode,
             swapped_inputs,
             out,
@@ -669,28 +613,6 @@ def _convolve1d_gpu(
     inp, out, ker, mode, use_convolve, swapped_inputs, cp_stream,
 ):
 
-    # end is used to handle threads that compute last
-    # elements in kernel
-    end = ker.shape[0] - 1
-
-    # P1 is the amount of padding required
-    if ker.shape[0] % 2 == 1:  # odd
-        if mode == 0:  # valid
-            P1 = 0
-        elif mode == 1:  # same
-            P1 = ker.shape[0] // 2
-        else:  # full
-            P1 = ker.shape[0] - 1
-
-    else:  # even
-        if mode == 0:  # valid
-            P1 = 0
-        elif mode == 1:  # same
-            P1 = ker.shape[0] // 2
-            end = ker.shape[0]
-        else:  # full
-            P1 = ker.shape[0] - 1
-
     d_inp = cp.array(inp)
     d_kernel = cp.array(ker)
 
@@ -709,7 +631,7 @@ def _convolve1d_gpu(
         use_numba=False,
     )
 
-    kernel(d_inp, d_kernel, P1, end, mode, swapped_inputs, out)
+    kernel(d_inp, d_kernel, mode, swapped_inputs, out)
 
     return out
 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -366,9 +366,121 @@ extern "C" {
             out[oPixelPos.x * outW + oPixelPos.y] = temp;
         }
     }
+
+    __global__ void _cupy_correlate_1d(
+            const ${datatype} * __restrict__ inp,
+            const ${datatype} * __restrict__ kernel,
+            const int kerW,
+            const int P1,
+            const int end,
+            ${datatype} * __restrict__ out,
+            const int outW) {
+
+        const int tx {
+            static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+        const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+        for ( int tid = tx; tid < outW; tid += stride ) {
+
+            ${datatype} temp {};
+
+            if ( tid >= P1 && tid < outW - P1 ) {
+                for ( int j = 0; j < kerW; j++ ) {
+
+                    temp += inp[tid - P1 + j] * kernel[j];
+                }
+            } else if ( tid < P1 ) {
+                for ( int j = 0; j < kerW; j++ ) {
+
+                    ${datatype} input = (tid < P1 - j) ? 0 : inp[tid - P1 + j];
+                    temp += input * kernel[j];
+                }
+            } else {
+                for ( int j = 0; j < kerW; j++ ) {
+
+                    ${datatype} input = ( tid - (end - P1) ) <
+                        (outW - end + (end - j)) ? inp[tid - P1 + j] : 0;
+                    temp += input * kernel[j];
+                }
+            }
+
+            out[tid] = temp;
+        }
+    }
+
+    __global__ void _cupy_convolve_1d(
+            const ${datatype} * __restrict__ inp,
+            const ${datatype} * __restrict__ kernel,
+            const int kerW,
+            const int P1,
+            const int end,
+            ${datatype} * __restrict__ out,
+            const int outW) {
+
+        const int tx {
+            static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+        const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+        for ( int tid = tx; tid < outW; tid += stride ) {
+
+            ${datatype} temp {};
+
+            if ( tid >= P1 && tid < outW - P1 ) {
+                for ( int j = 0; j < kerW; j++ ) {
+
+                    temp += inp[tid - P1 + j] * kernel[( kerW - 1 ) - j];
+                }
+            } else if ( tid < P1 ) {
+                for ( int j = 0; j < kerW; j++ ) {
+
+                    ${datatype} input = (tid < P1 - j) ? 0 : inp[tid - P1 + j];
+                    temp += input * kernel[( kerW - 1 ) - j];
+                }
+            } else {
+                for ( int j = 0; j < kerW; j++ ) {
+
+                    ${datatype} input = ( tid - (end - P1) ) <
+                        (outW - end + (end - j)) ? inp[tid - P1 + j] : 0;
+                    temp += input * kernel[( kerW - 1 ) - j];
+                }
+            }
+
+            out[tid] = temp;
+        }
+    }
 }
 """
 )
+
+
+class _cupy_convolve_1d_wrapper(object):
+    def __init__(self, grid, block, stream, kernel):
+        if isinstance(grid, int):
+            grid = (grid,)
+        if isinstance(block, int):
+            block = (block,)
+
+        self.grid = grid
+        self.block = block
+        self.stream = stream
+        self.kernel = kernel
+
+    def __call__(
+        self, d_inp, d_kernel, P1, end, out,
+    ):
+
+        kernel_args = (
+            d_inp,
+            d_kernel,
+            d_kernel.shape[0],
+            P1,
+            end,
+            out,
+            out.shape[0],
+        )
+
+        self.stream.use()
+        self.kernel(self.grid, self.block, kernel_args)
 
 
 class _cupy_convolve_2d_wrapper(object):
@@ -406,27 +518,33 @@ class _cupy_convolve_2d_wrapper(object):
         self.kernel(self.grid, self.block, kernel_args)
 
 
-def _get_backend_kernel(flip, dtype, grid, block, stream, use_numba):
+def _get_backend_kernel(use_convolve, dtype, grid, block, stream, use_numba):
 
     if use_numba:
         nb_stream = stream_cupy_to_numba(stream)
-        kernel = _numba_kernel_cache[(flip, dtype.name)]
+        kernel = _numba_kernel_cache[(use_convolve, dtype.name)]
 
         if kernel:
             return kernel[grid, block, nb_stream]
     else:
-        kernel = _cupy_kernel_cache[(flip, dtype.name)]
+        kernel = _cupy_kernel_cache[(use_convolve, dtype.name)]
         if kernel:
-            return _cupy_convolve_2d_wrapper(grid, block, stream, kernel)
+            if use_convolve < 2:
+                return _cupy_convolve_2d_wrapper(grid, block, stream, kernel)
+            else:
+                return _cupy_convolve_1d_wrapper(grid, block, stream, kernel)
 
     raise NotImplementedError(
-        "No kernel found for flip {}, datatype {}".format(flip, dtype.name)
+        "No kernel found for use_convolve {}, datatype {}".format(
+            use_convolve, dtype.name
+        )
     )
 
 
 def _populate_kernel_cache():
     for numba_type, c_type in _SUPPORTED_TYPES.items():
-        # JIT compile the numba kernels, flip = 0/1 (correlate/convolve)
+        # JIT compile the numba kernels,
+        # use_convolve = 0/1 (correlate/convolve)
         sig = _numba_convolve_2d_signature(numba_type)
         _numba_kernel_cache[(0, str(numba_type))] = cuda.jit(
             sig, fastmath=True
@@ -450,10 +568,72 @@ def _populate_kernel_cache():
         _cupy_kernel_cache[(1, str(numba_type))] = module2.get_function(
             "_cupy_convolve_2d"
         )
+        _cupy_kernel_cache[(2, str(numba_type))] = module2.get_function(
+            "_cupy_correlate_1d"
+        )
+        _cupy_kernel_cache[(3, str(numba_type))] = module2.get_function(
+            "_cupy_convolve_1d"
+        )
+
+
+def _convolve1d_gpu(
+    inp, out, ker, mode, use_convolve, cp_stream,
+):
+
+    # end is used to handle threads that compute last
+    # elements in kernel
+    end = ker.shape[0] - 1
+
+    # P1 is the amount of padding required
+    if ker.shape[0] % 2 == 1:  # odd
+        if mode == 0:  # valid
+            P1 = 0
+        elif mode == 1:  # same
+            P1 = ker.shape[0] // 2
+        else:  # full
+            P1 = ker.shape[0] - 1
+
+    else:  # even
+        if mode == 0:  # valid
+            P1 = 0
+        elif mode == 1:  # same
+            P1 = ker.shape[0] // 2
+            end = ker.shape[0]
+        else:  # full
+            P1 = ker.shape[0] - 1
+
+    d_inp = cp.array(inp)
+    d_kernel = cp.array(ker)
+
+    device_id = cp.cuda.Device()
+    numSM = device_id.attributes["MultiProcessorCount"]
+    threadsperblock = 256
+    blockspergrid = numSM * 20
+
+    kernel = _get_backend_kernel(
+        use_convolve + 2,
+        out.dtype,
+        blockspergrid,
+        threadsperblock,
+        cp_stream,
+        use_numba=False,
+    )
+
+    kernel(d_inp, d_kernel, P1, end, out)
+
+    return out
 
 
 def _convolve2d_gpu(
-    inp, out, kernel, mode, boundary, flip, fillvalue, cp_stream, use_numba,
+    inp,
+    out,
+    kernel,
+    mode,
+    boundary,
+    use_convolve,
+    fillvalue,
+    cp_stream,
+    use_numba,
 ):
 
     if (boundary != PAD) and (boundary != REFLECT) and (boundary != CIRCULAR):
@@ -476,7 +656,7 @@ def _convolve2d_gpu(
             if mode == 2:  # full
                 P1 = P2 = P3 = P4 = S[0] * 2 - 1
             else:  # same/valid
-                if flip:
+                if use_convolve:
                     P1 = P2 = P3 = P4 = S[0]
                 else:
                     P1 = P3 = S[0] - 1
@@ -491,7 +671,7 @@ def _convolve2d_gpu(
             P3 = S[1] - 1
             P4 = S[1] - 1
         else:  # same/valid
-            if flip:
+            if use_convolve:
                 P1 = S[0] // 2
                 P2 = S[0] // 2 if (S[0] % 2) else S[0] // 2 - 1
                 P3 = S[1] // 2
@@ -536,7 +716,12 @@ def _convolve2d_gpu(
     )
 
     kernell = _get_backend_kernel(
-        flip, out.dtype, blockspergrid, threadsperblock, cp_stream, use_numba,
+        use_convolve,
+        out.dtype,
+        blockspergrid,
+        threadsperblock,
+        cp_stream,
+        use_numba,
     )
 
     kernell(
@@ -545,10 +730,54 @@ def _convolve2d_gpu(
     return out
 
 
+def _convolve(
+    in1,
+    in2,
+    use_convolve,
+    mode="full",
+    cp_stream=cp.cuda.stream.Stream(null=True),
+):
+
+    val = _valfrommode(mode)
+
+    # Promote inputs
+    promType = cp.promote_types(in1.dtype, in2.dtype)
+    in1 = in1.astype(promType)
+    in2 = in2.astype(promType)
+
+    # Create empty array to hold number of aout dimensions
+    out_dimens = np.empty(in1.ndim, np.int)
+    if val == VALID:
+        for i in range(in1.ndim):
+            out_dimens[i] = in1.shape[i] - in2.shape[i] + 1
+            if out_dimens[i] < 0:
+                raise Exception(
+                    "no part of the output is valid, use option 1 (same) or 2 \
+                     (full) for third argument"
+                )
+    elif val == SAME:
+        for i in range(in1.ndim):
+            out_dimens[i] = in1.shape[i]
+    elif val == FULL:
+        for i in range(in1.ndim):
+            out_dimens[i] = in1.shape[i] + in2.shape[i] - 1
+    else:
+        raise Exception("mode must be 0 (valid), 1 (same), or 2 (full)")
+
+    # Create empty array out on GPU
+    out = cp.empty(out_dimens.tolist(), in1.dtype)
+
+    out = _convolve1d_gpu(
+        in1, out, in2, val, use_convolve, cp_stream=cp_stream,
+    )
+
+    return out
+
+
 def _convolve2d(
     in1,
     in2,
-    flip,
+    use_convolve,
     mode="full",
     boundary="fill",
     fillvalue=0,
@@ -556,15 +785,18 @@ def _convolve2d(
     use_numba=False,
 ):
 
+    val = _valfrommode(mode)
+    bval = _bvalfromboundary(boundary)
+
     # Promote inputs
     promType = cp.promote_types(in1.dtype, in2.dtype)
     in1 = in1.astype(promType)
     in2 = in2.astype(promType)
 
-    if (boundary != PAD) and (boundary != REFLECT) and (boundary != CIRCULAR):
+    if (bval != PAD) and (bval != REFLECT) and (bval != CIRCULAR):
         raise Exception("Incorrect boundary value.")
 
-    if (boundary == PAD) and (fillvalue is not None):
+    if (bval == PAD) and (fillvalue is not None):
         fill = np.array(fillvalue, in1.dtype)
         if fill is None:
             raise Exception("If you see this let developers know.")
@@ -581,7 +813,7 @@ def _convolve2d(
 
     # Create empty array to hold number of aout dimensions
     out_dimens = np.empty(in1.ndim, np.int)
-    if mode == VALID:
+    if val == VALID:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] - in2.shape[i] + 1
             if out_dimens[i] < 0:
@@ -589,10 +821,10 @@ def _convolve2d(
                     "no part of the output is valid, use option 1 (same) or 2 \
                      (full) for third argument"
                 )
-    elif mode == SAME:
+    elif val == SAME:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i]
-    elif mode == FULL:
+    elif val == FULL:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] + in2.shape[i] - 1
     else:
@@ -605,9 +837,9 @@ def _convolve2d(
         in1,
         out,
         in2,
-        mode,
-        boundary,
-        flip,
+        val,
+        bval,
+        use_convolve,
         fill,
         cp_stream=cp_stream,
         use_numba=use_numba,

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -26,6 +26,7 @@ from numba import (
     int64,
     void,
 )
+
 try:
     # Numba <= 0.49
     from numba.types.scalars import Complex
@@ -736,11 +737,7 @@ def _convolve2d_gpu(
 
 
 def _convolve(
-    in1,
-    in2,
-    use_convolve,
-    mode="full",
-    cp_stream=cp.cuda.stream.Stream(null=True),
+    in1, in2, use_convolve, mode, cp_stream=cp.cuda.stream.Stream(null=True),
 ):
 
     val = _valfrommode(mode)

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -135,10 +135,10 @@ class BenchFirWin:
 
 
 @pytest.mark.benchmark(group="Correlate")
-@pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 14])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 14])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
+@pytest.mark.parametrize("method", ["direct"])
 class BenchCorrelate:
     def cpu_version(self, cpu_sig, num_taps, mode, method):
         return signal.correlate(cpu_sig, num_taps, mode=mode, method=method)
@@ -167,10 +167,10 @@ class BenchCorrelate:
 
 
 @pytest.mark.benchmark(group="Convolve")
-@pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 14])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 14])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
+@pytest.mark.parametrize("method", ["direct"])
 class BenchConvolve:
     def cpu_version(self, cpu_sig, cpu_win, mode, method):
         return signal.convolve(cpu_sig, cpu_win, mode=mode, method=method)

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -135,21 +135,21 @@ class BenchFirWin:
 
 
 @pytest.mark.benchmark(group="Correlate")
-@pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 14])
-@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 14])
+@pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 13])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 13])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-@pytest.mark.parametrize("method", ["direct"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
 class BenchCorrelate:
     def cpu_version(self, cpu_sig, num_taps, mode, method):
         return signal.correlate(cpu_sig, num_taps, mode=mode, method=method)
 
-    def bench_correlate_cpu(
+    def bench_correlate1d_cpu(
         self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
         cpu_sig, _ = rand_data_gen(num_samps)
         benchmark(self.cpu_version, cpu_sig, np.ones(num_taps), mode, method)
 
-    def bench_correlate_gpu(
+    def bench_correlate1d_gpu(
         self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
 
@@ -167,15 +167,15 @@ class BenchCorrelate:
 
 
 @pytest.mark.benchmark(group="Convolve")
-@pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 14])
-@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 14])
+@pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 13])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 13])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-@pytest.mark.parametrize("method", ["direct"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
 class BenchConvolve:
     def cpu_version(self, cpu_sig, cpu_win, mode, method):
         return signal.convolve(cpu_sig, cpu_win, mode=mode, method=method)
 
-    def bench_convolve_cpu(
+    def bench_convolve1d_cpu(
         self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
         cpu_sig, _ = rand_data_gen(num_samps)
@@ -183,7 +183,7 @@ class BenchConvolve:
 
         benchmark(self.cpu_version, cpu_sig, cpu_win, mode, method)
 
-    def bench_convolve_gpu(
+    def bench_convolve1d_gpu(
         self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
 
@@ -275,64 +275,6 @@ class BenchHilbert2:
 
         key = self.cpu_version(cpu_sig)
         assert array_equal(cp.asnumpy(output), key)
-
-
-# @pytest.mark.benchmark(group="Convolve")
-# @pytest.mark.parametrize("num_samps", [2 ** 16, 2 ** 20])
-# @pytest.mark.parametrize("num_taps", [5, 100, 1024])
-# @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-# class BenchConvolve:
-#     def cpu_version(self, cpu_sig, cpu_filt, mode):
-#         return signal.convolve(cpu_sig, cpu_filt, mode=mode, method="direct")
-
-#     def bench_convolve_cpu(
-#         self, rand_data_gen, benchmark, num_samps, num_taps, mode
-#     ):
-#         cpu_sig, _ = rand_data_gen(num_samps)
-#         cpu_filt, _ = rand_data_gen(num_taps)
-#         benchmark(self.cpu_version, cpu_sig, cpu_filt, mode)
-
-#     def bench_convolve_gpu(
-#         self, rand_data_gen, benchmark, num_samps, num_taps, mode,
-#     ):
-
-#         cpu_sig, gpu_sig = rand_data_gen(num_samps)
-#         cpu_filt, gpu_filt = rand_data_gen(num_taps)
-#         output = benchmark(
-#             cusignal.convolve, gpu_sig, gpu_filt, mode=mode, method="direct",
-#         )
-
-#         key = self.cpu_version(cpu_sig, cpu_filt, mode)
-#         assert array_equal(cp.asnumpy(output), key)
-
-
-# @pytest.mark.benchmark(group="Correlate")
-# @pytest.mark.parametrize("num_samps", [2 ** 16, 2 ** 20])
-# @pytest.mark.parametrize("num_taps", [5, 100, 1024])
-# @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-# class BenchCorrelate:
-#     def cpu_version(self, cpu_sig, cpu_filt, mode):
-#         return signal.correlate(cpu_sig, cpu_filt, mode=mode, method="direct")
-
-#     def bench_correlate_cpu(
-#         self, rand_data_gen, benchmark, num_samps, num_taps, mode
-#     ):
-#         cpu_sig, _ = rand_data_gen(num_samps)
-#         cpu_filt, _ = rand_data_gen(num_taps)
-#         benchmark(self.cpu_version, cpu_sig, cpu_filt, mode)
-
-#     def bench_correlate_gpu(
-#         self, rand_data_gen, benchmark, num_samps, num_taps, mode,
-#     ):
-
-#         cpu_sig, gpu_sig = rand_data_gen(num_samps)
-#         cpu_filt, gpu_filt = rand_data_gen(num_taps)
-#         output = benchmark(
-#             cusignal.correlate, gpu_sig, gpu_filt, mode=mode, method="direct",
-#         )
-
-#         key = self.cpu_version(cpu_sig, cpu_filt, mode)
-#         assert array_equal(cp.asnumpy(output), key)
 
 
 @pytest.mark.benchmark(group="Convolve2d")

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -136,57 +136,65 @@ class BenchFirWin:
 
 @pytest.mark.benchmark(group="Correlate")
 @pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
 class BenchCorrelate:
-    def cpu_version(self, cpu_sig, num_taps, mode):
-        return signal.correlate(cpu_sig, num_taps, mode=mode)
+    def cpu_version(self, cpu_sig, num_taps, mode, method):
+        return signal.correlate(cpu_sig, num_taps, mode=mode, method=method)
 
     def bench_correlate_cpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
         cpu_sig, _ = rand_data_gen(num_samps)
-        benchmark(self.cpu_version, cpu_sig, np.ones(num_taps), mode)
+        benchmark(self.cpu_version, cpu_sig, np.ones(num_taps), mode, method)
 
     def bench_correlate_gpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
 
         cpu_sig, gpu_sig = rand_data_gen(num_samps)
         output = benchmark(
-            cusignal.correlate, gpu_sig, cp.ones(num_taps), mode=mode
+            cusignal.correlate,
+            gpu_sig,
+            cp.ones(num_taps),
+            mode=mode,
+            method=method,
         )
 
-        key = self.cpu_version(cpu_sig, np.ones(num_taps), mode)
+        key = self.cpu_version(cpu_sig, np.ones(num_taps), mode, method)
         assert array_equal(cp.asnumpy(output), key)
 
 
 @pytest.mark.benchmark(group="Convolve")
 @pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
 class BenchConvolve:
-    def cpu_version(self, cpu_sig, cpu_win, mode):
-        return signal.convolve(cpu_sig, cpu_win, mode=mode)
+    def cpu_version(self, cpu_sig, cpu_win, mode, method):
+        return signal.convolve(cpu_sig, cpu_win, mode=mode, method=method)
 
     def bench_convolve_cpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
         cpu_sig, _ = rand_data_gen(num_samps)
         cpu_win = signal.windows.hann(num_taps)
 
-        benchmark(self.cpu_version, cpu_sig, cpu_win, mode)
+        benchmark(self.cpu_version, cpu_sig, cpu_win, mode, method)
 
     def bench_convolve_gpu(
-        self, rand_data_gen, benchmark, num_samps, num_taps, mode
+        self, rand_data_gen, benchmark, num_samps, num_taps, mode, method
     ):
 
         cpu_sig, gpu_sig = rand_data_gen(num_samps)
         gpu_win = cusignal.windows.hann(num_taps)
-        output = benchmark(cusignal.convolve, gpu_sig, gpu_win, mode=mode)
+        output = benchmark(
+            cusignal.convolve, gpu_sig, gpu_win, mode=mode, method=method
+        )
 
         cpu_win = signal.windows.hann(num_taps)
-        key = self.cpu_version(cpu_sig, cpu_win, mode)
+        key = self.cpu_version(cpu_sig, cpu_win, mode, method)
         assert array_equal(cp.asnumpy(output), key)
 
 
@@ -267,6 +275,64 @@ class BenchHilbert2:
 
         key = self.cpu_version(cpu_sig)
         assert array_equal(cp.asnumpy(output), key)
+
+
+# @pytest.mark.benchmark(group="Convolve")
+# @pytest.mark.parametrize("num_samps", [2 ** 16, 2 ** 20])
+# @pytest.mark.parametrize("num_taps", [5, 100, 1024])
+# @pytest.mark.parametrize("mode", ["full", "valid", "same"])
+# class BenchConvolve:
+#     def cpu_version(self, cpu_sig, cpu_filt, mode):
+#         return signal.convolve(cpu_sig, cpu_filt, mode=mode, method="direct")
+
+#     def bench_convolve_cpu(
+#         self, rand_data_gen, benchmark, num_samps, num_taps, mode
+#     ):
+#         cpu_sig, _ = rand_data_gen(num_samps)
+#         cpu_filt, _ = rand_data_gen(num_taps)
+#         benchmark(self.cpu_version, cpu_sig, cpu_filt, mode)
+
+#     def bench_convolve_gpu(
+#         self, rand_data_gen, benchmark, num_samps, num_taps, mode,
+#     ):
+
+#         cpu_sig, gpu_sig = rand_data_gen(num_samps)
+#         cpu_filt, gpu_filt = rand_data_gen(num_taps)
+#         output = benchmark(
+#             cusignal.convolve, gpu_sig, gpu_filt, mode=mode, method="direct",
+#         )
+
+#         key = self.cpu_version(cpu_sig, cpu_filt, mode)
+#         assert array_equal(cp.asnumpy(output), key)
+
+
+# @pytest.mark.benchmark(group="Correlate")
+# @pytest.mark.parametrize("num_samps", [2 ** 16, 2 ** 20])
+# @pytest.mark.parametrize("num_taps", [5, 100, 1024])
+# @pytest.mark.parametrize("mode", ["full", "valid", "same"])
+# class BenchCorrelate:
+#     def cpu_version(self, cpu_sig, cpu_filt, mode):
+#         return signal.correlate(cpu_sig, cpu_filt, mode=mode, method="direct")
+
+#     def bench_correlate_cpu(
+#         self, rand_data_gen, benchmark, num_samps, num_taps, mode
+#     ):
+#         cpu_sig, _ = rand_data_gen(num_samps)
+#         cpu_filt, _ = rand_data_gen(num_taps)
+#         benchmark(self.cpu_version, cpu_sig, cpu_filt, mode)
+
+#     def bench_correlate_gpu(
+#         self, rand_data_gen, benchmark, num_samps, num_taps, mode,
+#     ):
+
+#         cpu_sig, gpu_sig = rand_data_gen(num_samps)
+#         cpu_filt, gpu_filt = rand_data_gen(num_taps)
+#         output = benchmark(
+#             cusignal.correlate, gpu_sig, gpu_filt, mode=mode, method="direct",
+#         )
+
+#         key = self.cpu_version(cpu_sig, cpu_filt, mode)
+#         assert array_equal(cp.asnumpy(output), key)
 
 
 @pytest.mark.benchmark(group="Convolve2d")

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -205,7 +205,7 @@ def correlate(in1, in2, mode="full", method="auto"):
         return convolve(in1, _reverse_and_conj(in2), mode, method)
 
     elif method == "direct":
-        raise ValueError("Direct method is not yet implemented in cuSignal")
+        return _signaltools._convolve(in1, in2, 0, mode)
 
     else:
         raise ValueError(
@@ -744,11 +744,7 @@ def convolve(in1, in2, mode="full", method="auto"):
     if volume.ndim == kernel.ndim == 0:
         return volume * kernel
     elif volume.ndim != kernel.ndim:
-        raise ValueError(
-            "volume and kernel should have \
-                         the same "
-            "dimensionality"
-        )
+        raise ValueError("in1 and in2 should have the same dimensionality")
 
     if _inputs_swap_needed(mode, volume.shape, kernel.shape):
         # Convolution is commutative; order doesn't have any effect on output
@@ -766,16 +762,15 @@ def convolve(in1, in2, mode="full", method="auto"):
     elif method == "direct":
         # fastpath to faster numpy.convolve for 1d inputs when possible
         if _np_conv_ok(volume, kernel, mode):
-            return cp.asarray(
-                np.convolve(cp.asnumpy(volume), cp.asnumpy(kernel), mode)
-            )
+            return _signaltools._convolve(volume, kernel, 1, mode)
+            # return cp.asarray(
+            #     np.convolve(cp.asnumpy(volume), cp.asnumpy(kernel), mode)
+            # )
 
         return correlate(volume, _reverse_and_conj(kernel), mode, "direct")
     else:
         raise ValueError(
-            "Acceptable method flags are \
-                         'auto',"
-            " 'direct', or 'fft'."
+            "Acceptable method flags are 'auto'," " 'direct', or 'fft'."
         )
 
 
@@ -914,14 +909,12 @@ def convolve2d(
     if _inputs_swap_needed(mode, in1.shape, in2.shape):
         in1, in2 = in2, in1
 
-    val = _signaltools._valfrommode(mode)
-    bval = _signaltools._bvalfromboundary(boundary)
     out = _signaltools._convolve2d(
         in1,
         in2,
         1,
-        val,
-        bval,
+        mode,
+        boundary,
         fillvalue,
         cp_stream=cp_stream,
         use_numba=use_numba,
@@ -1012,14 +1005,12 @@ def correlate2d(
     if swapped_inputs:
         in1, in2 = in2, in1
 
-    val = _signaltools._valfrommode(mode)
-    bval = _signaltools._bvalfromboundary(boundary)
     out = _signaltools._convolve2d(
         in1,
         in2.conj(),
         0,
-        val,
-        bval,
+        mode,
+        boundary,
         fillvalue,
         cp_stream=cp_stream,
         use_numba=use_numba,
@@ -1795,7 +1786,7 @@ def decimate(x, q, n=None, axis=-1, zero_phase=True):
     -----
     Only FIR filter types are currently supported in cuSignal.
     """
-    
+
     x = asarray(x)
     if isinstance(n, (list, ndarray)):
         b = asarray(n)
@@ -1803,7 +1794,7 @@ def decimate(x, q, n=None, axis=-1, zero_phase=True):
         if n is None:
             half_len = 10 * q  # reasonable cutoff for our sinc-like function
             n = 2 * half_len
-        b = firwin(n + 1, 1. / q, window='hamming')
+        b = firwin(n + 1, 1.0 / q, window="hamming")
 
     sl = [slice(None)] * x.ndim
 

--- a/python/cusignal/signaltools.py
+++ b/python/cusignal/signaltools.py
@@ -205,7 +205,13 @@ def correlate(in1, in2, mode="full", method="auto"):
         return convolve(in1, _reverse_and_conj(in2), mode, method)
 
     elif method == "direct":
-        return _signaltools._convolve(in1, in2, 0, mode)
+
+        swapped_inputs = in2.size > in1.size
+
+        if swapped_inputs:
+            in1, in2 = in2, in1
+
+        return _signaltools._convolve(in1, in2, False, swapped_inputs, mode)
 
     else:
         raise ValueError(
@@ -464,11 +470,13 @@ def _fftconv_faster(x, h, mode):
     return big_O_constant * fft_time < direct_time
 
 
+#  TODO: Does this even work????
 def _reverse_and_conj(x):
     """
     Reverse array `x` in all dimensions and perform the complex conjugate
     """
     reverse = (slice(None, None, -1),) * x.ndim
+    # return cp.flip(x, 0)
     return x[reverse].conj()
 
 
@@ -760,14 +768,19 @@ def convolve(in1, in2, mode="full", method="auto"):
             out = cp.around(out)
         return out.astype(result_type)
     elif method == "direct":
-        # fastpath to faster numpy.convolve for 1d inputs when possible
-        if _np_conv_ok(volume, kernel, mode):
-            return _signaltools._convolve(volume, kernel, 1, mode)
-            # return cp.asarray(
-            #     np.convolve(cp.asnumpy(volume), cp.asnumpy(kernel), mode)
-            # )
 
-        return correlate(volume, _reverse_and_conj(kernel), mode, "direct")
+        swapped_inputs = (
+            (mode != "valid")
+            and (kernel.size > volume.size)
+        )
+
+        if swapped_inputs:
+            volume, kernel = kernel, volume
+
+        return _signaltools._convolve(
+            volume, kernel, True, swapped_inputs, mode
+        )
+
     else:
         raise ValueError(
             "Acceptable method flags are 'auto'," " 'direct', or 'fft'."

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -67,29 +67,39 @@ def test_firwin(num_samps, f1, f2):
 
 
 @pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
-def test_correlate(num_samps, num_taps, mode="same"):
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
+def test_correlate(num_samps, num_taps, mode, method):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
-    cpu_corr = signal.correlate(cpu_sig, np.ones(num_taps), mode=mode)
+    cpu_corr = signal.correlate(
+        cpu_sig, np.ones(num_taps), mode=mode, method=method
+    )
     gpu_corr = cp.asnumpy(
-        cusignal.correlate(gpu_sig, cp.ones(num_taps), mode=mode)
+        cusignal.correlate(
+            gpu_sig, cp.ones(num_taps), mode=mode, method=method
+        )
     )
     assert array_equal(cpu_corr, gpu_corr)
 
 
 @pytest.mark.parametrize("num_samps", [2 ** 15])
-@pytest.mark.parametrize("num_taps", [128, 2 ** 8, 2 ** 15])
-def test_convolve(num_samps, num_taps, mode="same"):
+@pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 15])
+@pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
+def test_convolve(num_samps, num_taps, mode, method):
     cpu_sig = np.random.rand(num_samps)
     cpu_win = signal.windows.hann(num_taps)
 
     gpu_sig = cp.asarray(cpu_sig)
     gpu_win = cusignal.windows.hann(num_taps)
 
-    cpu_conv = signal.convolve(cpu_sig, cpu_win, mode=mode)
-    gpu_conv = cp.asnumpy(cusignal.convolve(gpu_sig, gpu_win, mode=mode))
+    cpu_conv = signal.convolve(cpu_sig, cpu_win, mode=mode, method=method)
+    gpu_conv = cp.asnumpy(
+        cusignal.convolve(gpu_sig, gpu_win, mode=mode, method=method)
+    )
     assert array_equal(cpu_conv, gpu_conv)
 
 
@@ -187,16 +197,17 @@ def test_correlate2d(num_samps, num_taps, boundary, mode, use_numba):
     assert array_equal(cpu_correlate2d, gpu_correlate2d)
 
 
-@pytest.mark.parametrize('num_samps', [2**14])
-@pytest.mark.parametrize('downsample_factor', [2, 3, 4, 8, 64])
-@pytest.mark.parametrize('zero_phase', [True, False])
+@pytest.mark.parametrize("num_samps", [2 ** 14])
+@pytest.mark.parametrize("downsample_factor", [2, 3, 4, 8, 64])
+@pytest.mark.parametrize("zero_phase", [True, False])
 def test_decimate(num_samps, downsample_factor, zero_phase):
     cpu_time = np.linspace(0, 10, num_samps, endpoint=False)
-    cpu_sig = np.cos(-cpu_time ** 2 / 6.0)
+    cpu_sig = np.cos(-(cpu_time ** 2) / 6.0)
     gpu_sig = cp.asarray(cpu_sig)
 
-    cpu_decimate = signal.decimate(cpu_sig, downsample_factor,
-                                   ftype='fir', zero_phase=zero_phase)
+    cpu_decimate = signal.decimate(
+        cpu_sig, downsample_factor, ftype="fir", zero_phase=zero_phase
+    )
     gpu_decimate = cp.asnumpy(
         cusignal.decimate(gpu_sig, downsample_factor, zero_phase=zero_phase)
     )


### PR DESCRIPTION
### Info
This PR statifies feature request https://github.com/rapidsai/cusignal/issues/57, by adding 1D **correlate** and **convolve** to `_signaltools.py`. They are only implemented with CuPy kernels, not Numba. They are active when `method='direct'`

It also adds appropriate tests and benchmarks.

**This PR is not implemented on the framework introduced in PR https://github.com/rapidsai/cusignal/pull/56. This PR should be merged first!**

### Benchmarks
Benchmarks show speedups from **10x** - **890x**.
Notice that [direct-valid-32768-32768] provides the best time. Not sure what NumPy is doing, but investigation is need to determine if it is something we can implement as well.
```bash
------------------------------------------------------------------------------------------------------- benchmark 'Convolve': 54 tests -------------------------------------------------------------------------------------------------------
Name (time in us)                                        Min                     Max                   Mean                 StdDev                 Median                   IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_convolve_cpu[direct-valid-32768-32768]         19.5190 (1.0)          544.4290 (4.34)         20.7032 (1.0)           4.5724 (1.78)         19.9510 (1.0)          0.1980 (1.0)     2831;5832  48,301.6148 (1.0)       48184           1
bench_convolve_gpu[direct-same-128-32768]            71.7730 (3.68)      25,757.7850 (205.52)       80.5012 (3.89)        226.1544 (88.27)        74.0310 (3.71)         1.3285 (6.71)      10;1975  12,422.1772 (0.26)      13851           1
bench_convolve_gpu[direct-same-256-32768]            72.6510 (3.72)         125.3270 (1.0)          75.2440 (3.63)          2.5621 (1.0)          74.7820 (3.75)         0.9910 (5.01)      639;807  13,290.0946 (0.28)      13510           1
bench_convolve_gpu[direct-same-32768-32768]          73.3970 (3.76)      56,916.3840 (454.14)    4,892.1529 (236.30)    1,421.0731 (554.66)    4,924.1260 (246.81)      85.4342 (431.50)   535;1199     204.4090 (0.00)      13465           1
bench_convolve_gpu[direct-full-128-32768]            73.8240 (3.78)       8,212.6740 (65.53)        82.1504 (3.97)         88.4081 (34.51)        75.9750 (3.81)         1.3088 (6.61)      32;2020  12,172.7965 (0.25)      13027           1
bench_convolve_gpu[direct-full-256-32768]            74.3840 (3.81)         158.6200 (1.27)         77.7072 (3.75)          4.4513 (1.74)         76.8890 (3.85)         0.9670 (4.88)      548;961  12,868.8220 (0.27)      13238           1
bench_convolve_gpu[direct-full-32768-32768]          74.9600 (3.84)      62,150.6220 (495.91)    9,467.6260 (457.30)    2,274.4338 (887.73)    9,768.6610 (489.63)     489.6252 (>1000.0)   567;640     105.6231 (0.00)      13105           1
bench_convolve_gpu[direct-valid-128-32768]           75.1690 (3.85)      25,324.4350 (202.07)       85.5132 (4.13)        257.7155 (100.59)       77.1340 (3.87)         1.1018 (5.56)      10;1726  11,694.0963 (0.24)      13091           1
bench_convolve_gpu[direct-valid-256-32768]           75.7140 (3.88)         193.4150 (1.54)         78.1216 (3.77)          3.0269 (1.18)         77.8160 (3.90)         0.8900 (4.50)      324;585  12,800.5647 (0.27)      12935           1
bench_convolve_gpu[direct-valid-32768-32768]         76.0830 (3.90)      43,851.0890 (349.89)    1,190.7790 (57.52)       770.4226 (300.70)    1,200.7500 (60.18)        9.5830 (48.40)    564;3063     839.7864 (0.02)      13110           1
bench_convolve_cpu[direct-full-128-32768]           770.9510 (39.50)      1,174.3700 (9.37)        774.7226 (37.42)        13.5172 (5.28)        772.8400 (38.74)        2.3535 (11.89)      14;132   1,290.7846 (0.03)       1283           1
bench_convolve_cpu[direct-valid-128-32768]          812.7830 (41.64)     10,289.4120 (82.10)       899.2819 (43.44)       464.0750 (181.13)      819.4600 (41.07)        9.3855 (47.40)      60;220   1,111.9983 (0.02)       1231           1
bench_convolve_cpu[direct-same-128-32768]           814.6270 (41.74)      5,712.7550 (45.58)       882.5774 (42.63)       311.1694 (121.45)      817.8875 (40.99)       11.0415 (55.77)      77;185   1,133.0450 (0.02)       1232           1
bench_convolve_cpu[direct-valid-256-32768]        1,040.7870 (53.32)      5,811.8060 (46.37)     1,152.3040 (55.66)       305.4505 (119.22)    1,087.3775 (54.50)       85.0970 (429.80)      53;57     867.8265 (0.02)        942           1
bench_convolve_cpu[direct-same-256-32768]         1,046.7450 (53.63)      1,850.5980 (14.77)     1,128.5300 (54.51)        47.1762 (18.41)     1,143.2285 (57.30)        2.5390 (12.82)     187;247     886.1085 (0.02)        878           1
bench_convolve_cpu[direct-full-256-32768]         1,052.2960 (53.91)     12,119.2810 (96.70)     1,206.7463 (58.29)       456.0604 (178.00)    1,149.7900 (57.63)       92.4052 (466.71)      44;74     828.6746 (0.02)        863           1
bench_convolve_cpu[direct-same-32768-32768]      42,779.8850 (>1000.0)   44,761.0730 (357.15)   43,196.8897 (>1000.0)     439.4461 (171.52)   43,027.3470 (>1000.0)    363.1223 (>1000.0)       2;2      23.1498 (0.00)         25           1
bench_convolve_cpu[direct-full-32768-32768]      67,935.4310 (>1000.0)  196,794.0850 (>1000.0)  77,206.4692 (>1000.0)  26,228.4376 (>1000.0)  69,260.7580 (>1000.0)  1,635.1098 (>1000.0)       1;5      12.9523 (0.00)         25           1
```