### PR TITLE
[REVIEW] Add Jupyter Notebook to Show I/O Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #112 - Remove Numba kernels
 - PR #121 - Add docs build script
 - PR #126 - Install dependencies via meta package
+- PR #131 - Add IO API guide Jupyter notebook
 
 ## Bug Fixes
 - PR #116 - Fix stream usage on CuPy raw kernels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - PR #112 - Remove Numba kernels
 - PR #121 - Add docs build script
 - PR #126 - Install dependencies via meta package
-- PR #131 - Add IO API guide Jupyter notebook
+- PR #132 - Add IO API guide Jupyter notebook
 
 ## Bug Fixes
 - PR #116 - Fix stream usage on CuPy raw kernels

--- a/notebooks/api_guide/io_examples.ipynb
+++ b/notebooks/api_guide/io_examples.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Demonstration of GPU Accelerated SigMF Reader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import numpy as np\n",
+    "import cupy as cp\n",
+    "import cusignal\n",
+    "\n",
+    "cusignal.precompile_kernels()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta_file = '/data/oracle/KRI-16Devices-RawData/2ft/WiFi_air_X310_3123D7B_2ft_run1.sigmf-meta'\n",
+    "data_file = '/data/oracle/KRI-16Devices-RawData/2ft/WiFi_air_X310_3123D7B_2ft_run1.sigmf-data'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Baseline Reader (CPU, Numpy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(meta_file, 'r') as f:\n",
+    "    md = json.loads(f.read())\n",
+    "\n",
+    "if md['_metadata']['global']['core:datatype'] == 'cf32':\n",
+    "    data_type = np.complex64"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "137 ms ± 334 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "data_cpu = np.fromfile(data_file, dtype=data_type)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Baseline Reader (GPU, Numpy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "198 ms ± 2.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "data_gpu = cp.fromfile(data_file, dtype=data_type)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### cuSignal - Default Reader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "82 ms ± 284 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "data_cusignal = cusignal.read_sigmf(data_file, meta_file)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### cuSignal - Use Pinned GPU Array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binary = cusignal.read_bin(data_file)\n",
+    "buffer = cusignal.get_pinned_mem(binary.shape, cp.ubyte)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "82.1 ms ± 66.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "data_cusignal_pinned = cusignal.read_sigmf(data_file, meta_file, buffer)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### cuSignal - Use Shared Array (Zero Copy between CPU <-> GPU)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binary = cusignal.read_bin(data_file)\n",
+    "buffer = cusignal.get_shared_mem(binary.shape, cp.ubyte)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "139 ms ± 861 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "data_cusignal_shared = cusignal.read_sigmf(data_file, meta_file, buffer)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/api_guide/io_examples.ipynb
+++ b/notebooks/api_guide/io_examples.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please note that our work with both SigMF readers and writers is focused on appropriately handling the data payload on GPU. This is similar to our usage of DPDK within the Aerial SDK and cuVNF."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -22,6 +29,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are using the Northeastern University Oracle SigMF recordings found [here](http://www.genesys-lab.org/oracle)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -29,6 +43,20 @@
    "source": [
     "meta_file = '/data/oracle/KRI-16Devices-RawData/2ft/WiFi_air_X310_3123D7B_2ft_run1.sigmf-meta'\n",
     "data_file = '/data/oracle/KRI-16Devices-RawData/2ft/WiFi_air_X310_3123D7B_2ft_run1.sigmf-data'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reader (Binary and SigMF)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For our purposes here, [SigMF](https://github.com/gnuradio/SigMF) data is treated as a JSON header and processed on CPU, while the *binary* payload file is mmaped to GPU and cuSignal uses a CUDA kernel to parse the file. While we've focused on SigMF here, you can use the underlying `cusignal.read_bin` and `cusignal.parse_bin` (and corresponding write functions) for your own datasets."
    ]
   },
   {
@@ -60,7 +88,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "137 ms ± 334 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "128 ms ± 147 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -85,7 +113,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "198 ms ± 2.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "188 ms ± 341 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -99,7 +127,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### cuSignal - Default Reader"
+    "### cuSignal - Use Paged Memory (Default)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This method is preferred for offline signal processing and is the easiest to use"
    ]
   },
   {
@@ -111,7 +146,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "82 ms ± 284 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "82.2 ms ± 172 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -125,7 +160,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### cuSignal - Use Pinned GPU Array"
+    "### cuSignal - Use Pinned Buffer (Pinned)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This method is preferred for online signal processing tasks when you're streaming data to the GPU with known and consistent data sizes"
    ]
   },
   {
@@ -147,7 +189,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "82.1 ms ± 66.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "82.2 ms ± 50.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -161,7 +203,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### cuSignal - Use Shared Array (Zero Copy between CPU <-> GPU)"
+    "### cuSignal - Use Shared Buffer (Mapped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This method is preferred for the Jetson line of embedded GPUs. We're showing performance here on a PCIe GPU (which is why it's so slow!)"
    ]
   },
   {
@@ -183,13 +232,159 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "139 ms ± 861 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "82.8 ms ± 866 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
     "data_cusignal_shared = cusignal.read_sigmf(data_file, meta_file, buffer)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Writer (Binary and SigMF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "sigmf = cusignal.read_sigmf(data_file, meta_file)\n",
+    "test_file_ext = \"test-data.sigmf-data\"\n",
+    "\n",
+    "if os.path.exists(test_file_ext):\n",
+    "    os.remove(test_file_ext)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Baseline Writer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "338 ms ± 837 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "sigmf.tofile(test_file_ext)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### cuSignal - Use Paged Memory (Default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "341 ms ± 830 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "cusignal.write_sigmf(test_file_ext, sigmf, append=False)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### cuSignal - Use Pinned Buffer (Pinned)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binary = cusignal.read_bin(data_file)\n",
+    "buffer = cusignal.get_pinned_mem(binary.shape, cp.ubyte)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "253 ms ± 1.22 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "cusignal.write_sigmf(test_file_ext, sigmf, buffer, append=False)\n",
+    "cp.cuda.runtime.deviceSynchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### cuSignal - Use Mapped Buffer (Mapped)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binary = cusignal.read_bin(data_file)\n",
+    "buffer = cusignal.get_shared_mem(binary.shape, cp.ubyte)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "253 ms ± 950 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "cusignal.write_sigmf(test_file_ext, sigmf, buffer, append=False)\n",
     "cp.cuda.runtime.deviceSynchronize()"
    ]
   }


### PR DESCRIPTION
Adding a new `api_guide` Jupyter notebook to demonstrate how to GPU accelerate SigMF/binary data reads with cuSignal. 

To-Do

- [x] Show API for signal writes
- [x] Show CUDA stream usage to overlap IO with compute