### PR TITLE
Removed Numba kernels for 0.15

### DIFF
--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -81,9 +81,6 @@ class BenchResamplePoly:
             self.cpu_version, cpu_sig, up, down, window,
         )
 
-    # Add parameter 'use_numba' to GPU test. It is not needed on CPU test.
-    # This reduces redundant executions and runtime
-    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_resample_poly_gpu(
         self,
         linspace_data_gen,
@@ -92,7 +89,6 @@ class BenchResamplePoly:
         up,
         down,
         window,
-        use_numba,
     ):
 
         cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)
@@ -104,7 +100,6 @@ class BenchResamplePoly:
             up,
             down,
             window=window,
-            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, up, down, window)
@@ -129,9 +124,8 @@ class BenchUpFirDn:
             self.cpu_version, cpu_sig, up, down, axis,
         )
 
-    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_upfirdn_gpu(
-        self, rand_data_gen, benchmark, num_samps, up, down, axis, use_numba,
+        self, rand_data_gen, benchmark, num_samps, up, down, axis,
     ):
 
         cpu_sig, gpu_sig = rand_data_gen(num_samps)
@@ -142,7 +136,6 @@ class BenchUpFirDn:
             up,
             down,
             axis,
-            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, up, down, axis)
@@ -167,7 +160,6 @@ class BenchUpFirDn2d:
             self.cpu_version, cpu_sig, up, down, axis,
         )
 
-    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_upfirdn2d_gpu(
         self,
         rand_2d_data_gen,
@@ -176,7 +168,6 @@ class BenchUpFirDn2d:
         up,
         down,
         axis,
-        use_numba,
     ):
 
         cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
@@ -187,7 +178,6 @@ class BenchUpFirDn2d:
             up,
             down,
             axis,
-            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, up, down, axis)
@@ -407,7 +397,6 @@ class BenchConvolve2d:
         cpu_filt, _ = rand_2d_data_gen(num_taps)
         benchmark(self.cpu_version, cpu_sig, cpu_filt, boundary, mode)
 
-    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_convolve2d_gpu(
         self,
         rand_2d_data_gen,
@@ -416,7 +405,6 @@ class BenchConvolve2d:
         num_taps,
         boundary,
         mode,
-        use_numba,
     ):
 
         cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
@@ -427,7 +415,6 @@ class BenchConvolve2d:
             gpu_filt,
             boundary=boundary,
             mode=mode,
-            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, cpu_filt, boundary, mode)
@@ -452,7 +439,6 @@ class BenchCorrelate2d:
         cpu_filt, _ = rand_2d_data_gen(num_taps)
         benchmark(self.cpu_version, cpu_sig, cpu_filt, boundary, mode)
 
-    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_correlate2d_gpu(
         self,
         rand_2d_data_gen,
@@ -461,7 +447,6 @@ class BenchCorrelate2d:
         num_taps,
         boundary,
         mode,
-        use_numba,
     ):
 
         cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
@@ -472,7 +457,6 @@ class BenchCorrelate2d:
             gpu_filt,
             boundary=boundary,
             mode=mode,
-            use_numba=use_numba,
         )
 
         key = self.cpu_version(cpu_sig, cpu_filt, boundary, mode)

--- a/python/cusignal/benchmark/bench_spectral.py
+++ b/python/cusignal/benchmark/bench_spectral.py
@@ -372,7 +372,6 @@ class BenchLombScargle:
 
         benchmark(self.cpu_version, x, y, f, precenter, normalize)
 
-    @pytest.mark.parametrize("use_numba", [True, False])
     def bench_lombscargle_gpu(
         self,
         linspace_data_gen,
@@ -382,7 +381,6 @@ class BenchLombScargle:
         num_out_samps,
         precenter,
         normalize,
-        use_numba,
     ):
         A = 2.0
         w = 1.0
@@ -405,7 +403,6 @@ class BenchLombScargle:
             d_f,
             precenter,
             normalize,
-            use_numba=use_numba,
         )
 
         key = self.cpu_version(x, y, f, precenter, normalize)

--- a/python/cusignal/convolution/_convolution_cuda.py
+++ b/python/cusignal/convolution/_convolution_cuda.py
@@ -13,12 +13,10 @@
 
 import cupy as cp
 import numpy as np
