### PR TITLE
[REVIEW] Fix code refactor bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #52 - Mirror API change in Numba 0.49
 - PR #70 - Typo fix in docs api.rst that broke build
 - PR #93 - Remove `lfilter` due to poor performance in real-time applications
+- PR #96 - Move data type check to `_populate_kernel_cache`
 
 # cuSignal 0.13 (31 Mar 2020)
 

--- a/python/cusignal/utils/compile_kernels.py
+++ b/python/cusignal/utils/compile_kernels.py
@@ -151,15 +151,6 @@ def _validate_input(dtype, k_type):
 
         for np_type in d:
 
-            # Check dtypes from user input
-            try:
-                SUPPORTED_TYPES[np_type]
-
-            except KeyError:
-                raise KeyError(
-                    "Datatype {} not found for '{}'".format(np_type, k.value)
-                )
-
             _populate_kernel_cache(np_type, False, k)
 
 
@@ -167,7 +158,13 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
 
     SUPPORTED_TYPES = _get_supported_types(k_type)
 
-    numba_type, c_type = SUPPORTED_TYPES[np_type]
+    # Check dtypes from user input
+    try:
+        numba_type, c_type = SUPPORTED_TYPES[np_type]
+    except KeyError:
+        raise KeyError(
+            "Datatype {} not found for '{}'".format(np_type, k_type.value)
+        )
 
     if not use_numba:
         if (str(numba_type), k_type.value) in _cupy_kernel_cache:


### PR DESCRIPTION
During the code refactor I moved the data type check to `_validate_input` which only checks data type during kernel precompile. This left a bug during runtime allowing users to pass incompatible data types causing a crash. I moved the following code back to `_populate_kernel_cache`, now code gets checked on both paths.

```python
try:
        numba_type, c_type = SUPPORTED_TYPES[np_type]
except KeyError:
        raise KeyError(
            "Datatype {} not found for '{}'".format(np_type, k_type.value)
        )
```