### PR TITLE
[REVIEW] Autosync functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #66 - Add CuPy Module for 2d upfirdn, along with tests/benchmarks
 - PR #73 - Local gpuCI build script
 - PR #75 - Add accelerated `lfilter` method.
+- PR #82 - Implement `autosync` to synchronize raw kernels by default
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.

--- a/python/cusignal/_lfilter.py
+++ b/python/cusignal/_lfilter.py
@@ -274,7 +274,7 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
             _populate_kernel_cache(d, b, k)
 
 
-def _lfilter_gpu(b, a, x, clamp, cp_stream):
+def _lfilter_gpu(b, a, x, clamp, cp_stream, autosync):
 
     out = cp.zeros_like(x)
 
@@ -293,7 +293,7 @@ def _lfilter_gpu(b, a, x, clamp, cp_stream):
 
     kernel(b, a, x, out)
 
-    # Turn on in a different PR
-    # cp_stream.synchronize()
+    if autosync is True:
+        cp_stream.synchronize()
 
     return out

--- a/python/cusignal/_signaltools.py
+++ b/python/cusignal/_signaltools.py
@@ -932,7 +932,8 @@ def _convolve(
     use_convolve,
     swapped_inputs,
     mode,
-    cp_stream=cp.cuda.stream.Stream(null=True),
+    cp_stream,
+    autosync,
 ):
 
     val = _valfrommode(mode)
@@ -972,8 +973,11 @@ def _convolve(
     out = cp.empty(out_dimens.tolist(), in1.dtype)
 
     out = _convolve_gpu(
-        in1, out, in2, val, use_convolve, swapped_inputs, cp_stream=cp_stream,
+        in1, out, in2, val, use_convolve, swapped_inputs, cp_stream,
     )
+
+    if autosync is True:
+        cp_stream.synchronize()
 
     return out
 
@@ -982,11 +986,12 @@ def _convolve2d(
     in1,
     in2,
     use_convolve,
-    mode="full",
-    boundary="fill",
-    fillvalue=0,
-    cp_stream=cp.cuda.stream.Stream(null=True),
-    use_numba=False,
+    mode,
+    boundary,
+    fillvalue,
+    cp_stream,
+    autosync,
+    use_numba,
 ):
 
     val = _valfrommode(mode)
@@ -1045,9 +1050,12 @@ def _convolve2d(
         bval,
         use_convolve,
         fill,
-        cp_stream=cp_stream,
-        use_numba=use_numba,
+        cp_stream,
+        use_numba,
     )
+
+    if autosync is True:
+        cp_stream.synchronize()
 
     return out
 

--- a/python/cusignal/_spectral.py
+++ b/python/cusignal/_spectral.py
@@ -425,7 +425,7 @@ def precompile_kernels(dtype=None, backend=None, k_type=None):
             _populate_kernel_cache(d, b, k)
 
 
-def _lombscargle(x, y, freqs, pgram, y_dot, cp_stream, use_numba):
+def _lombscargle(x, y, freqs, pgram, y_dot, cp_stream, autosync, use_numba):
 
     device_id = cp.cuda.Device()
     numSM = device_id.attributes["MultiProcessorCount"]
@@ -444,3 +444,6 @@ def _lombscargle(x, y, freqs, pgram, y_dot, cp_stream, use_numba):
     )
 
     kernel(x, y, freqs, pgram, y_dot)
+
+    if autosync is True:
+        cp_stream.synchronize()

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -578,8 +578,9 @@ class _UpFIRDn(object):
         self,
         x,
         axis=-1,
-        cp_stream=cp.cuda.stream.Stream(null=True),
-        use_numba=False,
+        cp_stream,
+        autosync,
+        use_numba,
     ):
         """Apply the prepared filter to the specified axis of a nD signal x"""
 
@@ -637,5 +638,8 @@ class _UpFIRDn(object):
             padded_len,
             out,
         )
+
+        if autosync is True:
+            cp_stream.synchronize()
 
         return out

