### PR TITLE
[REVIEW] Fix bug in detrend calculation due to NotImplementedError with array slicing in cupy's r_ functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #138 - Fix overflow issues in `upfirdn`
 - PR #139 - Fixes packaging of python package
 - PR #143 - Fix six package missing with Scipy 1.5
+- PR #151 - Fix error in detrend related to missing indexing support with cp.r_
 
 
 # cuSignal 0.14 (03 Jun 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - PR #138 - Fix overflow issues in `upfirdn`
 - PR #139 - Fixes packaging of python package
 - PR #143 - Fix six package missing with Scipy 1.5
-- PR #151 - Fix error in detrend related to missing indexing support with cp.r_
+- PR #152 - Fix error in detrend related to missing indexing support with cp.r_
 
 
 # cuSignal 0.14 (03 Jun 2020)

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -159,10 +159,10 @@ def lfiltic(b, a, y, x=None):
         y = r_[y, zeros(N - L)]
 
     for m in range(M):
-        zi[m] = cp.sum(b[m + 1 :] * x[: M - m], axis=0)
+        zi[m] = cp.sum(b[m + 1:] * x[:M - m], axis=0)
 
     for m in range(N):
-        zi[m] -= cp.sum(a[m + 1 :] * y[: N - m], axis=0)
+        zi[m] -= cp.sum(a[m + 1:] * y[:N - m], axis=0)
 
     return zi
 
@@ -425,10 +425,10 @@ def hilbert(x, N=None, axis=-1):
     h = zeros(N)
     if N % 2 == 0:
         h[0] = h[N // 2] = 1
-        h[1 : N // 2] = 2
+        h[1:N // 2] = 2
     else:
         h[0] = 1
-        h[1 : (N + 1) // 2] = 2
+        h[1:(N + 1) // 2] = 2
 
     if x.ndim > 1:
         ind = [newaxis] * x.ndim
@@ -484,10 +484,10 @@ def hilbert2(x, N=None):
         N1 = N[p]
         if N1 % 2 == 0:
             h[0] = h[N1 // 2] = 1
-            h[1 : N1 // 2] = 2
+            h[1:N1 // 2] = 2
         else:
             h[0] = 1
-            h[1 : (N1 + 1) // 2] = 2
+            h[1:(N1 + 1) // 2] = 2
         exec("h%d = h" % (p + 1), globals(), locals())
 
     h = h1[:, newaxis] * h2[newaxis, :]
@@ -537,7 +537,6 @@ def detrend(data, axis=-1, type="linear", bp=0, overwrite_data=False):
     >>> x = 3 + 2*cp.linspace(0, 1, npoints) + noise
     >>> (cusignal.detrend(x) - noise).max() < 0.01
     True
-
     """
     if type not in ["linear", "l", "constant", "c"]:
         raise ValueError("Trend type must be 'linear' or 'constant'.")
@@ -563,7 +562,7 @@ def detrend(data, axis=-1, type="linear", bp=0, overwrite_data=False):
         rnk = len(dshape)
         if axis < 0:
             axis = axis + rnk
-        newdims = cp.r_[axis, 0:axis, axis + 1 : rnk]
+        newdims = np.r_[axis, 0:axis, axis + 1:rnk]
         newdata = reshape(
             transpose(data, tuple(newdims)), (N, _prod(dshape) // N)
         )


### PR DESCRIPTION
closes https://github.com/rapidsai/cusignal/issues/151

Using numpy's `r_` functionality to calculate new array dimensions. Since this is an 'array setup' operation, I don't anticipate a major performance hit here.