### PR TITLE
[REVIEW] Install dependencies via meta package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 - PR #112 - Remove Numba kernels
 - PR #121 - Add docs build script
+- PR #126 - Install dependencies via meta package
 
 ## Bug Fixes
 - PR #116 - Fix stream usage on CuPy raw kernels

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -44,12 +44,11 @@ logger "Activate conda env..."
 source activate gdf
 conda install -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=${CUDA_REL} \
-    "scipy>=1.3.0" \
-    "numpy>=1.17.3" \
-    boost \
-    "numba>=0.49.0" \
-    "cupy>=7.2.0" \
-    pytest-benchmark
+    "rapids-build-env=$MINOR_VERSION.*"
+
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env rapids-notebook-env
+# conda install "your-pkg=1.0.0"
 
 logger "Check versions..."
 python --version


### PR DESCRIPTION
Install dependencies via `rapids-build-env` (which is pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/

Depends on https://github.com/rapidsai/integration/pull/49