### PR TITLE
[REVIEW] Add pytest-benchmark to Conda environment files and clarify dev naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #87 - Update lfilter documentation to clarifiy single-threaded perf
 - PR #89 - Include data types in tests and benchmarks
 - PR #95 - Add `.gitattributes` to remove notebooks from GitHub stats
+- PR #97 - Add pytest-benchmark to conda ymls and update conda env name
 
 ## Bug Fixes
 - PR #44 - Fix issues in pytests 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ While there are many versions of Anaconda for AArch64 platforms, cuSignal has be
 
 3. Activate conda environment
 
-    `conda activate cusignal`
+    `conda activate cusignal-dev`
 
 4. Install cuSignal module
 
@@ -249,7 +249,7 @@ While there are many versions of Anaconda for AArch64 platforms, cuSignal has be
 
 3. Activate conda environment
 
-    `conda activate cusignal`
+    `conda activate cusignal-dev`
 
 4. Install cuSignal module
 
@@ -291,7 +291,7 @@ While there are many versions of Anaconda for AArch64 platforms, cuSignal has be
 
 3. Activate conda environment
 
-    `conda activate cusignal`
+    `conda activate cusignal-dev`
 
 4. Install cuSignal Core Dependencies
 

--- a/conda/environments/cusignal_base.yml
+++ b/conda/environments/cusignal_base.yml
@@ -1,4 +1,4 @@
-name: cusignal
+name: cusignal-dev
 channels:
   - conda-forge
   - nvidia
@@ -10,9 +10,10 @@ dependencies:
   - cudatoolkit>=9.2,<=10.2
   - boost
   - matplotlib
-  - numba
+  - numba>=0.49
   - pytest
-  - cupy>=6.2.0
+  - pytest-benchmark
+  - cupy>=7.2.0
   - sphinx
   - sphinx_rtd_theme
   - numpydoc

--- a/conda/environments/cusignal_full.yml
+++ b/conda/environments/cusignal_full.yml
@@ -1,4 +1,4 @@
-name: cusignal
+name: cusignal-dev
 channels:
   - conda-forge
   - nvidia
@@ -12,9 +12,10 @@ dependencies:
   - cudatoolkit>=9.2,<=10.2
   - boost
   - matplotlib
-  - numba
+  - numba>=0.49
   - pytest
-  - cupy>=6.2.0
+  - pytest-benchmark
+  - cupy>=7.2.0
   - pytorch
   - cudf
   - cuml

--- a/conda/environments/cusignal_jetson_base.yml
+++ b/conda/environments/cusignal_jetson_base.yml
@@ -1,4 +1,4 @@
-name: cusignal
+name: cusignal-aarch64-dev
 channels:
   - conda-forge
   - nvidia
@@ -9,8 +9,9 @@ dependencies:
   - scipy
   - numpy
   - matplotlib
-  - numba
+  - numba>=0.49
   - pytest
+  - pytest-benchmark
   - sphinx
   - sphinx_rtd_theme
   - numpydoc


### PR DESCRIPTION
Closes https://github.com/rapidsai/cusignal/issues/94

* Add pytest-benchmark
* Update conda env name from cusignal to cusignal-dev