### PR TITLE
[REVIEW] Added warning for Numba kernel deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #55 - Update notebooks to use timeit instead of time
 - PR #56 - Ability to precompile select Numba/CuPy kernel on import
 - PR #60 - Updated decimate function to use an existing FIR window
+- PR #65 - Added deprecation warning for Numba kernels
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -14,6 +14,7 @@
 import cupy as cp
 import itertools
 import numpy as np
+import warnings
 
 from enum import Enum
 from math import gcd
@@ -37,6 +38,9 @@ except ImportError:
     from numba.core.types.scalars import Complex
 
 from .fir_filter_design import firwin
+
+# Display FutureWarnings only once per module
+warnings.simplefilter("once", FutureWarning)
 
 
 class GPUKernel(Enum):
@@ -589,6 +593,12 @@ def _get_backend_kernel(
             )
 
     else:
+        warnings.warn(
+            "Numba kernels will be removed in a later release",
+            FutureWarning,
+            stacklevel=4,
+        )
+
         nb_stream = stream_cupy_to_numba(stream)
         kernel = _numba_kernel_cache[(dtype.name, k_type)]
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -14,6 +14,7 @@
 import cupy as cp
 import itertools
 import numpy as np
+import warnings
 
 from enum import Enum
 from math import sin, cos, atan2
@@ -23,6 +24,9 @@ from numba import (
     void,
 )
 from string import Template
+
+# Display FutureWarnings only once per module
+warnings.simplefilter("once", FutureWarning)
 
 
 class GPUKernel(Enum):
@@ -276,6 +280,12 @@ def _get_backend_kernel(dtype, grid, block, stream, use_numba, k_type):
             )
 
     else:
+        warnings.warn(
+            "Numba kernels will be removed in a later release",
+            FutureWarning,
+            stacklevel=4,
+        )
+
         nb_stream = stream_cupy_to_numba(stream)
         kernel = _numba_kernel_cache[(dtype.name, k_type)]
 

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -28,6 +28,9 @@ except ImportError:
     # Numba >= 0.49
     from numba.core.types.scalars import Complex
 
+# Display FutureWarnings only once per module
+warnings.simplefilter("once", FutureWarning)
+
 
 class GPUKernel(Enum):
     UPFIRDN = 0
@@ -281,9 +284,10 @@ def _get_backend_kernel(dtype, grid, block, stream, use_numba, k_type):
 
     if k_type == GPUKernel.UPFIRDN2D and not use_numba:
         warnings.warn(
-            "CuPy backend is only implemented for ndim == 1 \
-                Running with Numba CUDA backend",
+            """CuPy backend is only implemented for ndim == 1:
+            ***Running with Numba CUDA backend***""",
             UserWarning,
+            stacklevel=4,
         )
         use_numba = True
 
@@ -297,6 +301,12 @@ def _get_backend_kernel(dtype, grid, block, stream, use_numba, k_type):
             )
 
     else:
+        warnings.warn(
+            "Numba kernels will be removed in a later release",
+            FutureWarning,
+            stacklevel=4,
+        )
+
         nb_stream = stream_cupy_to_numba(stream)
         kernel = _numba_kernel_cache[(dtype.name, k_type)]
         if kernel:
@@ -336,9 +346,10 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
 
     if k_type == GPUKernel.UPFIRDN2D and not use_numba:
         warnings.warn(
-            "CuPy backend is only implemented for ndim == 1 \
-                Running with Numba CUDA backend",
+            """CuPy backend is only implemented for ndim == 1:
+            ***Running with Numba CUDA backend***""",
             UserWarning,
+            stacklevel=4,
         )
         use_numba = True
 


### PR DESCRIPTION
### Info

This PR add deprecation warnings to Numba kernel selections.

Current message is 

> FutureWarning: Numba kernels will be removed in a later release

Also, this PR fixes the stack level for **upfirdn2d** warning to show proper warning location.

```bash
/home/belt/anaconda3/envs/cusignal/lib/python3.8/site-packages/cusignal-0.14.0a0+194.g9949e1d.dirty-py3.8.egg/cusignal/_upfirdn.py:348: UserWarning: CuPy backend is only implemented for ndim == 1                 Running with Numba CUDA backend
  warnings.warn(
```
changed to
```bash
upfirdn2d.py:61: UserWarning: CuPy backend is only implemented for ndim == 1:
            ***Running with Numba CUDA backend***
  gpu = cusignal.upfirdn(h, x, 2, 3, axis=axis)
```

### Example
```bash
upfirdn2d.py:31: FutureWarning: Numba kernels will be removed in a later release
  gpu = cusignal.upfirdn(h, x, 2, 3, axis=axis, use_numba=True)
```
and 
```bash
lomb.py:38: FutureWarning: Numba kernels will be removed in a later release
  cusignal.lombscargle(d_x, d_y, d_f, use_numba=True)
```