-import warnings
 
-from numba import cuda, int64, void
 from string import Template
 
-from ..utils._caches import _cupy_kernel_cache, _numba_kernel_cache
+from ..utils._caches import _cupy_kernel_cache
 from .convolution_utils import (
     FULL,
     SAME,
@@ -30,113 +28,6 @@ from .convolution_utils import (
     _valfrommode,
     _bvalfromboundary,
 )
-
-
-def _numba_convolve_2d(inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick):
-
-    y, x = cuda.grid(2)
-
-    if pick != 3:  # non-square
-        i = cp.int32(x + S0)
-    else:
-        i = cp.int32(x + S1)
-    j = cp.int32(y + S0)
-
-    oPixelPos = (x, y)
-    if (x < outH) and (y < outW):
-
-        temp: out.dtype = 0
-
-        if pick == 1:  # odd
-            for k in range(cp.int32(-S0), cp.int32(S0 + 1)):
-                for l in range(cp.int32(-S0), cp.int32(S0 + 1)):
-                    iPixelPos = (cp.int32(i + k), cp.int32(j + l))
-                    coefPos = (cp.int32(-k + S0), cp.int32(-l + S0))
-                    temp += inp[iPixelPos] * kernel[coefPos]
-
-        elif pick == 2:  # even
-            for k in range(cp.int32(-S0), cp.int32(S0)):
-                for l in range(cp.int32(-S0), cp.int32(S0)):
-                    iPixelPos = (cp.int32(i + k), cp.int32(j + l))
-                    coefPos = (
-                        cp.int32(cp.int32(-k + S0) - 1),
-                        cp.int32(cp.int32(-l + S0) - 1),
-                    )
-                    temp += inp[iPixelPos] * kernel[coefPos]
-
-        else:  # non-squares
-            for k in range(cp.int32(S0)):
-                for l in range(cp.int32(S1)):
-                    iPixelPos = (
-                        cp.int32(cp.int32(i + k) - S1),
-                        cp.int32(cp.int32(j + l) - S0),
-                    )
-                    coefPos = (
-                        cp.int32(cp.int32(-k + S0) - 1),
-                        cp.int32(cp.int32(-l + S1) - 1),
-                    )
-                    temp += inp[iPixelPos] * kernel[coefPos]
-
-        out[oPixelPos] = temp
-
-
-def _numba_correlate_2d(
-    inp, inpW, inpH, kernel, S0, S1, out, outW, outH, pick
-):
-
-    y, x = cuda.grid(2)
-
-    if pick != 3:  # non-square
-        i = cp.int32(x + S0)
-    else:
-        i = cp.int32(x + S1)
-    j = cp.int32(y + S0)
-
-    oPixelPos = (x, y)
-    if (x < outH) and (y < outW):
-
-        temp: out.dtype = 0
-
-        if pick == 1:  # odd
-            for k in range(cp.int32(-S0), cp.int32(S0 + 1)):
-                for l in range(cp.int32(-S0), cp.int32(S0 + 1)):
-                    iPixelPos = (cp.int32(i + k), cp.int32(j + l))
-                    coefPos = (cp.int32(k + S0), cp.int32(l + S0))
-                    temp += inp[iPixelPos] * kernel[coefPos]
-
-        elif pick == 2:  # even
-            for k in range(cp.int32(-S0), cp.int32(S0)):
-                for l in range(cp.int32(-S0), cp.int32(S0)):
-                    iPixelPos = (cp.int32(i + k), cp.int32(j + l))
-                    coefPos = (cp.int32(k + S0), cp.int32(l + S0))
-                    temp += inp[iPixelPos] * kernel[coefPos]
-
-        else:  # non-squares
-            for k in range(cp.int32(S0)):
-                for l in range(cp.int32(S1)):
-                    iPixelPos = (
-                        cp.int32(cp.int32(i + k) - S1),
-                        cp.int32(cp.int32(j + l) - S0),
-                    )
-                    coefPos = (k, l)
-                    temp += inp[iPixelPos] * kernel[coefPos]
-
-        out[oPixelPos] = temp
-
-
-def _numba_convolve_2d_signature(ty):
-    return void(
-        ty[:, :],  # inp
-        int64,  # inpW
-        int64,  # inpH
-        ty[:, :],  # kernel
-        int64,  # S0
-        int64,  # S1 - only used by non-squares
-        ty[:, :],  # out
-        int64,  # outW
-        int64,  # outH
-        int64,  # pick
-    )
 
 
 # Custom Cupy raw kernel implementing upsample, filter, downsample operation
@@ -481,51 +372,29 @@ class _cupy_convolve_2d_wrapper(object):
 
 
 def _get_backend_kernel(
-    dtype, grid, block, stream, use_numba, k_type,
+    dtype, grid, block, stream, k_type,
 ):
-    from ..utils.compile_kernels import _stream_cupy_to_numba, GPUKernel
+    from ..utils.compile_kernels import GPUKernel
 
-    if not use_numba:
-        kernel = _cupy_kernel_cache[(dtype.name, k_type.value)]
-        if kernel:
-            if k_type == GPUKernel.CONVOLVE or k_type == GPUKernel.CORRELATE:
-                return _cupy_convolve_wrapper(grid, block, stream, kernel)
-            elif (
-                k_type == GPUKernel.CONVOLVE2D
-                or k_type == GPUKernel.CORRELATE2D
-            ):
-                return _cupy_convolve_2d_wrapper(grid, block, stream, kernel)
-            else:
-                raise NotImplementedError(
-                    "No CuPY kernel found for k_type {}, datatype {}".format(
-                        k_type, dtype
-                    )
+    kernel = _cupy_kernel_cache[(dtype.name, k_type.value)]
+    if kernel:
+        if k_type == GPUKernel.CONVOLVE or k_type == GPUKernel.CORRELATE:
+            return _cupy_convolve_wrapper(grid, block, stream, kernel)
+        elif (
+            k_type == GPUKernel.CONVOLVE2D
+            or k_type == GPUKernel.CORRELATE2D
+        ):
+            return _cupy_convolve_2d_wrapper(grid, block, stream, kernel)
+        else:
+            raise NotImplementedError(
+                "No CuPY kernel found for k_type {}, datatype {}".format(
+                    k_type, dtype
                 )
-        else:
-            raise ValueError(
-                "Kernel {} not found in _cupy_kernel_cache".format(k_type)
             )
-
     else:
-        warnings.warn(
-            "Numba kernels will be removed in a later release",
-            FutureWarning,
-            stacklevel=4,
+        raise ValueError(
+            "Kernel {} not found in _cupy_kernel_cache".format(k_type)
         )
-
-        nb_stream = _stream_cupy_to_numba(stream)
-        kernel = _numba_kernel_cache[(dtype.name, k_type.value)]
-
-        if kernel:
-            return kernel[grid, block, nb_stream]
-        else:
-            raise ValueError(
-                "Kernel {} not found in _numba_kernel_cache".format(k_type)
-            )
-
-    raise NotImplementedError(
-        "No kernel found for k_type {}, datatype {}".format(k_type, dtype.name)
-    )
 
 
 def _convolve_gpu(
@@ -543,23 +412,21 @@ def _convolve_gpu(
     blockspergrid = numSM * 20
 
     if use_convolve:
-        _populate_kernel_cache(out.dtype.type, False, GPUKernel.CONVOLVE)
+        _populate_kernel_cache(out.dtype.type, GPUKernel.CONVOLVE)
         kernel = _get_backend_kernel(
             out.dtype,
             blockspergrid,
             threadsperblock,
             cp_stream,
-            False,
             GPUKernel.CONVOLVE,
         )
     else:
-        _populate_kernel_cache(out.dtype.type, False, GPUKernel.CORRELATE)
+        _populate_kernel_cache(out.dtype.type, GPUKernel.CORRELATE)
         kernel = _get_backend_kernel(
             out.dtype,
             blockspergrid,
             threadsperblock,
             cp_stream,
-            False,
             GPUKernel.CORRELATE,
         )
 
@@ -577,7 +444,6 @@ def _convolve2d_gpu(
     use_convolve,
     fillvalue,
     cp_stream,
-    use_numba,
 ):
     from ..utils.compile_kernels import _populate_kernel_cache, GPUKernel
 
@@ -661,25 +527,23 @@ def _convolve2d_gpu(
     )
 
     if use_convolve:
-        _populate_kernel_cache(out.dtype.type, use_numba, GPUKernel.CONVOLVE2D)
+        _populate_kernel_cache(out.dtype.type, GPUKernel.CONVOLVE2D)
         kernel = _get_backend_kernel(
             out.dtype,
             blockspergrid,
             threadsperblock,
             cp_stream,
-            use_numba,
             GPUKernel.CONVOLVE2D,
         )
     else:
         _populate_kernel_cache(
-            out.dtype.type, use_numba, GPUKernel.CORRELATE2D
+            out.dtype.type, GPUKernel.CORRELATE2D
         )
         kernel = _get_backend_kernel(
             out.dtype,
             blockspergrid,
             threadsperblock,
             cp_stream,
-            use_numba,
             GPUKernel.CORRELATE2D,
         )
 
@@ -749,7 +613,6 @@ def _convolve2d(
     fillvalue,
     cp_stream,
     autosync,
-    use_numba,
 ):
 
     val = _valfrommode(mode)
@@ -801,7 +664,7 @@ def _convolve2d(
     out = cp.empty(out_dimens.tolist(), in1.dtype)
 
     out = _convolve2d_gpu(
-        in1, out, in2, val, bval, use_convolve, fill, cp_stream, use_numba,
+        in1, out, in2, val, bval, use_convolve, fill, cp_stream,
     )
 
     if autosync is True:

--- a/python/cusignal/convolution/convolve.py
+++ b/python/cusignal/convolution/convolve.py
@@ -349,7 +349,6 @@ def convolve2d(
     fillvalue=0,
     cp_stream=cp.cuda.stream.Stream(null=True),
     autosync=True,
-    use_numba=False,
 ):
     """
     Convolve two 2-dimensional arrays.
@@ -394,9 +393,6 @@ def convolve2d(
         false will allow asynchronous operation but might required
         manual synchronize later `cp_stream.synchronize()`.
         Default is True.
-    use_numba : bool, optional
-        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is False.
 
     Returns
     -------
@@ -441,7 +437,7 @@ def convolve2d(
         in1, in2 = in2, in1
 
     out = _convolution_cuda._convolve2d(
-        in1, in2, 1, mode, boundary, fillvalue, cp_stream, autosync, use_numba,
+        in1, in2, 1, mode, boundary, fillvalue, cp_stream, autosync,
     )
     return out
 

--- a/python/cusignal/convolution/correlate.py
+++ b/python/cusignal/convolution/correlate.py
@@ -181,7 +181,6 @@ def correlate2d(
     fillvalue=0,
     cp_stream=cp.cuda.stream.Stream(null=True),
     autosync=True,
-    use_numba=False,
 ):
     """
     Cross-correlate two 2-dimensional arrays.
@@ -226,9 +225,6 @@ def correlate2d(
         false will allow asynchronous operation but might required
         manual synchronize later `cp_stream.synchronize()`
         Default is true.
-    use_numba : bool, optional
-        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is False.
 
     Returns
     -------
@@ -283,7 +279,6 @@ def correlate2d(
         fillvalue,
         cp_stream,
         autosync,
-        use_numba,
     )
 
     if swapped_inputs:

--- a/python/cusignal/filtering/_upfirdn_cuda.py
+++ b/python/cusignal/filtering/_upfirdn_cuda.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 
 import cupy as cp
-import warnings
 
 from math import ceil
-from numba import cuda, int64, void
 from string import Template
 
-from ..utils._caches import _cupy_kernel_cache, _numba_kernel_cache
+from ..utils._caches import _cupy_kernel_cache
 
 
 def _pad_h(h, up):
@@ -44,100 +42,6 @@ def _output_len(len_h, in_len, up, down):
     if nt % down > 0:
         need += 1
     return need
-
-
-# Custom Numba kernel implementing upsample, filter, downsample operation
-# Matthew Nicely - mnicely@nvidia.com
-def _numba_upfirdn_1d(
-    x, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out
-):
-
-    X = cuda.grid(1)
-    strideX = cuda.gridsize(1)
-
-    for i in range(X, cp.int32(out.shape[0]), strideX):
-
-        x_idx = cp.int32(cp.int32(cp.int32(i * down) // up) % padded_len)
-        h_idx = cp.int32(cp.int32(cp.int32(i * down) % up) * h_per_phase)
-
-        x_conv_idx = cp.int32(cp.int32(x_idx - h_per_phase) + 1)
-        if x_conv_idx < 0:
-            h_idx -= x_conv_idx
-            x_conv_idx = 0
-
-        temp: out.dtype = 0
-
-        # If axis = 0, we need to know each column in x.
-        for x_c in range(cp.int32(x_conv_idx), cp.int32(x_idx + 1)):
-            if x_c < x_shape_a and x_c >= 0:
-                temp += x[x_c] * h_trans_flip[h_idx]
-            h_idx += 1
-
-        out[i] = temp
-
-
-def _numba_upfirdn_2d(
-    inp, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out
-):
-
-    y, x = cuda.grid(2)
-
-    if x < out.shape[1] and y < out.shape[0]:
-
-        if axis == 1:
-            x_idx = cp.int32(cp.int32(cp.int32(x * down) // up) % padded_len)
-            h_idx = cp.int32(cp.int32(cp.int32(x * down) % up) * h_per_phase)
-        else:
-            x_idx = cp.int32(cp.int32(cp.int32(y * down) // up) % padded_len)
-            h_idx = cp.int32(cp.int32(cp.int32(y * down) % up) * h_per_phase)
-
-        x_conv_idx = cp.int32(cp.int32(x_idx - h_per_phase) + 1)
-        if x_conv_idx < 0:
-            h_idx -= x_conv_idx
-            x_conv_idx = 0
-
-        temp: out.dtype = 0
-
-        # If axis = 0, we need to know each column in x.
-        for x_c in range(cp.int32(x_conv_idx), cp.int32(x_idx + 1)):
-            if x_c < x_shape_a and x_c >= 0:  # If inside input
-                # if multi-dimenstional array
-                if axis == 1:  # process columns
-                    temp += inp[y, x_c] * h_trans_flip[h_idx]
-                else:  # process rows
-                    temp += inp[x_c, x] * h_trans_flip[h_idx]
-
-            h_idx += 1
-
-        out[y, x] = temp
-
-
-def _numba_upfirdn_1d_signature(ty):
-    return void(
-        ty[:],  # x
-        ty[:],  # h_trans_flip
-        int64,  # up
-        int64,  # down
-        int64,  # axis
-        int64,  # x_shape_a
-        int64,  # h_per_phase
-        int64,  # padded_len
-        ty[:],  # out
-    )
-
-
-def _numba_upfirdn_2d_signature(ty):
-    return void(
-        ty[:, :],  # x
-        ty[:],  # h_trans_flip
-        int64,  # up
-        int64,  # down
-        int64,  # axis
-        int64,  # x_shape_a
-        int64,  # h_per_phase
-        int64,  # padded_len
-        ty[:, :],  # out
-    )
 
 
 # Custom Cupy raw kernel implementing upsample, filter, downsample operation
@@ -338,43 +242,22 @@ class _cupy_upfirdn2d_wrapper(object):
 
 
 def _get_backend_kernel(
-    dtype, grid, block, stream, use_numba, k_type,
+    dtype, grid, block, stream, k_type,
 ):
-    from ..utils.compile_kernels import _stream_cupy_to_numba, GPUKernel
+    from ..utils.compile_kernels import GPUKernel
 
-    if not use_numba:
-        kernel = _cupy_kernel_cache[(dtype.name, k_type.value)]
-        if kernel:
-            if k_type == GPUKernel.UPFIRDN:
-                return _cupy_upfirdn_wrapper(grid, block, stream, kernel)
-            elif k_type == GPUKernel.UPFIRDN2D:
-                return _cupy_upfirdn2d_wrapper(grid, block, stream, kernel)
-        else:
-            raise ValueError(
-                "Kernel {} not found in _cupy_kernel_cache".format(k_type)
-            )
-
+    kernel = _cupy_kernel_cache[(dtype.name, k_type.value)]
+    if kernel:
+        if k_type == GPUKernel.UPFIRDN:
+            return _cupy_upfirdn_wrapper(grid, block, stream, kernel)
+        elif k_type == GPUKernel.UPFIRDN2D:
+            return _cupy_upfirdn2d_wrapper(grid, block, stream, kernel)
     else:
-        warnings.warn(
-            "Numba kernels will be removed in a later release",
-            FutureWarning,
-            stacklevel=4,
+        raise ValueError(
+            "Kernel {} not found in _cupy_kernel_cache".format(k_type)
         )
 
-        nb_stream = _stream_cupy_to_numba(stream)
-        kernel = _numba_kernel_cache[(dtype.name, k_type.value)]
-        if kernel:
-            return kernel[grid, block, nb_stream]
-        else:
-            raise ValueError(
-                "Kernel {} not found in _numba_kernel_cache".format(k_type)
-            )
-
-    raise NotImplementedError(
-        "No kernel found for k_type {}, datatype {}".format(k_type, dtype.name)
-    )
-
-
+  
 class _UpFIRDn(object):
     def __init__(self, h, x_dtype, up, down):
         """Helper for resampling"""
@@ -393,7 +276,7 @@ class _UpFIRDn(object):
         self._h_trans_flip = cp.ascontiguousarray(self._h_trans_flip)
 
     def apply_filter(
-        self, x, axis, cp_stream, autosync, use_numba,
+        self, x, axis, cp_stream, autosync,
     ):
         """Apply the prepared filter to the specified axis of a nD signal x"""
         from ..utils.compile_kernels import _populate_kernel_cache, GPUKernel
@@ -427,26 +310,24 @@ class _UpFIRDn(object):
 
         if out.ndim == 1:
             _populate_kernel_cache(
-                out.dtype.type, use_numba, GPUKernel.UPFIRDN
+                out.dtype.type, GPUKernel.UPFIRDN
             )
             kernel = _get_backend_kernel(
                 out.dtype,
                 blockspergrid,
                 threadsperblock,
                 cp_stream,
-                use_numba,
                 GPUKernel.UPFIRDN,
             )
         elif out.ndim == 2:
             _populate_kernel_cache(
-                out.dtype.type, use_numba, GPUKernel.UPFIRDN2D
+                out.dtype.type, GPUKernel.UPFIRDN2D
             )
             kernel = _get_backend_kernel(
                 out.dtype,
                 blockspergrid,
                 threadsperblock,
                 cp_stream,
-                use_numba,
                 GPUKernel.UPFIRDN2D,
             )
         else:

--- a/python/cusignal/filtering/resample.py
+++ b/python/cusignal/filtering/resample.py
@@ -91,7 +91,6 @@ def decimate(
     zero_phase=True,
     cp_stream=cp.cuda.stream.Stream(null=True),
     autosync=True,
-    use_numba=False,
 ):
     """
     Downsample the signal after applying an anti-aliasing filter.
@@ -122,9 +121,7 @@ def decimate(
         false will allow asynchronous operation but might required
         manual synchronize later `cp_stream.synchronize()`.
         Default is True.
-    use_numba : bool, optional
-        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is False.
+
     Returns
     -------
     y : ndarray
@@ -303,7 +300,6 @@ def resample_poly(
     window=("kaiser", 5.0),
     cp_stream=cp.cuda.stream.Stream(null=True),
     autosync=True,
-    use_numba=False,
 ):
     """
     Resample `x` along the given axis using polyphase filtering.
@@ -338,9 +334,6 @@ def resample_poly(
         false will allow asynchronous operation but might required
         manual synchronize later `cp_stream.synchronize()`.
         Default is True.
-    use_numba : bool, optional
-        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is False.
 
     Returns
     -------
@@ -445,7 +438,7 @@ def resample_poly(
     n_pre_remove_end = n_pre_remove + n_out
 
     # filter then remove excess
-    y = upfirdn(h, x, up, down, axis=axis, use_numba=use_numba)
+    y = upfirdn(h, x, up, down, axis=axis)
     keep = [slice(None)] * x.ndim
     keep[axis] = slice(n_pre_remove, n_pre_remove_end)
     return y[tuple(keep)]
@@ -459,7 +452,6 @@ def upfirdn(
     axis=-1,
     cp_stream=cp.cuda.stream.Stream(null=True),
     autosync=True,
-    use_numba=False,
 ):
     """Upsample, FIR filter, and downsample
     Parameters
@@ -487,9 +479,7 @@ def upfirdn(
         false will allow asynchronous operation but might required
         manual synchronize later `cp_stream.synchronize()`.
         Default is True.
-    use_numba : bool, optional
-        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is False.
+
     Returns
     -------
     y : ndarray
@@ -552,5 +542,5 @@ def upfirdn(
     ufd = _UpFIRDn(h, x.dtype, up, down)
     # This is equivalent to (but faster than) using cp.apply_along_axis
     return ufd.apply_filter(
-        x, axis, cp_stream=cp_stream, autosync=autosync, use_numba=use_numba
+        x, axis, cp_stream=cp_stream, autosync=autosync
     )

--- a/python/cusignal/spectral_analysis/spectral.py
+++ b/python/cusignal/spectral_analysis/spectral.py
@@ -38,7 +38,6 @@ def lombscargle(
     normalize=False,
     cp_stream=cp.cuda.stream.Stream(null=True),
     autosync=True,
-    use_numba=False,
 ):
     """
     lombscargle(x, y, freqs)
@@ -75,9 +74,6 @@ def lombscargle(
         false will allow asynchronous operation but might required
         manual synchronize later `cp_stream.synchronize()`.
         Default is True.
-    use_numba : bool, optional
-        Option to use Numba CUDA kernel or raw CuPy kernel. Raw CuPy
-        can yield performance gains over Numba. Default is False.
 
     Returns
     -------
@@ -165,7 +161,7 @@ def lombscargle(
     else:
         y_in = y
 
-    _lombscargle(x, y_in, freqs, pgram, y_dot, cp_stream, autosync, use_numba)
+    _lombscargle(x, y_in, freqs, pgram, y_dot, cp_stream, autosync)
 
     return pgram
 

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -39,8 +39,7 @@ def test_resample(num_samps, resample_num_samps, window):
 @pytest.mark.parametrize("up", [2, 3, 7])
 @pytest.mark.parametrize("down", [1, 2, 9])
 @pytest.mark.parametrize("window", [("kaiser", 0.5)])
-@pytest.mark.parametrize("use_numba", [True, False])
-def test_resample_poly(num_samps, up, down, window, use_numba):
+def test_resample_poly(num_samps, up, down, window):
     cpu_time = np.linspace(0, 10, num_samps, endpoint=False)
     cpu_sig = np.cos(-(cpu_time ** 2) / 6.0)
     gpu_sig = cp.asarray(cpu_sig)
@@ -48,7 +47,7 @@ def test_resample_poly(num_samps, up, down, window, use_numba):
     cpu_resample = signal.resample_poly(cpu_sig, up, down, window=window)
     gpu_resample = cp.asnumpy(
         cusignal.resample_poly(
-            gpu_sig, up, down, window=window, use_numba=use_numba
+            gpu_sig, up, down, window=window
         )
     )
 
@@ -58,8 +57,7 @@ def test_resample_poly(num_samps, up, down, window, use_numba):
 @pytest.mark.parametrize("num_samps", [2 ** 14])
 @pytest.mark.parametrize("up", [2, 3, 7])
 @pytest.mark.parametrize("down", [1, 2, 9])
-@pytest.mark.parametrize("use_numba", [True, False])
-def test_upfirdn(num_samps, up, down, use_numba):
+def test_upfirdn(num_samps, up, down):
     cpu_sig = np.random.rand(num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
@@ -67,7 +65,7 @@ def test_upfirdn(num_samps, up, down, use_numba):
 
     cpu_resample = signal.upfirdn(h, cpu_sig, up, down)
     gpu_resample = cp.asnumpy(
-        cusignal.upfirdn(h, gpu_sig, up, down, use_numba=use_numba)
+        cusignal.upfirdn(h, gpu_sig, up, down)
     )
 
     assert array_equal(cpu_resample, gpu_resample)
@@ -76,8 +74,7 @@ def test_upfirdn(num_samps, up, down, use_numba):
 @pytest.mark.parametrize("num_samps", [2 ** 8])
 @pytest.mark.parametrize("up", [2, 3, 7])
 @pytest.mark.parametrize("down", [1, 2, 9])
-@pytest.mark.parametrize("use_numba", [True, False])
-def test_upfirdn2d(num_samps, up, down, use_numba):
+def test_upfirdn2d(num_samps, up, down):
     cpu_sig = np.random.rand(num_samps, num_samps)
     gpu_sig = cp.asarray(cpu_sig)
 
@@ -85,7 +82,7 @@ def test_upfirdn2d(num_samps, up, down, use_numba):
 
     cpu_resample = signal.upfirdn(h, cpu_sig, up, down)
     gpu_resample = cp.asnumpy(
-        cusignal.upfirdn(h, gpu_sig, up, down, use_numba=use_numba)
+        cusignal.upfirdn(h, gpu_sig, up, down)
     )
 
     assert array_equal(cpu_resample, gpu_resample)
@@ -201,8 +198,7 @@ def test_hilbert2(num_samps):
 @pytest.mark.parametrize("num_taps", [5, 100])
 @pytest.mark.parametrize("boundary", ["symm"])
 @pytest.mark.parametrize("mode", ["same"])
-@pytest.mark.parametrize("use_numba", [True, False])
-def test_convolve2d(num_samps, num_taps, boundary, mode, use_numba):
+def test_convolve2d(num_samps, num_taps, boundary, mode):
     cpu_sig = np.random.rand(num_samps, num_samps)
     cpu_filt = np.random.rand(num_taps, num_taps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -217,7 +213,6 @@ def test_convolve2d(num_samps, num_taps, boundary, mode, use_numba):
             gpu_filt,
             boundary=boundary,
             mode=mode,
-            use_numba=use_numba,
         )
     )
     assert array_equal(cpu_convolve2d, gpu_convolve2d)
@@ -227,8 +222,7 @@ def test_convolve2d(num_samps, num_taps, boundary, mode, use_numba):
 @pytest.mark.parametrize("num_taps", [5, 100])
 @pytest.mark.parametrize("boundary", ["symm"])
 @pytest.mark.parametrize("mode", ["same"])
-@pytest.mark.parametrize("use_numba", [True, False])
-def test_correlate2d(num_samps, num_taps, boundary, mode, use_numba):
+def test_correlate2d(num_samps, num_taps, boundary, mode):
     cpu_sig = np.random.rand(num_samps, num_samps)
     cpu_filt = np.random.rand(num_taps, num_taps)
     gpu_sig = cp.asarray(cpu_sig)
@@ -243,7 +237,6 @@ def test_correlate2d(num_samps, num_taps, boundary, mode, use_numba):
             gpu_filt,
             boundary=boundary,
             mode=mode,
-            use_numba=use_numba,
         )
     )
     assert array_equal(cpu_correlate2d, gpu_correlate2d)

--- a/python/cusignal/test/test_spectral.py
+++ b/python/cusignal/test/test_spectral.py
@@ -204,9 +204,8 @@ def test_stft_complex(num_samps, fs, nperseg):
 @pytest.mark.parametrize("num_out_samps", [2 ** 16, 2 ** 18])
 @pytest.mark.parametrize("precenter", [True, False])
 @pytest.mark.parametrize("normalize", [True, False])
-@pytest.mark.parametrize("use_numba", [True, False])
 def test_lombscargle(
-    num_in_samps, num_out_samps, precenter, normalize, use_numba
+    num_in_samps, num_out_samps, precenter, normalize
 ):
     A = 2.0
     w = 1.0
@@ -229,7 +228,7 @@ def test_lombscargle(
 
     gpu_lombscargle = cp.asnumpy(
         cusignal.lombscargle(
-            d_x, d_y, d_f, precenter, normalize, use_numba=use_numba,
+            d_x, d_y, d_f, precenter, normalize,
         )
     )
 

--- a/python/cusignal/utils/_caches.py
+++ b/python/cusignal/utils/_caches.py
@@ -13,4 +13,3 @@
 
 # Kernel caches
 _cupy_kernel_cache = {}
-_numba_kernel_cache = {}


### PR DESCRIPTION
# Info 
This PR remove Numba kernels for the following functions

1. correlate2d
2. convolve2d
3. lombscargle
4. upfirdn
5. upfirdn2d