### PR TITLE
[PR-REVIEW] Fix overflow issues in upfirdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #116 - Fix stream usage on CuPy raw kernels
 - PR #124 - Remove cp_stream and autosync
 - PR #127 - Fix selected documentation formatting errors
+- PR #138 - Fix overflow issues in `upfirdn`
 
 
 # cuSignal 0.14 (03 Jun 2020)

--- a/python/cusignal/filtering/_upfirdn_cuda.py
+++ b/python/cusignal/filtering/_upfirdn_cuda.py
@@ -67,7 +67,7 @@ extern "C" {
             static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x) };
         const int stride { static_cast<int>(blockDim.x * gridDim.x) };
 
-        for ( int tid = t; tid < outW; tid += stride ) {
+        for ( size_t tid = t; tid < outW; tid += stride ) {
             int x_idx { static_cast<int>((tid * down) / up) % padded_len };
             int h_idx { (tid * down) % up * h_per_phase };
             int x_conv_idx { x_idx - h_per_phase + 1 };

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -38,11 +38,29 @@ class TestSignaltools:
 
         assert array_equal(cpu_resample, gpu_resample)
 
-    @pytest.mark.parametrize("num_samps", [2 ** 14])
-    @pytest.mark.parametrize("up", [2, 3, 7])
-    @pytest.mark.parametrize("down", [1, 2, 9])
+    @pytest.mark.parametrize("num_samps", [2 ** 14, 2 ** 24])
+    @pytest.mark.parametrize("up", [2, 3, 7, 400])
+    @pytest.mark.parametrize("down", [1, 2, 9, 1333])
     @pytest.mark.parametrize("window", [("kaiser", 0.5)])
     def test_resample_poly(
+        self, linspace_data_gen, num_samps, up, down, window
+    ):
+        cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)
+
+        cpu_resample = signal.resample_poly(cpu_sig, up, down, window=window)
+        gpu_resample = cp.asnumpy(
+            cusignal.resample_poly(
+                gpu_sig, up, down, window=window
+            )
+        )
+
+        assert array_equal(cpu_resample, gpu_resample)
+
+    @pytest.mark.parametrize("num_samps", [2 ** 24])
+    @pytest.mark.parametrize("up", [400, 1234])
+    @pytest.mark.parametrize("down", [1333, 2123])
+    @pytest.mark.parametrize("window", [("kaiser", 0.5)])
+    def test_resample_poly_big(
         self, linspace_data_gen, num_samps, up, down, window
     ):
         cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -49,9 +49,7 @@ class TestSignaltools:
 
         cpu_resample = signal.resample_poly(cpu_sig, up, down, window=window)
         gpu_resample = cp.asnumpy(
-            cusignal.resample_poly(
-                gpu_sig, up, down, window=window
-            )
+            cusignal.resample_poly(gpu_sig, up, down, window=window)
         )
 
         assert array_equal(cpu_resample, gpu_resample)
@@ -67,9 +65,7 @@ class TestSignaltools:
 
         cpu_resample = signal.resample_poly(cpu_sig, up, down, window=window)
         gpu_resample = cp.asnumpy(
-            cusignal.resample_poly(
-                gpu_sig, up, down, window=window
-            )
+            cusignal.resample_poly(gpu_sig, up, down, window=window)
         )
 
         assert array_equal(cpu_resample, gpu_resample)
@@ -83,9 +79,7 @@ class TestSignaltools:
         h = [1, 1, 1]
 
         cpu_resample = signal.upfirdn(h, cpu_sig, up, down)
-        gpu_resample = cp.asnumpy(
-            cusignal.upfirdn(h, gpu_sig, up, down)
-        )
+        gpu_resample = cp.asnumpy(cusignal.upfirdn(h, gpu_sig, up, down))
 
         assert array_equal(cpu_resample, gpu_resample)
 
@@ -98,9 +92,7 @@ class TestSignaltools:
         h = [1, 1, 1]
 
         cpu_resample = signal.upfirdn(h, cpu_sig, up, down)
-        gpu_resample = cp.asnumpy(
-            cusignal.upfirdn(h, gpu_sig, up, down)
-        )
+        gpu_resample = cp.asnumpy(cusignal.upfirdn(h, gpu_sig, up, down))
 
         assert array_equal(cpu_resample, gpu_resample)
 
@@ -202,10 +194,7 @@ class TestSignaltools:
 
         gpu_convolve2d = cp.asnumpy(
             cusignal.convolve2d(
-                gpu_sig,
-                gpu_filt,
-                boundary=boundary,
-                mode=mode,
+                gpu_sig, gpu_filt, boundary=boundary, mode=mode,
             )
         )
         assert array_equal(cpu_convolve2d, gpu_convolve2d)
@@ -225,10 +214,7 @@ class TestSignaltools:
         )
         gpu_correlate2d = cp.asnumpy(
             cusignal.correlate2d(
-                gpu_sig,
-                gpu_filt,
-                boundary=boundary,
-                mode=mode,
+                gpu_sig, gpu_filt, boundary=boundary, mode=mode,
             )
         )
         assert array_equal(cpu_correlate2d, gpu_correlate2d)
@@ -258,14 +244,12 @@ class TestSignaltools:
         cpu_sig = np.random.rand(num_signals, num_samps)
         gpu_sig = cp.asarray(cpu_sig)
 
-        cpu_sos = signal.ellip(64, 0.009, 80, 0.05, output='sos')
+        cpu_sos = signal.ellip(64, 0.009, 80, 0.05, output="sos")
 
         cpu_sosfilt = signal.sosfilt(cpu_sos, cpu_sig)
 
         gpu_sos = cp.asarray(cpu_sos)
 
-        gpu_sosfilt = cp.asnumpy(
-            cusignal.sosfilt(gpu_sos, gpu_sig)
-        )
+        gpu_sosfilt = cp.asnumpy(cusignal.sosfilt(gpu_sos, gpu_sig))
 
         assert array_equal(cpu_sosfilt, gpu_sosfilt)

--- a/python/cusignal/test/test_signaltools.py
+++ b/python/cusignal/test/test_signaltools.py
@@ -39,8 +39,8 @@ class TestSignaltools:
         assert array_equal(cpu_resample, gpu_resample)
 
     @pytest.mark.parametrize("num_samps", [2 ** 14, 2 ** 24])
-    @pytest.mark.parametrize("up", [2, 3, 7, 400])
-    @pytest.mark.parametrize("down", [1, 2, 9, 1333])
+    @pytest.mark.parametrize("up", [2, 3, 7])
+    @pytest.mark.parametrize("down", [1, 2, 9])
     @pytest.mark.parametrize("window", [("kaiser", 0.5)])
     def test_resample_poly(
         self, linspace_data_gen, num_samps, up, down, window


### PR DESCRIPTION
## Info
This PR is to fix #137 , where an overflow issue occurs in the `_cupy_upfirdn_1d()` function.

The fix consists of using `size_t` over `int`.

Adding tests as well.

This only fixes the CuPy raw kernel in 0.15.