### PR TITLE
[REVIEW] Added AIR-T conda recipe so that cuSignal officially support the AIR_T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # cuSignal 0.15.0 (Date TBD)
 
 ## New Features
+- PR #144 - Added AIR-T conda recipe
 - PR #119 - Added code of conduct
 - PR #122 - GPU accelerated SigMF Reader
 - PR #136 - Split reader and writer in IO packages and update docs

--- a/conda/environments/cusignal_airt.yml
+++ b/conda/environments/cusignal_airt.yml
@@ -1,0 +1,21 @@
+name: cusignal
+channels:
+  - conda-forge
+  - nvidia
+  - defaults
+  - numba
+dependencies:
+  - python=3.6.9
+  - scipy>=1.4.0,<1.5.0
+  - numpy
+  - matplotlib
+  - numba>=0.49
+  - pytest
+  - pytest-benchmark
+  - sphinx
+  - sphinx_rtd_theme
+  - numpydoc
+  - ipython
+  - pip
+  - pip:
+    - cupy>=7.2.0


### PR DESCRIPTION
Added AIR-T conda recipe so that cuSignal officially support the AIR_T