### PR TITLE
[REVIEW] cusignal.lfilter implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #65 - Added deprecation warning for Numba kernels
 - PR #67 - cuSignal code refactor and documentation update
 - PR #71 - README spelling and conda install fixes
+- PR #78 - Ported lfilter to CuPy Raw Kernel (only 1D functional)
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 

--- a/python/cusignal/_lfilter.py
+++ b/python/cusignal/_lfilter.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cupy as cp
+import itertools
+import numpy as np
+
+from enum import Enum
+from numba import (
+    cuda,
+    float32,
+    float64,
+)
+from string import Template
+
+
+class GPUKernel(Enum):
+    LFILTER = 0
+
+
+class GPUBackend(Enum):
+    CUPY = 0
+
+
+# Numba type supported and corresponding C type
+_SUPPORTED_TYPES = {
+    np.float32: [float32, "float"],
+    np.float64: [float64, "double"],
+}
+
+_cupy_kernel_cache = {}
+
+
+# Use until functionality provided in Numba 0.49/0.50 available
+def stream_cupy_to_numba(cp_stream):
+    """
+    Notes:
+        1. The lifetime of the returned Numba stream should be as
+           long as the CuPy one, which handles the deallocation
+           of the underlying CUDA stream.
+        2. The returned Numba stream is assumed to live in the same
+           CUDA context as the CuPy one.
+        3. The implementation here closely follows that of
+           cuda.stream() in Numba.
+    """
+    from ctypes import c_void_p
+    import weakref
+
+    # get the pointer to actual CUDA stream
+    raw_str = cp_stream.ptr
+
+    # gather necessary ingredients
+    ctx = cuda.devices.get_context()
+    handle = c_void_p(raw_str)
+
+    # create a Numba stream
+    nb_stream = cuda.cudadrv.driver.Stream(
+        weakref.proxy(ctx), handle, finalizer=None
+    )
+
+    return nb_stream
+
+
+# Custom Cupy raw kernel implementing upsample, filter, downsample operation
+# Matthew Nicely - mnicely@nvidia.com
+loaded_from_source = Template(
+    """
+extern "C" {
+    __global__ void _cupy_lfilter(
+            const int x_len,
+            const int a_len,
+            const ${datatype} * __restrict__ x,
+            const ${datatype} * __restrict__ a,
+            const ${datatype} * __restrict__ b,
+            ${datatype} * __restrict__ out) {
+
+        for ( int tid = 0; tid < x_len; tid++) {
+
+            ${datatype} isw {};
+            ${datatype} wos {};
+
+            // Create input_signal_windows
+            if( tid > ( a_len ) ) {
+                for ( int i = 0; i < a_len; i++ ) {
+                    isw += x[tid - i] * b[i];
+                    wos += out[tid - i] * a[i];
+                }
+            } else {
+                for ( int i = 0; i <= tid; i++ ) {
+                    isw += x[tid - i] * b[i];
+                    wos += out[tid - i] * a[i];
+                }
+            }
+
+            isw -= wos;
+
+            out[tid] = isw / a[0];
+        }
+    }
+}
+"""
+)
+
+
+class _cupy_lfilter_wrapper(object):
+    def __init__(self, grid, block, stream, kernel):
+        if isinstance(grid, int):
+            grid = (grid,)
+        if isinstance(block, int):
+            block = (block,)
+
+        self.grid = grid
+        self.block = block
+        self.stream = stream
+        self.kernel = kernel
+
+    def __call__(self, b, a, x, out):
+
+        kernel_args = (
+            x.shape[0],
+            a.shape[0],
+            x,
+            a,
+            b,
+            out,
+        )
+
+        self.stream.use()
+        self.kernel(self.grid, self.block, kernel_args)
+
+
+def _get_backend_kernel(
+    dtype, grid, block, stream, use_numba, k_type,
+):
+
+    if not use_numba:
+        kernel = _cupy_kernel_cache[(dtype.name, k_type)]
+        if kernel:
+            if k_type == GPUKernel.LFILTER:
+                return _cupy_lfilter_wrapper(grid, block, stream, kernel)
+            else:
+                raise NotImplementedError(
+                    "No CuPY kernel found for k_type {}, datatype {}".format(
+                        k_type, dtype
+                    )
+                )
+        else:
+            raise ValueError(
+                "Kernel {} not found in _cupy_kernel_cache".format(k_type)
+            )
+
+    raise NotImplementedError(
+        "No kernel found for k_type {}, datatype {}".format(k_type, dtype.name)
+    )
+
+
+def _populate_kernel_cache(np_type, use_numba, k_type):
+
+    # Check in np_type is a supported option
+    try:
+        numba_type, c_type = _SUPPORTED_TYPES[np_type]
+
+    except ValueError:
+        raise ValueError("No kernel found for datatype {}".format(np_type))
+
+    # Check if use_numba is support
+    try:
+        GPUBackend(use_numba)
+
+    except ValueError:
+        raise
+
+    # Check if use_numba is support
+    try:
+        GPUKernel(k_type)
+
+    except ValueError:
+        raise
+
+    if not use_numba:
+        if (str(numba_type), k_type) in _cupy_kernel_cache:
+            return
+        # Instantiate the cupy kernel for this type and compile
+        src = loaded_from_source.substitute(datatype=c_type)
+        module = cp.RawModule(
+            code=src, options=("-std=c++11", "-use_fast_math")
+        )
+        if k_type == GPUKernel.LFILTER:
+            _cupy_kernel_cache[
+                (str(numba_type), GPUKernel.LFILTER)
+            ] = module.get_function("_cupy_lfilter")
+        else:
+            raise NotImplementedError(
+                "No kernel found for k_type {}, datatype {}".format(
+                    k_type, str(numba_type)
+                )
+            )
+    else:
+        raise NotImplementedError(
+            "Numba kernel not implemented for k_type {}".format(k_type)
+        )
+
+
+def precompile_kernels(dtype=None, backend=None, k_type=None):
+    r"""
+    Precompile GPU kernels for later use.
+
+    Parameters
+    ----------
+    dtype : numpy datatype or list of datatypes, optional
+        Data types for which kernels should be precompiled. If not
+        specified, all supported data types will be precompiled.
+        Specific to this unit
+            np.float32
+            np.float64
+    backend : GPUBackend, optional
+        Which GPU backend to precompile for. If not specified,
+        all supported backends will be precompiled.
+        Specific to this unit
+            GPUBackend.CUPY
+    k_type : GPUKernel, optional
+        Which GPU kernel to compile for. If not specified,
+        all supported kernels will be precompiled.
+        Specific to this unit
+            GPUKernel.LFILTER
+        Examples
+    ----------
+    To precompile all kernels in this unit
+    >>> import cusignal
+    >>> from cusignal._upfirdn import GPUBackend, GPUKernel
+    >>> cusignal._signaltools.precompile_kernels()
+
+    To precompile a specific NumPy datatype, CuPy backend, and kernel type
+    >>> cusignal._signaltools.precompile_kernels( [np.float64],
+        [GPUBackend.CUPY], [GPUKernel.LFILTER],)
+
+
+    To precompile a specific NumPy datatype and kernel type,
+    but both Numba and CuPY variations
+    >>> cusignal._signaltools.precompile_kernels( dtype=[np.float64],
+        k_type=[GPUKernel.LFILTER],)
+    """
+    if dtype is not None and not hasattr(dtype, "__iter__"):
+        raise TypeError(
+            "dtype ({}) should be in list - e.g [np.float32,]".format(dtype)
+        )
+
+    elif backend is not None and not hasattr(backend, "__iter__"):
+        raise TypeError(
+            "backend ({}) should be in list - e.g [{},]".format(
+                backend, backend
+            )
+        )
+    elif k_type is not None and not hasattr(k_type, "__iter__"):
+        raise TypeError(
+            "k_type ({}) should be in list - e.g [{},]".format(k_type, k_type)
+        )
+    else:
+        dtype = list(dtype) if dtype else _SUPPORTED_TYPES.keys()
+        backend = list(backend) if backend else list(GPUBackend)
+        k_type = list(k_type) if k_type else list(GPUKernel)
+
+        for d, b, k in itertools.product(dtype, backend, k_type):
+            _populate_kernel_cache(d, b, k)
+
+
+def _lfilter_gpu(b, a, x, clamp, cp_stream):
+
+    out = cp.zeros_like(x)
+
+    threadsperblock = 1
+    blockspergrid = 1
+
+    _populate_kernel_cache(out.dtype.type, False, GPUKernel.LFILTER)
+    kernel = _get_backend_kernel(
+        out.dtype,
+        blockspergrid,
+        threadsperblock,
+        cp_stream,
+        False,
+        GPUKernel.LFILTER,
+    )
+
+    kernel(b, a, x, out)
+
+    # Turn on in a different PR
+    # cp_stream.synchronize()
+
+    return out

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -221,7 +221,7 @@ class BenchFirWin:
 @pytest.mark.parametrize("num_samps", [2 ** 7, 2 ** 10 + 1, 2 ** 13])
 @pytest.mark.parametrize("num_taps", [125, 2 ** 8, 2 ** 13])
 @pytest.mark.parametrize("mode", ["full", "valid", "same"])
