### PR TITLE
[WIP] Implementation of `sosfilt` as an alternative to `lfilter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #73 - Local gpuCI build script
 - PR #75 - Add accelerated `lfilter` method.
 - PR #82 - Implement `autosync` to synchronize raw kernels by default
+- PR #99 - Implement `sosfilt` as an alternative to `lfilter`
 
 ## Improvements
 - PR #40 - Ability to specify time/freq domain for resample.

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -25,6 +25,7 @@ from cusignal.filtering.resample import (
 from cusignal.filtering.filtering import (
     wiener,
     lfiltic,
+    sosfilt,
     hilbert,
     hilbert2,
     detrend,

--- a/python/cusignal/benchmark/bench_signaltools.py
+++ b/python/cusignal/benchmark/bench_signaltools.py
@@ -459,10 +459,10 @@ class BenchSignaltools:
             assert array_equal(cp.asnumpy(output), key)
 
     @pytest.mark.benchmark(group="SOSFilt")
-    @pytest.mark.parametrize("order", [128, 256, 512])
-    @pytest.mark.parametrize("num_samps", [2 ** 14, 2 ** 16, 2 ** 18, 2 ** 20])
+    @pytest.mark.parametrize("order", [32, 64, 128, 256, 512])
+    @pytest.mark.parametrize("num_samps", [2 ** 15, 2 ** 20])
     @pytest.mark.parametrize("num_signals", [1, 2, 10])
-    # @pytest.mark.parametrize("num_samps", [10000])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
     class BenchSOSFilt:
         np.random.seed(1234)
 
@@ -476,12 +476,14 @@ class BenchSignaltools:
             num_signals,
             num_samps,
             order,
+            dtype,
         ):
             cpu_sos = signal.ellip(order, 0.009, 80, 0.05, output='sos')
+            cpu_sos = np.array(cpu_sos, dtype=dtype)
             cpu_sig = np.random.rand(num_signals, num_samps)
+            cpu_sig = np.array(cpu_sig, dtype=dtype)
             benchmark(self.cpu_version, cpu_sos, cpu_sig)
 
-        @pytest.mark.parametrize("use_numba", [True])
         def bench_sosfilt_gpu(
             self,
             rand_2d_data_gen,
@@ -489,19 +491,20 @@ class BenchSignaltools:
             num_signals,
             num_samps,
             order,
-            use_numba,
+            dtype,
         ):
 
             cpu_sos = signal.ellip(order, 0.009, 80, 0.05, output='sos')
+            cpu_sos = np.array(cpu_sos, dtype=dtype)
             gpu_sos = cp.asarray(cpu_sos)
             cpu_sig = np.random.rand(num_signals, num_samps)
+            cpu_sig = np.array(cpu_sig, dtype=dtype)
             gpu_sig = cp.asarray(cpu_sig)
 
             output = benchmark(
                 cusignal.sosfilt,
                 gpu_sos,
                 gpu_sig,
-                use_numba=use_numba,
             )
 
             key = self.cpu_version(cpu_sos, cpu_sig)

--- a/python/cusignal/filter_design/filter_design_utils.py
+++ b/python/cusignal/filter_design/filter_design_utils.py
@@ -11,18 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cusignal.filtering.resample import (
-    decimate,
-    resample,
-    resample_poly,
-    upfirdn,
-)
-from cusignal.filtering.filtering import (
-    wiener,
-    lfiltic,
-    sosfilt,
-    hilbert,
-    hilbert2,
-    detrend,
-    freq_shift,
-)
+import cupy as cp
+
+
+def _validate_sos(sos):
+    """Helper to validate a SOS input"""
+    sos = cp.atleast_2d(sos)
+    if sos.ndim != 2:
+        raise ValueError('sos array must be 2D')
+    n_sections, m = sos.shape
+    if m != 6:
+        raise ValueError('sos array must be shape (n_sections, 6)')
+    if not (sos[:, 3] == 1).all():
+        raise ValueError('sos[:, 3] should be all ones')
+    return sos, n_sections

--- a/python/cusignal/filtering/_sosfilt_cuda.py
+++ b/python/cusignal/filtering/_sosfilt_cuda.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cupy as cp
+import numpy as np
+import warnings
+
+from numba import cuda, int64, void
+from string import Template
+
+from ..utils._caches import _cupy_kernel_cache, _numba_kernel_cache
+
+
+def _sosfilt(sos, x, zi):
+
+    n_signals, n_samples = x.shape
+    n_sections = sos.shape[0]
+    b = sos[:, :3]
+    a = sos[:, 4:]
+
+    for i in range(n_signals):
+        for n in range(n_samples):
+            for s in range(n_sections):
+                x_n = x[i, n]  # make a temporary copy
+                # Use direct II transposed structure:
+                x[i, n] = b[s, 0] * x_n + zi[i, s, 0]
+                zi[i, s, 0] = (
+                    b[s, 1] * x_n - a[s, 0] * x[i, n] + zi[i, s, 1])
+                zi[i, s, 1] = (
+                    b[s, 2] * x_n - a[s, 1] * x[i, n])

--- a/python/cusignal/filtering/_sosfilt_cuda.py
+++ b/python/cusignal/filtering/_sosfilt_cuda.py
@@ -11,30 +11,248 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cupy as cp
-import numpy as np
 import warnings
 
-from numba import cuda, int64, void
+from numba import cuda, void, float64
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache, _numba_kernel_cache
 
 
-def _sosfilt(sos, x, zi):
+def _numba_sosfilt(sos, x_in, zi):
 
-    n_signals, n_samples = x.shape
+    n_samples = x_in.shape[1]
     n_sections = sos.shape[0]
-    b = sos[:, :3]
-    a = sos[:, 4:]
 
-    for i in range(n_signals):
-        for n in range(n_samples):
-            for s in range(n_sections):
-                x_n = x[i, n]  # make a temporary copy
+    zi_width = 2
+    sos_width = 6
+
+    s_buffer = cuda.shared.array(shape=0, dtype=float64)
+
+    s_out = s_buffer[:n_sections]
+    s_zi = s_buffer[n_sections : (n_sections + sos.shape[0] * zi_width)]
+    s_sos = s_buffer[(n_sections + sos.shape[0] * zi_width) :]
+
+    x, y = cuda.grid(2)
+
+    # Reset shared memory
+    s_out[x] = 0
+
+    # Load zi
+    for i in range(zi_width):
+        s_zi[x * zi_width + i] = zi[y, x, i]
+
+    # Load SOS
+    # b is in s_sos[x * sos_width + [0-2]]
+    # a is in s_sos[x * sos_width + [3-6]]
+    for i in range(sos_width):
+        s_sos[x * sos_width + i] = sos[x, i]
+
+    cuda.syncthreads()
+
+    load_size = n_sections - 1
+    unload_size = n_samples - load_size
+
+    if y < x_in.shape[0]:
+        # Loading phase
+        for n in range(load_size):
+            # for s in range(n_sections):
+            if x == 0:
+                x_n = x_in[y, n]  # make a temporary copy
+            else:
+                x_n = s_out[x - 1]
+
+            # Use direct II transposed structure:
+            # temp = b[x, 0] * x_n + zi[y, x, 0]
+            temp = s_sos[x * sos_width + 0] * x_n + s_zi[x * zi_width + 0]
+
+            # print("1", y, n, x, x_n, temp, zi[y, x, 0], a[x, 0], b[x, 0])
+
+            # zi[y, x, 0] = (b[x, 1] * x_n - a[x, 0] * temp + zi[y, x, 1])
+            # zi[y, x, 1] = (b[x, 2] * x_n - a[x, 1] * temp)
+            s_zi[x * zi_width + 0] = (
+                s_sos[x * sos_width + 1] * x_n
+                - s_sos[x * sos_width + 4] * temp
+                + s_zi[x * zi_width + 1]
+            )
+            s_zi[x * zi_width + 1] = (
+                s_sos[x * sos_width + 2] * x_n
+                - s_sos[x * sos_width + 5] * temp
+            )
+
+            s_out[x] = temp
+
+            cuda.syncthreads()
+
+        # Processing phase
+        for n in range(load_size, n_samples):
+
+            if x == 0:
+                x_n = x_in[y, n]  # make a temporary copy
+            else:
+                x_n = s_out[x - 1]
+
+            # Use direct II transposed structure:
+            # temp = b[x, 0] * x_n + zi[y, x, 0]
+            temp = s_sos[x * sos_width + 0] * x_n + s_zi[x * zi_width + 0]
+
+            # print("1", y, n, x, x_n, temp, zi[y, x, 0], a[x, 0], b[x, 0])
+
+            # zi[y, x, 0] = (b[x, 1] * x_n - a[x, 0] * temp + zi[y, x, 1])
+            # zi[y, x, 1] = (b[x, 2] * x_n - a[x, 1] * temp)
+            s_zi[x * zi_width + 0] = (
+                s_sos[x * sos_width + 1] * x_n
+                - s_sos[x * sos_width + 4] * temp
+                + s_zi[x * zi_width + 1]
+            )
+            s_zi[x * zi_width + 1] = (
+                s_sos[x * sos_width + 2] * x_n
+                - s_sos[x * sos_width + 5] * temp
+            )
+
+            if x < load_size:
+                s_out[x] = temp
+            if x == load_size:
+                x_in[y, n - load_size] = temp
+
+            cuda.syncthreads()
+
+        # Unloading phase
+        for n in range(n_sections):
+            # retire threads that are less than n
+            if x > n:
+                x_n = s_out[x - 1]
+
                 # Use direct II transposed structure:
-                x[i, n] = b[s, 0] * x_n + zi[i, s, 0]
-                zi[i, s, 0] = (
-                    b[s, 1] * x_n - a[s, 0] * x[i, n] + zi[i, s, 1])
-                zi[i, s, 1] = (
-                    b[s, 2] * x_n - a[s, 1] * x[i, n])
+                # temp = b[x, 0] * x_n + zi[y, x, 0]
+                temp = s_sos[x * sos_width + 0] * x_n + s_zi[x * zi_width + 0]
+
+                # zi[y, x, 0] = (b[x, 1] * x_n - a[x, 0] * temp + zi[y, x, 1])
+                # zi[y, x, 1] = (b[x, 2] * x_n - a[x, 1] * temp)
+                s_zi[x * zi_width + 0] = (
+                    s_sos[x * sos_width + 1] * x_n
+                    - s_sos[x * sos_width + 4] * temp
+                    + s_zi[x * zi_width + 1]
+                )
+                s_zi[x * zi_width + 1] = (
+                    s_sos[x * sos_width + 2] * x_n
+                    - s_sos[x * sos_width + 5] * temp
+                )
+
+                if x < load_size:
+                    s_out[x] = temp
+                if x == load_size:
+                    x_in[y, n + unload_size] = temp
+
+                cuda.syncthreads()
+
+
+def _numba_sosfilt_signature(ty):
+    return void(ty[:, :], ty[:, :], ty[:, :, :],)
+
+
+# Custom Cupy raw kernel implementing lombscargle operation
+# Matthew Nicely - mnicely@nvidia.com
+_cupy_sosfilt_src = Template(
+    """
+$header
+
+extern "C" {
+    __global__ void _cupy_sosfilt( ) {
+
+        const int tx {
+            static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
+        const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
+
+    }
+}
+"""
+)
+
+
+class _cupy_lombscargle_wrapper(object):
+    def __init__(self, grid, block, stream, kernel):
+        if isinstance(grid, int):
+            grid = (grid,)
+        if isinstance(block, int):
+            block = (block,)
+
+        self.grid = grid
+        self.block = block
+        self.stream = stream
+        self.kernel = kernel
+
+    def __call__(self, sos, x, zi, a, b):
+
+        kernel_args = ()
+
+        self.stream.use()
+        self.kernel(self.grid, self.block, kernel_args)
+
+
+def _get_backend_kernel(dtype, grid, block, smem, stream, use_numba, k_type):
+    from ..utils.compile_kernels import _stream_cupy_to_numba
+
+    if not use_numba:
+        kernel = _cupy_kernel_cache[(dtype.name, k_type.value)]
+        if kernel:
+            return _cupy_lombscargle_wrapper(grid, block, stream, kernel)
+        else:
+            raise ValueError(
+                "Kernel {} not found in _cupy_kernel_cache".format(k_type)
+            )
+
+    else:
+        warnings.warn(
+            "Numba kernels will be removed in a later release",
+            FutureWarning,
+            stacklevel=4,
+        )
+
+        nb_stream = _stream_cupy_to_numba(stream)
+        kernel = _numba_kernel_cache[(dtype.name, k_type.value)]
+
+        if kernel:
+            return kernel[grid, block, nb_stream, smem]
+        else:
+            raise ValueError(
+                "Kernel {} not found in _numba_kernel_cache".format(k_type)
+            )
+
+    raise NotImplementedError(
+        "No kernel found for datatype {}".format(dtype.name)
+    )
+
+
+def _sosfilt(sos, x, zi, cp_stream, autosync, use_numba):
+    from ..utils.compile_kernels import _populate_kernel_cache, GPUKernel
+
+    threadsperblock = (sos.shape[0], 1)  # Up-to (512, 2) = 1024 max per block
+    blockspergrid = (1, x.shape[0])
+
+    print("tbp", sos.shape[0] * 2, (sos.shape[0], 1), (1, x.shape[0]))
+
+    _populate_kernel_cache(x.dtype.type, use_numba, GPUKernel.SOSFILT)
+
+    out_size = threadsperblock[0]
+    z_size = zi.shape[1] * zi.shape[2]
+    sos_size = sos.shape[0] * sos.shape[1]
+
+    shared_mem = (out_size + z_size + sos_size) * x.dtype.itemsize
+
+    print("sm", shared_mem, out_size, z_size, sos_size, x.dtype.itemsize)
+
+    kernel = _get_backend_kernel(
+        x.dtype,
+        blockspergrid,
+        threadsperblock,
+        shared_mem,
+        cp_stream,
+        use_numba,
+        GPUKernel.SOSFILT,
+    )
+
+    kernel(sos, x, zi)
+
+    if autosync is True:
+        cp_stream.synchronize()

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -226,12 +226,11 @@ def sosfilt(sos, x, axis=-1, zi=None):
     >>> import cusignal
     >>> import cupy as cp
     >>> # Generate filter on CPU with Scipy.Signal
-    >>> b, a = signal.ellip(13, 0.009, 80, 0.05, output='ba')
     >>> sos = signal.ellip(13, 0.009, 80, 0.05, output='sos')
     >>> # Move data to GPU
     >>> sos = cp.asarray(sos)
     >>> x = cp.random.randn(100_000_000)
-    >>> y = signal.sosfilt(sos, x)
+    >>> y = cusignal.sosfilt(sos, x)
     """
     x = cp.asarray(x)
     sos = cp.asarray(sos)

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -227,6 +227,9 @@ def sosfilt(
 
     Notes
     -----
+    WARNING: This is an experimental API and is prone to change in future
+    versions of cuSignal.
+
     The filter function is implemented as a series of second-order filters
     with direct-form II transposed structure. It is designed to minimize
     numerical precision errors for high-order filters.

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -41,6 +41,8 @@ from cupy import linalg
 import numpy as np
 
 from ..convolution.correlate import correlate
+from ..filter_design.filter_design_utils import _validate_sos
+from ._sosfilt_cuda import _sosfilt
 
 
 def wiener(im, mysize=None, noise=None):
@@ -163,6 +165,117 @@ def lfiltic(b, a, y, x=None):
         zi[m] -= cp.sum(a[m + 1 :] * y[: N - m], axis=0)
 
     return zi
+
+
+def sosfilt(sos, x, axis=-1, zi=None):
+    """
+    Filter data along one dimension using cascaded second-order sections.
+    Filter a data sequence, `x`, using a digital IIR filter defined by
+    `sos`.
+
+    Parameters
+    ----------
+    sos : array_like
+        Array of second-order filter coefficients, must have shape
+        ``(n_sections, 6)``. Each row corresponds to a second-order
+        section, with the first three columns providing the numerator
+        coefficients and the last three providing the denominator
+        coefficients.
+    x : array_like
+        An N-dimensional input array.
+    axis : int, optional
+        The axis of the input data array along which to apply the
+        linear filter. The filter is applied to each subarray along
+        this axis.  Default is -1.
+    zi : array_like, optional
+        Initial conditions for the cascaded filter delays.  It is a (at
+        least 2D) vector of shape ``(n_sections, ..., 2, ...)``, where
+        ``..., 2, ...`` denotes the shape of `x`, but with ``x.shape[axis]``
+        replaced by 2.  If `zi` is None or is not given then initial rest
+        (i.e. all zeros) is assumed.
+        Note that these initial conditions are *not* the same as the initial
+        conditions given by `lfiltic` or `lfilter_zi`.
+
+    Returns
+    -------
+    y : ndarray
+        The output of the digital filter.
+    zf : ndarray, optional
+        If `zi` is None, this is not returned, otherwise, `zf` holds the
+        final filter delay values.
+    See Also
+    --------
+    zpk2sos, sos2zpk, sosfilt_zi, sosfiltfilt, sosfreqz
+
+    Notes
+    -----
+    The filter function is implemented as a series of second-order filters
+    with direct-form II transposed structure. It is designed to minimize
+    numerical precision errors for high-order filters.
+
+    Examples
+    --------
+    sosfilt is a stable alternative to `lfilter` as using 2nd order sections
+    reduces numerical error. We are working on building out sos filter output,
+    so please submit GitHub feature requests as needed. You can also generate
+    a filter on CPU with scipy.signal and then move that to GPU for actual
+    filtering operations with `cp.asarray`.
+
+    Plot a 13th-order filter's impulse response using both `sosfilt`:
+    >>> from scipy import signal
+    >>> import cusignal
+    >>> import cupy as cp
+    >>> # Generate filter on CPU with Scipy.Signal
+    >>> b, a = signal.ellip(13, 0.009, 80, 0.05, output='ba')
+    >>> sos = signal.ellip(13, 0.009, 80, 0.05, output='sos')
+    >>> # Move data to GPU
+    >>> sos = cp.asarray(sos)
+    >>> x = cp.random.randn(100_000_000)
+    >>> y = signal.sosfilt(sos, x)
+    """
+    x = cp.asarray(x)
+    sos = cp.asarray(sos)
+    if x.ndim == 0:
+        raise ValueError('x must be at least 1D')
+    sos, n_sections = _validate_sos(sos)
+    x_zi_shape = list(x.shape)
+    x_zi_shape[axis] = 2
+    x_zi_shape = tuple([n_sections] + x_zi_shape)
+    inputs = [sos, x]
+    if zi is not None:
+        inputs.append(cp.asarray(zi))
+    dtype = cp.result_type(*inputs)
+    if dtype.char not in 'fdgFDGO':
+        raise NotImplementedError("input type '%s' not supported" % dtype)
+    if zi is not None:
+        zi = cp.array(zi, dtype)  # make a copy so that we can operate in place
+        if zi.shape != x_zi_shape:
+            raise ValueError('Invalid zi shape. With axis=%r, an input with '
+                             'shape %r, and an sos array with %d sections, zi '
+                             'must have shape %r, got %r.' %
+                             (axis, x.shape, n_sections, x_zi_shape, zi.shape))
+        return_zi = True
+    else:
+        zi = cp.zeros(x_zi_shape, dtype=dtype)
+        return_zi = False
+    axis = axis % x.ndim  # make positive
+    x = cp.moveaxis(x, axis, -1)
+    zi = cp.moveaxis(zi, [0, axis + 1], [-2, -1])
+    x_shape, zi_shape = x.shape, zi.shape
+    x = cp.reshape(x, (-1, x.shape[-1]))
+    x = cp.array(x, dtype, order='C')  # make a copy, can modify in place
+    zi = cp.ascontiguousarray(cp.reshape(zi, (-1, n_sections, 2)))
+    sos = sos.astype(dtype, copy=False)
+    _sosfilt(sos, x, zi)
+    x.shape = x_shape
+    x = cp.moveaxis(x, -1, axis)
+    if return_zi:
+        zi.shape = zi_shape
+        zi = cp.moveaxis(zi, [-2, -1], [0, axis + 1])
+        out = (x, zi)
+    else:
+        out = x
+    return out
 
 
 def hilbert(x, N=None, axis=-1):

--- a/python/cusignal/filtering/resample.py
+++ b/python/cusignal/filtering/resample.py
@@ -156,7 +156,7 @@ def decimate(
         # upfirdn is generally faster than lfilter by a factor equal to the
         # downsampling factor, since it only calculates the needed outputs
         n_out = x.shape[axis] // q + bool(x.shape[axis] % q)
-        y = upfirdn(b, x, up=1, down=q, axis=axis)
+        y = upfirdn(b, x, 1, q, axis, cp_stream, autosync, use_numba)
         sl[axis] = slice(None, n_out, None)
 
     return y[tuple(sl)]
@@ -445,7 +445,7 @@ def resample_poly(
     n_pre_remove_end = n_pre_remove + n_out
 
     # filter then remove excess
-    y = upfirdn(h, x, up, down, axis=axis, use_numba=use_numba)
+    y = upfirdn(h, x, up, down, axis, cp_stream, autosync, use_numba)
     keep = [slice(None)] * x.ndim
     keep[axis] = slice(n_pre_remove, n_pre_remove_end)
     return y[tuple(keep)]

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -243,8 +243,7 @@ class TestSignaltools:
 
     @pytest.mark.parametrize("num_signals", [1, 2, 10])
     @pytest.mark.parametrize("num_samps", [100])
-    @pytest.mark.parametrize("use_numba", [True])
-    def test_sosfilt(self, num_signals, num_samps, use_numba):
+    def test_sosfilt(self, num_signals, num_samps):
         cpu_sig = np.random.rand(num_signals, num_samps)
         gpu_sig = cp.asarray(cpu_sig)
 
@@ -255,7 +254,7 @@ class TestSignaltools:
         gpu_sos = cp.asarray(cpu_sos)
 
         gpu_sosfilt = cp.asnumpy(
-            cusignal.sosfilt(gpu_sos, gpu_sig, use_numba=use_numba)
+            cusignal.sosfilt(gpu_sos, gpu_sig)
         )
 
         assert array_equal(cpu_sosfilt, gpu_sosfilt)

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -240,3 +240,22 @@ class TestSignaltools:
         )
 
         assert array_equal(cpu_decimate, gpu_decimate)
+
+    @pytest.mark.parametrize("num_signals", [1, 2, 10])
+    @pytest.mark.parametrize("num_samps", [100])
+    @pytest.mark.parametrize("use_numba", [True])
+    def test_sosfilt(self, num_signals, num_samps, use_numba):
+        cpu_sig = np.random.rand(num_signals, num_samps)
+        gpu_sig = cp.asarray(cpu_sig)
+
+        cpu_sos = signal.ellip(64, 0.009, 80, 0.05, output='sos')
+
+        cpu_sosfilt = signal.sosfilt(cpu_sos, cpu_sig)
+
+        gpu_sos = cp.asarray(cpu_sos)
+
+        gpu_sosfilt = cp.asnumpy(
+            cusignal.sosfilt(gpu_sos, gpu_sig, use_numba=use_numba)
+        )
+
+        assert array_equal(cpu_sosfilt, gpu_sosfilt)

--- a/python/cusignal/utils/compile_kernels.py
+++ b/python/cusignal/utils/compile_kernels.py
@@ -35,7 +35,11 @@ from ..spectral_analysis._spectral_cuda import (
     _numba_lombscargle,
     _numba_lombscargle_signature,
 )
-
+from ..filtering._sosfilt_cuda import (
+    _cupy_sosfilt_src,
+    _numba_sosfilt,
+    _numba_sosfilt_signature,
+)
 from ..filtering._upfirdn_cuda import (
     _cupy_upfirdn_1d_src,
     _cupy_upfirdn_2d_src,
@@ -59,6 +63,7 @@ class GPUKernel(Enum):
     CORRELATE2D = 'correlate2d'
     CONVOLVE2D = 'convolve2d'
     LOMBSCARGLE = 'lombscargle'
+    SOSFILT = 'sosfilt'
     UPFIRDN = 'upfirdn'
     UPFIRDN2D = 'upfirdn2d'
 
@@ -74,6 +79,11 @@ _SUPPORTED_TYPES_CONVOLVE = {
 }
 
 _SUPPORTED_TYPES_LOMBSCARGLE = {
+    np.float32: [float32, "float"],
+    np.float64: [float64, "double"],
+}
+
+_SUPPORTED_TYPES_SOSFILT = {
     np.float32: [float32, "float"],
     np.float64: [float64, "double"],
 }
@@ -128,6 +138,9 @@ def _get_supported_types(k_type):
 
     elif k_type == GPUKernel.LOMBSCARGLE:
         SUPPORTED_TYPES = _SUPPORTED_TYPES_LOMBSCARGLE
+
+    elif k_type == GPUKernel.SOSFILT:
+        SUPPORTED_TYPES = _SUPPORTED_TYPES_SOSFILT
 
     elif k_type == GPUKernel.UPFIRDN or k_type == GPUKernel.UPFIRDN2D:
         SUPPORTED_TYPES = _SUPPORTED_TYPES_UPFIRDN
@@ -228,6 +241,18 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
             _cupy_kernel_cache[
                 (str(numba_type), k_type.value)
             ] = module.get_function("_cupy_lombscargle")
+
+        elif k_type == GPUKernel.SOSFILT:
+            src = _cupy_sosfilt_src.substitute(
+                datatype=c_type, header=header
+            )
+            module = cp.RawModule(
+                code=src, options=("-std=c++11", "-use_fast_math")
+            )
+            _cupy_kernel_cache[
+                (str(numba_type), k_type.value)
+            ] = module.get_function("_cupy_sosfilt")
+
         elif k_type == GPUKernel.UPFIRDN:
             src = _cupy_upfirdn_1d_src.substitute(
                 datatype=c_type, header=header
@@ -283,16 +308,25 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
             _numba_kernel_cache[(str(numba_type), k_type.value)] = cuda.jit(
                 sig, fastmath=True
             )(_numba_lombscargle)
+
+        elif k_type == GPUKernel.SOSFILT:
+            sig = _numba_sosfilt_signature(numba_type)
+            _numba_kernel_cache[(str(numba_type), k_type.value)] = cuda.jit(
+                sig, fastmath=True, max_registers=64
+            )(_numba_sosfilt)
+
         elif k_type == GPUKernel.UPFIRDN:
             sig = _numba_upfirdn_1d_signature(numba_type)
             _numba_kernel_cache[(str(numba_type), k_type.value)] = cuda.jit(
                 sig, fastmath=True
             )(_numba_upfirdn_1d)
+
         elif k_type == GPUKernel.UPFIRDN2D:
             sig = _numba_upfirdn_2d_signature(numba_type)
             _numba_kernel_cache[(str(numba_type), k_type.value)] = cuda.jit(
                 sig, fastmath=True
             )(_numba_upfirdn_2d)
+
         else:
             raise NotImplementedError(
                 "No kernel found for k_type {}, datatype {}".format(

--- a/python/cusignal/utils/compile_kernels.py
+++ b/python/cusignal/utils/compile_kernels.py
@@ -37,8 +37,6 @@ from ..spectral_analysis._spectral_cuda import (
 )
 from ..filtering._sosfilt_cuda import (
     _cupy_sosfilt_src,
-    _numba_sosfilt,
-    _numba_sosfilt_signature,
 )
 from ..filtering._upfirdn_cuda import (
     _cupy_upfirdn_1d_src,
@@ -310,10 +308,11 @@ def _populate_kernel_cache(np_type, use_numba, k_type):
             )(_numba_lombscargle)
 
         elif k_type == GPUKernel.SOSFILT:
-            sig = _numba_sosfilt_signature(numba_type)
-            _numba_kernel_cache[(str(numba_type), k_type.value)] = cuda.jit(
-                sig, fastmath=True, max_registers=64
-            )(_numba_sosfilt)
+            raise NotImplementedError(
+                "{} Numba has no Numba Implementation".format(
+                    k_type
+                )
+            )
 
         elif k_type == GPUKernel.UPFIRDN:
             sig = _numba_upfirdn_1d_signature(numba_type)


### PR DESCRIPTION
Scaffolding code for our `sosfilt` implementation. A few things here:
* `sosfilt` placed in `filtering/filtering.py`
* added `filter_design_utils.py` in `filter_design` for sos structure validation
* Added `sosfilt` Python code (to be moved to Numba/CuPy CUDA) in `filtering/_sosfilt_cuda.py`
* Updated documentation for sosfilt. @mnicely -- the example listed in the doc should serve as a good test case. I've pasted it below, too:

```python
from scipy import signal
import cusignal
import cupy as cp

# Generate filter on CPU with Scipy.Signal then move to GPU
sos = signal.ellip(13, 0.009, 80, 0.05, output='sos')
sos = cp.asarray(sos)

x = cp.random.randn(100_000_000)
y = cusignal.sosfilt(sos, x)
```

To-do:

- [ ] Create CUDA kernel for sosfilt with no initial conditions (e.g. Zi = None) - @mnicely 
- [ ] Build out `sos` filter output representation (e.g. cusignal equivalent of `signal.ellip(output='sos')` - @awthomp 
- [ ] Performance evaluation w.r.t. SciPy Signal
- [ ] Confirm I have a sensible code structure
- [ ] Eventually build out support for initial conditions (e.g. Zi is not None).

I'm going to target this for 0.15 but think the algorithm is straighforward enough to get into 0.14.

closes https://github.com/rapidsai/cusignal/issues/52