### PR TITLE
[REVIEW] Add git attributes to remove notebooks from stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-notebooks/api_guild/*.ipynb linguist-vendored
+notebooks/api_guide/*.ipynb linguist-vendored
 notebooks/*.ipynb linguist-vendored
 notebooks/sdr/*.ipynb linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+notebooks/api_guild/*.ipynb linguist-vendored
+notebooks/*.ipynb linguist-vendored
+notebooks/sdr/*.ipynb linguist-vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #78 - Ported lfilter to CuPy Raw Kernel (only 1D functional)
 - PR #83 - Implement code refactor
 - PR #87 - Update lfilter documentation to clarifiy single-threaded perf
+- PR #95 - Add `.gitattributes` to remove notebooks from GitHub stats
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 


### PR DESCRIPTION
cuSignal is classified on GitHub as a collection of Jupyter Notebooks. Adding the `linguist-vendored` option into `*.ipynb` to ignore the notebooks from GitHub stats.