--- a/python/cusignal/_upfirdn.py
+++ b/python/cusignal/_upfirdn.py
@@ -577,7 +577,7 @@ class _UpFIRDn(object):
     def apply_filter(
         self,
         x,
-        axis=-1,
+        axis,
         cp_stream,
         autosync,
         use_numba,

--- a/python/cusignal/convolution/__init__.py
+++ b/python/cusignal/convolution/__init__.py
@@ -15,9 +15,6 @@ from cusignal.convolution.convolve import (
     convolve,
     fftconvolve,
     convolve2d,
-    choose_conv_method
+    choose_conv_method,
 )
-from cusignal.convolution.correlate import (
-    correlate,
-    correlate2d
-)
+from cusignal.convolution.correlate import correlate, correlate2d

--- a/python/cusignal/convolution/correlate.py
+++ b/python/cusignal/convolution/correlate.py
@@ -20,7 +20,14 @@ from .. import _signaltools
 _modedict = {"valid": 0, "same": 1, "full": 2}
 
 
-def correlate(in1, in2, mode="full", method="auto"):
+def correlate(
+    in1,
+    in2,
+    mode="full",
+    method="auto",
+    cp_stream=cp.cuda.stream.Stream(null=True),
+    autosync=True,
+):
     r"""
     Cross-correlate two N-dimensional arrays.
 
@@ -58,6 +65,17 @@ def correlate(in1, in2, mode="full", method="auto"):
         ``auto``
            Automatically chooses direct or Fourier method based on an estimate
            of which is faster (default).  See `convolve` Notes for more detail.
+    cp_stream : CuPy stream, optional
+        Option allows upfirdn to run in a non-default stream. The use
+        of multiple non-default streams allow multiple kernels to
+        run concurrently. Default is cp.cuda.stream.Stream(null=True)
+        or default stream.
+    autosync : bool, optional
+        Option to automatically synchronize cp_stream. This will block
+        the host code until kernel is finished on the GPU. Setting to
+        false will allow asynchronous operation but might required
+        manual synchronize later `cp_stream.synchronize()`
+        Default is True.
 
     Returns
     -------
@@ -144,7 +162,9 @@ def correlate(in1, in2, mode="full", method="auto"):
         if swapped_inputs:
             in1, in2 = in2, in1
 
-        return _signaltools._convolve(in1, in2, False, swapped_inputs, mode)
+        return _signaltools._convolve(
+            in1, in2, False, swapped_inputs, mode, cp_stream, autosync
+        )
 
     else:
         raise ValueError(
@@ -159,6 +179,7 @@ def correlate2d(
     boundary="fill",
     fillvalue=0,
     cp_stream=cp.cuda.stream.Stream(null=True),
+    autosync=True,
     use_numba=False,
 ):
     """
@@ -193,6 +214,21 @@ def correlate2d(
            symmetrical boundary conditions.
     fillvalue : scalar, optional
         Value to fill pad input arrays with. Default is 0.
+    cp_stream : CuPy stream, optional
+        Option allows upfirdn to run in a non-default stream. The use
+        of multiple non-default streams allow multiple kernels to
+        run concurrently. Default is cp.cuda.stream.Stream(null=True)
+        or default stream.
+    autosync : bool, optional
+        Option to automatically synchronize cp_stream. This will block
+        the host code until kernel is finished on the GPU. Setting to
+        false will allow asynchronous operation but might required
+        manual synchronize later `cp_stream.synchronize()`
+        Default is true.
+    use_numba : bool, optional
+        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
+        can yield performance gains over Numba. Default is False.
+
     Returns
     -------
     correlate2d : ndarray
@@ -244,8 +280,9 @@ def correlate2d(
         mode,
         boundary,
         fillvalue,
-        cp_stream=cp_stream,
-        use_numba=use_numba,
+        cp_stream,
+        autosync,
+        use_numba,
     )
 
     if swapped_inputs:

--- a/python/cusignal/filtering/__init__.py
+++ b/python/cusignal/filtering/__init__.py
@@ -15,7 +15,7 @@ from cusignal.filtering.resample import (
     decimate,
     resample,
     resample_poly,
-    upfirdn
+    upfirdn,
 )
 from cusignal.filtering.filtering import (
     wiener,
@@ -24,5 +24,5 @@ from cusignal.filtering.filtering import (
     hilbert,
     hilbert2,
     detrend,
-    freq_shift
+    freq_shift,
 )

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -197,7 +197,8 @@ def lfilter(
         Option to automatically synchronize cp_stream. This will block
         the host code until kernel is finished on the GPU. Setting to
         false will allow asynchronous operation but might required
-        manual synchronize later `cp_stream.synchronize()`
+        manual synchronize later `cp_stream.synchronize()`.
+        Default is True.
 
     Returns
     -------

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -167,7 +167,12 @@ def lfiltic(b, a, y, x=None):
 
 
 def lfilter(
-    b, a, x, clip=False, cp_stream=cp.cuda.stream.Stream(null=True),
+    b,
+    a,
+    x,
+    clip=False,
+    cp_stream=cp.cuda.stream.Stream(null=True),
+    autosync=True,
 ):
     """
     Perform an IIR filter by evaluating difference equation.
@@ -188,6 +193,11 @@ def lfilter(
         of multiple non-default streams allow multiple kernels to
         run concurrently. Default is cp.cuda.stream.Stream(null=True)
         or default stream.
+    autosync : bool, optional
+        Option to automatically synchronize cp_stream. This will block
+        the host code until kernel is finished on the GPU. Setting to
+        false will allow asynchronous operation but might required
+        manual synchronize later `cp_stream.synchronize()`
 
     Returns
     -------
@@ -219,7 +229,7 @@ def lfilter(
         else:
             b = cp.pad(b, (0, len_array - b.shape[0]))
 
-    out = _lfilter_gpu(b, a, x, clip, cp_stream)
+    out = _lfilter_gpu(b, a, x, clip, cp_stream, autosync)
 
     return out
 

--- a/python/cusignal/filtering/resample.py
+++ b/python/cusignal/filtering/resample.py
@@ -66,7 +66,8 @@ def decimate(
         Option to automatically synchronize cp_stream. This will block
         the host code until kernel is finished on the GPU. Setting to
         false will allow asynchronous operation but might required
-        manual synchronize later `cp_stream.synchronize()`
+        manual synchronize later `cp_stream.synchronize()`.
+        Default is True.
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
         can yield performance gains over Numba. Default is False.
@@ -281,7 +282,8 @@ def resample_poly(
         Option to automatically synchronize cp_stream. This will block
         the host code until kernel is finished on the GPU. Setting to
         false will allow asynchronous operation but might required
-        manual synchronize later `cp_stream.synchronize()`
+        manual synchronize later `cp_stream.synchronize()`.
+        Default is True.
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
         can yield performance gains over Numba. Default is False.
@@ -429,7 +431,8 @@ def upfirdn(
         Option to automatically synchronize cp_stream. This will block
         the host code until kernel is finished on the GPU. Setting to
         false will allow asynchronous operation but might required
-        manual synchronize later `cp_stream.synchronize()`
+        manual synchronize later `cp_stream.synchronize()`.
+        Default is True.
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
         can yield performance gains over Numba. Default is False.

--- a/python/cusignal/spectral_analysis/__init__.py
+++ b/python/cusignal/spectral_analysis/__init__.py
@@ -19,5 +19,5 @@ from cusignal.spectral_analysis.spectral import (
     spectrogram,
     lombscargle,
     vectorstrength,
-    stft
+    stft,
 )

--- a/python/cusignal/spectral_analysis/spectral.py
+++ b/python/cusignal/spectral_analysis/spectral.py
@@ -17,8 +17,13 @@ from cupyx.scipy import fftpack
 from scipy._lib.six import string_types
 
 from ..windows.windows import get_window
-from ..utils.arraytools import _even_ext, _odd_ext, _const_ext, \
-    _zero_ext, _as_strided
+from ..utils.arraytools import (
+    _even_ext,
+    _odd_ext,
+    _const_ext,
+    _zero_ext,
+    _as_strided,
+)
 from ..filtering import filtering
 from .._spectral import _lombscargle
 
@@ -32,6 +37,7 @@ def lombscargle(
     precenter=False,
     normalize=False,
     cp_stream=cp.cuda.stream.Stream(null=True),
+    autosync=True,
     use_numba=False,
 ):
     """
@@ -63,9 +69,16 @@ def lombscargle(
         of multiple non-default streams allow multiple kernels to
         run concurrently. Default is cp.cuda.stream.Stream(null=True)
         or default stream.
+    autosync : bool, optional
+        Option to automatically synchronize cp_stream. This will block
+        the host code until kernel is finished on the GPU. Setting to
+        false will allow asynchronous operation but might required
+        manual synchronize later `cp_stream.synchronize()`.
+        Default is True.
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
         can yield performance gains over Numba. Default is False.
+        
     Returns
     -------
     pgram : array_like
@@ -152,9 +165,7 @@ def lombscargle(
     else:
         y_in = y
 
-    _lombscargle(
-        x, y_in, freqs, pgram, y_dot, cp_stream=cp_stream, use_numba=use_numba
-    )
+    _lombscargle(x, y_in, freqs, pgram, y_dot, cp_stream, autosync, use_numba)
 
     return pgram
 

--- a/python/cusignal/spectral_analysis/spectral.py
+++ b/python/cusignal/spectral_analysis/spectral.py
@@ -78,7 +78,7 @@ def lombscargle(
     use_numba : bool, optional
         Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
         can yield performance gains over Numba. Default is False.
-        
+
     Returns
     -------
     pgram : array_like


### PR DESCRIPTION
### Info
This PR implements auto-synchronization for all CuPy/Numba kernels by default. This will clear up some usage confusion and fix a bug with our pytest-benchmark results.

The following parameter has been added to all public facing API calls.
`autosync=True,`

If the API call, before `return` the following lines have been added.
```python
if autosync is True:
            cp_stream.synchronize()
```

If `autosync=False` is passed, once the CuPy/Numba kernel has launched control flow will return to the host code. The device and host code can be sync manually with the following command
`cp_stream.synchronize()`, where `cp_stream = cp.cuda.stream.Stream(null=True)`.


The results can be verified with pytest-benchmarks. If we look at _lombscargle_gpu_ for example. Notice with `autosync` the min, mean, and median are similar which is the expected result.

Without `autosync`
```bash
--------------------------------------------------------------------------------------------------- benchmark 'LombScargle': 16 tests ----------------------------------------------------------------------------------------------------
Name (time in us)                                             Min                    Max                  Mean                StdDev                Median                 IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_lombscargle_gpu[False-False-False-65536-1024]       29.0040 (1.0)      60,552.9920 (4.17)     1,306.4112 (1.19)     1,035.0094 (1.94)     1,327.3770 (1.07)       1.4130 (1.0)     1734;6800  765.4558 (0.84)      32737           1
bench_lombscargle_gpu[False-False-False-262144-1024]      30.5440 (1.05)     71,671.9320 (4.94)     4,894.5441 (4.46)     1,867.6320 (3.50)     4,971.4130 (4.02)       3.8665 (2.74)    1549;6743  204.3091 (0.22)      31544           1
bench_lombscargle_gpu[False-False-True-262144-1024]       54.8640 (1.89)     75,747.2040 (5.22)     4,295.7632 (3.92)     1,878.9878 (3.52)     4,354.0960 (3.52)      10.5630 (7.48)     882;3070  232.7875 (0.26)      17946           1
bench_lombscargle_gpu[False-True-False-262144-1024]       54.8740 (1.89)     46,749.8370 (3.22)     4,545.3072 (4.14)     1,706.0800 (3.20)     4,695.3890 (3.80)       6.3492 (4.49)     678;1887  220.0071 (0.24)      10083           1
bench_lombscargle_gpu[False-False-True-65536-1024]        55.1400 (1.90)     50,641.4120 (3.49)     1,477.6661 (1.35)       955.8781 (1.79)     1,498.0345 (1.21)       6.2265 (4.41)     948;3753  676.7429 (0.74)      17728           1
bench_lombscargle_gpu[False-True-False-65536-1024]        55.4460 (1.91)     41,642.3120 (2.87)     1,369.6814 (1.25)       932.4071 (1.75)     1,395.9580 (1.13)       6.0865 (4.31)     958;3655  730.0968 (0.80)      17671           1
bench_lombscargle_gpu[False-True-True-262144-1024]        76.3550 (2.63)     63,184.4460 (4.35)     5,005.8925 (4.56)     1,910.8791 (3.58)     5,083.2480 (4.11)      11.9348 (8.45)     653;3032  199.7646 (0.22)      12839           1
bench_lombscargle_gpu[False-True-True-65536-1024]         77.4010 (2.67)     51,545.4830 (3.55)     1,389.5927 (1.27)       933.0846 (1.75)     1,414.0095 (1.14)       5.6780 (4.02)     673;2909  719.6353 (0.79)      12572           1
bench_lombscargle_gpu[True-False-False-65536-1024]       299.5020 (10.33)    22,033.4830 (1.52)     1,346.8570 (1.23)       770.9792 (1.44)     1,568.6510 (1.27)      89.4115 (63.28)     663;749  742.4693 (0.81)       3295           1
bench_lombscargle_gpu[True-False-False-262144-1024]      299.9300 (10.34)    52,087.5320 (3.59)     4,389.6949 (4.00)     2,466.7014 (4.62)     5,185.7550 (4.20)     188.5533 (133.44)    625;651  227.8063 (0.25)       3303           1
bench_lombscargle_gpu[True-False-True-262144-1024]       332.1950 (11.45)    52,757.2630 (3.63)     4,131.1226 (3.77)     2,118.4987 (3.97)     4,450.4380 (3.60)     143.1417 (101.30)    360;479  242.0650 (0.27)       2969           1
bench_lombscargle_gpu[True-True-False-262144-1024]       332.8850 (11.48)    64,878.2120 (4.47)     5,567.8879 (5.07)     2,874.1524 (5.38)     6,241.0980 (5.05)      15.4735 (10.95)     426;778  179.6013 (0.20)       2976           1
bench_lombscargle_gpu[True-False-True-65536-1024]        333.5900 (11.50)    14,522.8340 (1.0)      1,227.0133 (1.12)       547.0857 (1.02)     1,332.9010 (1.08)      20.9625 (14.84)     428;657  814.9871 (0.89)       2977           1
bench_lombscargle_gpu[True-True-False-65536-1024]        336.2960 (11.59)    33,349.0760 (2.30)     1,097.2405 (1.0)        710.3954 (1.33)     1,235.7990 (1.0)        8.9152 (6.31)      459;712  911.3772 (1.0)        2893           1
bench_lombscargle_gpu[True-True-True-262144-1024]        362.2860 (12.49)    47,625.6800 (3.28)     4,355.9161 (3.97)     1,904.9775 (3.57)     4,673.3630 (3.78)      36.5145 (25.84)     299;655  229.5728 (0.25)       2729           1
bench_lombscargle_gpu[True-True-True-65536-1024]         362.4220 (12.50)    16,473.5230 (1.13)     1,445.0991 (1.32)       533.8362 (1.0)      1,533.6070 (1.24)       9.0655 (6.42)      340;802  691.9940 (0.76)       2735           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

With `autosync`
```bash
----------------------------------------------------------------------------------------- benchmark 'LombScargle': 16 tests ------------------------------------------------------------------------------------------
Name (time in ms)                                           Min                Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_lombscargle_gpu[False-False-False-65536-1024]      1.0543 (1.0)       7.9080 (5.73)     1.0931 (1.0)      0.3341 (79.08)    1.0572 (1.0)      0.0075 (1.89)        6;124  914.8243 (1.0)         946           1
bench_lombscargle_gpu[False-True-False-65536-1024]       1.2226 (1.16)      8.3422 (6.04)     1.2737 (1.17)     0.2788 (66.00)    1.2253 (1.16)     0.0133 (3.34)        7;159  785.1344 (0.86)        816           1
bench_lombscargle_gpu[False-True-True-65536-1024]        1.3391 (1.27)      1.3810 (1.0)      1.3441 (1.23)     0.0042 (1.0)      1.3426 (1.27)     0.0041 (1.02)       142;31  744.0169 (0.81)        746           1
bench_lombscargle_gpu[False-False-True-65536-1024]       1.4113 (1.34)      1.7937 (1.30)     1.4362 (1.31)     0.0373 (8.82)     1.4232 (1.35)     0.0235 (5.92)        77;74  696.2639 (0.76)        695           1
bench_lombscargle_gpu[True-False-False-65536-1024]       1.6203 (1.54)      8.3677 (6.06)     1.7277 (1.58)     0.4550 (107.69)   1.6273 (1.54)     0.0279 (7.01)       25;113  578.8032 (0.63)        616           1
bench_lombscargle_gpu[True-True-False-65536-1024]        1.6453 (1.56)     12.2741 (8.89)     1.7247 (1.58)     0.5106 (120.86)   1.6634 (1.57)     0.0419 (10.53)        7;65  579.8057 (0.63)        449           1
bench_lombscargle_gpu[True-True-True-65536-1024]         1.8001 (1.71)     10.2150 (7.40)     2.0787 (1.90)     0.6899 (163.30)   1.8157 (1.72)     0.5624 (141.46)       14;7  481.0691 (0.53)        423           1
bench_lombscargle_gpu[True-False-True-65536-1024]        1.8420 (1.75)      1.9205 (1.39)     1.8513 (1.69)     0.0085 (2.01)     1.8488 (1.75)     0.0040 (1.0)         48;58  540.1646 (0.59)        542           1
bench_lombscargle_gpu[True-False-True-262144-1024]       4.2316 (4.01)      5.8286 (4.22)     4.3108 (3.94)     0.1694 (40.09)    4.2432 (4.01)     0.0711 (17.88)       17;32  231.9760 (0.25)        237           1
bench_lombscargle_gpu[False-True-False-262144-1024]      4.4204 (4.19)      4.5226 (3.27)     4.4355 (4.06)     0.0198 (4.68)     4.4285 (4.19)     0.0126 (3.18)        25;25  225.4524 (0.25)        227           1
bench_lombscargle_gpu[False-False-True-262144-1024]      4.6347 (4.40)     15.0359 (10.89)    4.7831 (4.38)     0.7949 (188.15)   4.6524 (4.40)     0.0913 (22.95)        4;20  209.0699 (0.23)        216           1
bench_lombscargle_gpu[False-True-True-262144-1024]       4.7974 (4.55)     16.3258 (11.82)    4.9909 (4.57)     1.0006 (236.85)   4.8094 (4.55)     0.0628 (15.79)        6;27  200.3636 (0.22)        209           1
bench_lombscargle_gpu[True-True-True-262144-1024]        5.0142 (4.76)      5.4165 (3.92)     5.0302 (4.60)     0.0422 (9.99)     5.0225 (4.75)     0.0074 (1.87)         8;20  198.8003 (0.22)        200           1
bench_lombscargle_gpu[True-False-False-262144-1024]      5.4147 (5.14)      5.5066 (3.99)     5.4243 (4.96)     0.0136 (3.23)     5.4196 (5.13)     0.0070 (1.77)        14;17  184.3566 (0.20)        185           1
bench_lombscargle_gpu[False-False-False-262144-1024]     5.4574 (5.18)      5.5681 (4.03)     5.4924 (5.02)     0.0219 (5.18)     5.5021 (5.20)     0.0419 (10.53)        70;0  182.0681 (0.20)        181           1
bench_lombscargle_gpu[True-True-False-262144-1024]       5.9245 (5.62)     10.5966 (7.67)     6.0923 (5.57)     0.5513 (130.50)   5.9312 (5.61)     0.0135 (3.40)         7;37  164.1414 (0.18)        169           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```