### PR TITLE
[REVIEW] Fix Typo that Prevented Docs from Building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 
 - PR #52 - Mirror API change in Numba 0.49
+- PR #70 - Typo fix in docs api.rst that broke build
 
 # cuSignal 0.13 (31 Mar 2020)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -26,7 +26,7 @@ Filtering
 Resample
 ------------
 
-.. automodule::cusignal.filtering.resample
+.. automodule:: cusignal.filtering.resample
     :members:
     :undoc-members:
 
@@ -44,7 +44,7 @@ Filter Design
 Resample
 ------------
 
-.. automodule::cusignal.filter_design.fir_filter_design
+.. automodule:: cusignal.filter_design.fir_filter_design
     :members:
     :undoc-members:
 
@@ -55,7 +55,7 @@ Peak Finding
 Peak Finding
 ------------
 
-.. automodule::cusignal.peak_finding.peak_finding
+.. automodule:: cusignal.peak_finding.peak_finding
     :members:
     :undoc-members:
 


### PR DESCRIPTION
Hotfix to address various sections of the updated docs failing to build.