-@pytest.mark.parametrize("method", ["fft", "auto"])
+@pytest.mark.parametrize("method", ["direct", "fft", "auto"])
 class BenchCorrelate:
     def cpu_version(self, cpu_sig, num_taps, mode, method):
         return signal.correlate(cpu_sig, num_taps, mode=mode, method=method)

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -322,6 +322,35 @@ class BenchWiener:
         assert array_equal(cp.asnumpy(output), key)
 
 
+@pytest.mark.benchmark(group="Lfilter")
+@pytest.mark.parametrize("num_samps", [2 ** 16])
+class BenchLfilter:
+    def cpu_version(self, b, a, cpu_sig):
+        return signal.lfilter(b, a, cpu_sig)
+
+    def bench_lfilter_cpu(self, rand_data_gen, benchmark, num_samps):
+        cpu_sig = np.arange(num_samps) / num_samps
+        a = [1.0, 0.25, 0.5]
+        b = [1.0, 0.0, 0.0]
+
+        benchmark(self.cpu_version, b, a, cpu_sig)
+
+    def bench_lfilter_gpu(self, rand_data_gen, benchmark, num_samps):
+
+        cpu_sig = np.arange(num_samps) / num_samps
+        a = [1.0, 0.25, 0.5]
+        b = [1.0, 0.0, 0.0]
+
+        gpu_sig = cp.asarray(cpu_sig)
+        d_a = cp.asarray(a)
+        d_b = cp.asarray(b)
+
+        output = benchmark(cusignal.lfilter, d_b, d_a, gpu_sig)
+
+        key = self.cpu_version(b, a, cpu_sig)
+        assert array_equal(cp.asnumpy(output), key)
+
+
 @pytest.mark.benchmark(group="Hilbert")
 @pytest.mark.parametrize("num_samps", [2 ** 15])
 class BenchHilbert:

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -191,8 +191,13 @@ def lfilter(
     a = cp.asarray(a)
     b = cp.asarray(b)
 
-    assert a.shape[0] == b.shape[0]
-    assert len(x.shape) == 1
+    if a.shape[0] != b.shape[0] or len(a.shape) > 1 or len(b.shape) > 1:
+        raise ValueError("Inputs a and b must both be 1D arrays")
+
+    if len(x.shape) != 1:
+        raise NotImplementedError(
+            "Only functionality for 1D arrays are implemented at the moment"
+        )
 
     out = _lfilter_gpu(b, a, x, clamp, cp_stream)
 

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -41,6 +41,7 @@ from cupy import linalg
 import numpy as np
 
 from ..convolution.correlate import correlate
+from .._lfilter import _lfilter_gpu
 
 
 def wiener(im, mysize=None, noise=None):
@@ -165,10 +166,11 @@ def lfiltic(b, a, y, x=None):
     return zi
 
 
-def lfilter(b, a, x):
+def lfilter(
+    b, a, x, clamp=False, cp_stream=cp.cuda.stream.Stream(null=True),
+):
     """
     Perform an IIR filter by evaluating difference equation.
-
     Parameters
     ----------
     b : array_like
@@ -183,54 +185,18 @@ def lfilter(b, a, x):
     -------
     y : array
         The output of the digital filter. Output will be clipped to -1 to 1.
-
     """
-    # pack batch
-    shape = x.shape
-    x = x.reshape(-1, shape[-1])
 
-    assert (a.shape[0] == b.shape[0])
-    assert (len(x.shape) == 2)
+    x = cp.asarray(x)
+    a = cp.asarray(a)
+    b = cp.asarray(b)
 
-    dtype = x.dtype
-    n_channel, n_sample = x.shape
-    n_order = a.shape[0]
-    n_sample_padded = n_sample + n_order - 1
-    assert (n_order > 0)
+    assert a.shape[0] == b.shape[0]
+    assert len(x.shape) == 1
 
-    # Pad the input and create output
-    padded_x = cp.zeros((n_channel, n_sample_padded), dtype=dtype)
-    padded_x[:, (n_order - 1):] = x
-    padded_output_x = cp.zeros((n_channel, n_sample_padded), dtype=dtype)
+    out = _lfilter_gpu(b, a, x, clamp, cp_stream)
 
-    # Set up the coefficients matrix
-    # Flip coefficients' order
-    a_flipped = cp.flip(a, 0)
-    b_flipped = cp.flip(b, 0)
-
-    # calculate windowed_input_signal in parallel
-    # create indices of original with shape (n_channel, n_order, n_sample)
-    window_idxs = cp.expand_dims(
-        cp.arange(n_sample), 0) + cp.expand_dims(cp.arange(n_order), 1)
-    window_idxs = cp.tile(window_idxs, (n_channel, 1, 1))
-    window_idxs += (
-        cp.expand_dims(cp.expand_dims(cp.arange(n_channel), -1), -1) *
-        n_sample_padded
-    )
-    input_signal_windows = cp.matmul(b_flipped, cp.take(padded_x, window_idxs))
-
-    for i, o0 in enumerate(input_signal_windows[0, :]):
-        windowed_output_signal = padded_output_x[:, i:(i + n_order)]
-        o0 = cp.subtract(o0, windowed_output_signal.dot(a_flipped))
-        o0 = cp.divide(o0, a[0])
-        padded_output_x[:, i + n_order - 1] = o0
-
-    output = cp.clip(padded_output_x[:, (n_order - 1):], a_min=-1., a_max=1.)
-
-    # unpack batch
-    output = output.reshape(shape[:-1] + output.shape[-1:])
-
-    return output
+    return out
 
 
 def hilbert(x, N=None, axis=-1):

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -161,6 +161,22 @@ def test_wiener(num_samps):
     assert array_equal(cpu_wfilt, gpu_wfilt)
 
 
+@pytest.mark.parametrize("num_samps", [2 ** 8])
+def test_lfilter(num_samps):
+    cpu_sig = np.arange(num_samps) / num_samps
+    gpu_sig = cp.asarray(cpu_sig)
+
+    a = [1.0, 0.25, 0.5]
+    b = [1.0, 0.0, 0.0]
+
+    d_a = cp.asarray(a)
+    d_b = cp.asarray(b)
+
+    cpu_lfilter = signal.lfilter(b, a, cpu_sig)
+    gpu_lfilter = cp.asnumpy(cusignal.lfilter(d_b, d_a, gpu_sig, ))
+    assert array_equal(cpu_lfilter, gpu_lfilter)
+
+
 @pytest.mark.parametrize("num_samps", [2 ** 15])
 def test_hilbert(num_samps):
     cpu_sig = np.random.rand(num_samps)


### PR DESCRIPTION
This PR ports @luigifreitas lfilter implementation to a CuPy raw kernel

Pre-CuPy 
```bash
---------------------------------------------------------------------------------------------------- benchmark 'Lfilter': 2 tests ----------------------------------------------------------------------------------------------------
Name (time in us)                       Min                       Max                      Mean                 StdDev                    Median                     IQR            Outliers         OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_lfilter_cpu[65536]           248.5420 (1.0)          6,068.0390 (1.0)            265.2118 (1.0)         190.6781 (1.0)            248.9720 (1.0)            1.0130 (1.0)        22;763  3,770.5708 (1.0)        4016           1
bench_lfilter_gpu[65536]     3,148,112.2440 (>1000.0)  3,390,779.5800 (558.79)   3,260,895.4035 (>1000.0)  68,649.6840 (360.03)   3,273,964.9520 (>1000.0)  105,369.7988 (>1000.0)      10;0      0.3067 (0.00)         25           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Post-CuPy
```bash
----------------------------------------------------------------------------------------- benchmark 'Lfilter': 2 tests -----------------------------------------------------------------------------------------
Name (time in us)                    Min                    Max                   Mean             StdDev                 Median               IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_lfilter_cpu[65536]        248.9730 (1.0)         288.7730 (1.0)         249.8220 (1.0)       2.3228 (1.0)         249.3310 (1.0)      0.2702 (1.0)       188;485  4,002.8505 (1.0)        4009           1
bench_lfilter_gpu[65536]     29,370.4790 (117.97)   29,456.6140 (102.01)   29,384.6633 (117.62)   19.3389 (8.33)     29,377.8030 (117.83)   8.2640 (30.58)         3;3     34.0314 (0.01)         34           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

It is still much slower than the sciPy.signal CPU version but this was all the code can stay on the GPU.