### PR TITLE
[PR-REVIEW] Add debugging environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #146 - Add compatibility with Scipy 1.5.0
 - PR #149 - Update Jetson conda to miniforge, Fix CoC, and Add SciPy Talk
 - PR #69 - Multi-point Kalman Filter
+- PR #158 - Add debug flag for debugging
 
 ## Improvements
 - PR #112 - Remove Numba kernels

--- a/kalman_test_script.py
+++ b/kalman_test_script.py
@@ -10,8 +10,8 @@ from cupy import prof
 
 dim_x = 4
 dim_z = 4
-loops = 1
-iterations = 1
+loops = 10
+iterations = 250
 
 cpu_baseline32 = 0.0
 cpu_baseline64 = 0.0

--- a/kalman_test_script.py
+++ b/kalman_test_script.py
@@ -10,8 +10,8 @@ from cupy import prof
 
 dim_x = 4
 dim_z = 4
-loops = 10
-iterations = 250
+loops = 1
+iterations = 1
 
 cpu_baseline32 = 0.0
 cpu_baseline64 = 0.0

--- a/python/cusignal/convolution/_convolution_cuda.py
+++ b/python/cusignal/convolution/_convolution_cuda.py
@@ -17,6 +17,7 @@ import numpy as np
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache
+from ..utils.debugtools import print_atts
 from .convolution_utils import (
     FULL,
     SAME,
@@ -417,6 +418,8 @@ def _convolve_gpu(
 
     kernel(d_inp, d_kernel, mode, swapped_inputs, out)
 
+    print_atts(kernel)
+
     return out
 
 
@@ -518,6 +521,8 @@ def _convolve2d_gpu(
     kernel(
         d_inp, paddedW, paddedH, d_kernel, S[0], S[1], out, outW, outH, pick
     )
+
+    print_atts(kernel)
 
     return out
 

--- a/python/cusignal/estimation/filters.py
+++ b/python/cusignal/estimation/filters.py
@@ -12,10 +12,10 @@
 # limitations under the License.
 
 import cupy as cp
-import os
 import pkg_resources
 
 from . import _filters
+from ..utils.debugtools import print_atts
 
 
 class KalmanFilter(object):
@@ -129,23 +129,8 @@ class KalmanFilter(object):
             _filters.GPUKernel.UPDATE,
         )
 
-        if 'CUSIGNAL_DEV_DEBUG' in os.environ:
-            print("Predict")
-            print(self.predict_kernel.kernel.const_size_bytes)
-            print(self.predict_kernel.kernel.local_size_bytes)
-            print(self.predict_kernel.kernel.max_dynamic_shared_size_bytes)
-            print(self.predict_kernel.kernel.max_threads_per_block)
-            print(self.predict_kernel.kernel.num_regs)
-            print(self.predict_kernel.kernel.shared_size_bytes)
-            print()
-            print("Update")
-            print(self.update_kernel.kernel.const_size_bytes)
-            print(self.update_kernel.kernel.local_size_bytes)
-            print(self.update_kernel.kernel.max_dynamic_shared_size_bytes)
-            print(self.update_kernel.kernel.max_threads_per_block)
-            print(self.update_kernel.kernel.num_regs)
-            print(self.update_kernel.kernel.shared_size_bytes)
-            print()
+        print_atts(self.predict_kernel)
+        print_atts(self.predict_kernel)
 
     def predict(self):
 

--- a/python/cusignal/estimation/filters.py
+++ b/python/cusignal/estimation/filters.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import cupy as cp
+import os
 import pkg_resources
 
 from . import _filters
@@ -128,25 +129,23 @@ class KalmanFilter(object):
             _filters.GPUKernel.UPDATE,
         )
 
-        # print("Predict")
-        # print(self.predict_kernel.kernel.const_size_bytes)
-        # print(self.predict_kernel.kernel.local_size_bytes)
-        # print(self.predict_kernel.kernel.max_dynamic_shared_size_bytes)
-        # print(self.predict_kernel.kernel.max_threads_per_block)
-        # print(self.predict_kernel.kernel.num_regs)
-        # print(self.predict_kernel.kernel.shared_size_bytes)
-        # print()
-        # print("Update")
-        # print(self.update_kernel.kernel.const_size_bytes)
-        # print(self.update_kernel.kernel.local_size_bytes)
-        # print(self.update_kernel.kernel.max_dynamic_shared_size_bytes)
-        # print(self.update_kernel.kernel.max_threads_per_block)
-        # print(self.update_kernel.kernel.num_regs)
-        # print(self.update_kernel.kernel.shared_size_bytes)
-        # print()
-        # print(max_threads_per_block)
-        # print(min_blocks_per_multiprocessor)
-        # print()
+        if 'CUSIGNAL_DEV_DEBUG' in os.environ:
+            print("Predict")
+            print(self.predict_kernel.kernel.const_size_bytes)
+            print(self.predict_kernel.kernel.local_size_bytes)
+            print(self.predict_kernel.kernel.max_dynamic_shared_size_bytes)
+            print(self.predict_kernel.kernel.max_threads_per_block)
+            print(self.predict_kernel.kernel.num_regs)
+            print(self.predict_kernel.kernel.shared_size_bytes)
+            print()
+            print("Update")
+            print(self.update_kernel.kernel.const_size_bytes)
+            print(self.update_kernel.kernel.local_size_bytes)
+            print(self.update_kernel.kernel.max_dynamic_shared_size_bytes)
+            print(self.update_kernel.kernel.max_threads_per_block)
+            print(self.update_kernel.kernel.num_regs)
+            print(self.update_kernel.kernel.shared_size_bytes)
+            print()
 
     def predict(self):
 

--- a/python/cusignal/filtering/_sosfilt_cuda.py
+++ b/python/cusignal/filtering/_sosfilt_cuda.py
@@ -14,6 +14,7 @@
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache
+from ..utils.debugtools import print_atts
 
 
 # Custom Cupy raw kernel implementing lombscargle operation
@@ -223,3 +224,5 @@ def _sosfilt(sos, x, zi):
     )
 
     kernel(sos, x, zi)
+
+    print_atts(kernel)

--- a/python/cusignal/filtering/_upfirdn_cuda.py
+++ b/python/cusignal/filtering/_upfirdn_cuda.py
@@ -17,6 +17,7 @@ from math import ceil
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache
+from ..utils.debugtools import print_atts
 
 
 def _pad_h(h, up):
@@ -328,5 +329,7 @@ class _UpFIRDn(object):
             padded_len,
             out,
         )
+
+        print_atts(kernel)
 
         return out

--- a/python/cusignal/io/_reader_cuda.py
+++ b/python/cusignal/io/_reader_cuda.py
@@ -16,6 +16,7 @@ import cupy as cp
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache
+from ..utils.debugtools import print_atts
 
 
 # Custom Cupy raw kernel implementing binary readers
@@ -225,6 +226,8 @@ def _unpack(binary, dtype, endianness):
     )
 
     kernel(out_size, little, binary, out)
+
+    print_atts(kernel)
 
     # Remove binary data
     del binary

--- a/python/cusignal/io/_writer_cuda.py
+++ b/python/cusignal/io/_writer_cuda.py
@@ -16,6 +16,7 @@ import cupy as cp
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache
+from ..utils.debugtools import print_atts
 
 
 # Custom Cupy raw kernel implementing binary writers
@@ -97,6 +98,8 @@ def _pack(binary):
     )
 
     kernel(out_size, binary, out)
+
+    print_atts(kernel)
 
     # Remove binary data
     del binary

--- a/python/cusignal/spectral_analysis/_spectral_cuda.py
+++ b/python/cusignal/spectral_analysis/_spectral_cuda.py
@@ -16,6 +16,7 @@ import cupy as cp
 from string import Template
 
 from ..utils._caches import _cupy_kernel_cache
+from ..utils.debugtools import print_atts
 
 
 # Custom Cupy raw kernel implementing lombscargle operation
@@ -151,3 +152,5 @@ def _lombscargle(x, y, freqs, pgram, y_dot):
     )
 
     kernel(x, y, freqs, pgram, y_dot)
+
+    print_atts(kernel)

--- a/python/cusignal/utils/arraytools.py
+++ b/python/cusignal/utils/arraytools.py
@@ -16,8 +16,9 @@ from numba import cuda
 import numpy as np
 
 
-def get_shared_array(data, strides=None, order='C', stream=0, portable=False,
-                     wc=True):
+def get_shared_array(
+    data, strides=None, order="C", stream=0, portable=False, wc=True
+):
     """Return populated shared memory between GPU and CPU.
 
     Parameters
@@ -36,10 +37,15 @@ def get_shared_array(data, strides=None, order='C', stream=0, portable=False,
     dtype = data.dtype
 
     # Allocate mapped, shared memory in Numba
-    shared_mem_array = cuda.mapped_array(shape, dtype=dtype,
-                                         strides=strides,
-                                         order=order, stream=stream,
-                                         portable=portable, wc=wc)
+    shared_mem_array = cuda.mapped_array(
+        shape,
+        dtype=dtype,
+        strides=strides,
+        order=order,
+        stream=stream,
+        portable=portable,
+        wc=wc,
+    )
 
     # Load data into array space
     shared_mem_array[:] = data
@@ -48,8 +54,15 @@ def get_shared_array(data, strides=None, order='C', stream=0, portable=False,
 
 
 # Return shared memory array - similar to np.empty
-def get_shared_mem(shape, dtype=np.float32, strides=None, order='C', stream=0,
-                   portable=False, wc=True):
+def get_shared_mem(
+    shape,
+    dtype=np.float32,
+    strides=None,
+    order="C",
+    stream=0,
+    portable=False,
+    wc=True,
+):
     """Return shared memory between GPU and CPU. Similar to numpy.zeros
 
     Parameters
@@ -66,8 +79,15 @@ def get_shared_mem(shape, dtype=np.float32, strides=None, order='C', stream=0,
     wc : bool
     """
 
-    return cuda.mapped_array(shape, dtype=dtype, strides=strides, order=order,
-                             stream=stream, portable=portable, wc=wc)
+    return cuda.mapped_array(
+        shape,
+        dtype=dtype,
+        strides=strides,
+        order=order,
+        stream=stream,
+        portable=portable,
+        wc=wc,
+    )
 
 
 def get_pinned_array(data):
@@ -204,17 +224,20 @@ def _odd_ext(x, n, axis=-1):
     if n < 1:
         return x
     if n > x.shape[axis] - 1:
-        raise ValueError(("The extension length n (%d) is too big. " +
-                         "It must not exceed x.shape[axis]-1, which is %d.")
-                         % (n, x.shape[axis] - 1))
+        raise ValueError(
+            (
+                "The extension length n (%d) is too big. "
+                + "It must not exceed x.shape[axis]-1, which is %d."
+            )
+            % (n, x.shape[axis] - 1)
+        )
     left_end = _axis_slice(x, start=0, stop=1, axis=axis)
     left_ext = _axis_slice(x, start=n, stop=0, step=-1, axis=axis)
     right_end = _axis_slice(x, start=-1, axis=axis)
     right_ext = _axis_slice(x, start=-2, stop=-(n + 2), step=-1, axis=axis)
-    ext = cp.concatenate((2 * left_end - left_ext,
-                          x,
-                          2 * right_end - right_ext),
-                         axis=axis)
+    ext = cp.concatenate(
+        (2 * left_end - left_ext, x, 2 * right_end - right_ext), axis=axis
+    )
     return ext
 
 
@@ -258,15 +281,16 @@ def _even_ext(x, n, axis=-1):
     if n < 1:
         return x
     if n > x.shape[axis] - 1:
-        raise ValueError(("The extension length n (%d) is too big. " +
-                         "It must not exceed x.shape[axis]-1, which is %d.")
-                         % (n, x.shape[axis] - 1))
+        raise ValueError(
+            (
+                "The extension length n (%d) is too big. "
+                + "It must not exceed x.shape[axis]-1, which is %d."
+            )
+            % (n, x.shape[axis] - 1)
+        )
     left_ext = _axis_slice(x, start=n, stop=0, step=-1, axis=axis)
     right_ext = _axis_slice(x, start=-2, stop=-(n + 2), step=-1, axis=axis)
-    ext = cp.concatenate((left_ext,
-                          x,
-                          right_ext),
-                         axis=axis)
+    ext = cp.concatenate((left_ext, x, right_ext), axis=axis)
     return ext
 
 
@@ -320,10 +344,7 @@ def _const_ext(x, n, axis=-1):
     left_ext = ones * left_end
     right_end = _axis_slice(x, start=-1, axis=axis)
     right_ext = ones * right_end
-    ext = cp.concatenate((left_ext,
-                          x,
-                          right_ext),
-                         axis=axis)
+    ext = cp.concatenate((left_ext, x, right_ext), axis=axis)
     return ext
 
 
@@ -389,5 +410,6 @@ def _as_strided(x, shape=None, strides=None):
     shape = x.shape if shape is None else tuple(shape)
     strides = x.strides if strides is None else tuple(strides)
 
-    return cp.ndarray(shape=shape, dtype=x.dtype,
-                      memptr=x.data, strides=strides)
+    return cp.ndarray(
+        shape=shape, dtype=x.dtype, memptr=x.data, strides=strides
+    )

--- a/python/cusignal/utils/debugtools.py
+++ b/python/cusignal/utils/debugtools.py
@@ -12,3 +12,24 @@
 # limitations under the License.
 
 import os
+
+
+def print_atts(func):
+    if "CUSIGNAL_DEV_DEBUG" in os.environ:
+        print("name:", func.kernel.name)
+        print("max_threads_per_block:", func.kernel.max_threads_per_block)
+        print("num_regs:", func.kernel.num_regs)
+        print(
+            "max_dynamic_shared_size_bytes:",
+            func.kernel.max_dynamic_shared_size_bytes,
+        )
+        print("shared_size_bytes:", func.kernel.shared_size_bytes)
+        print(
+            "preferred_shared_memory_carveout:",
+            func.kernel.preferred_shared_memory_carveout,
+        )
+        print("const_size_bytes:", func.kernel.const_size_bytes)
+        print("local_size_bytes:", func.kernel.local_size_bytes)
+        print("ptx_version:", func.kernel.ptx_version)
+        print("binary_version:", func.kernel.binary_version)
+        print()

--- a/python/cusignal/utils/debugtools.py
+++ b/python/cusignal/utils/debugtools.py
@@ -15,7 +15,7 @@ import os
 
 
 def print_atts(func):
-    if "CUSIGNAL_DEV_DEBUG" in os.environ:
+    if os.environ.get('CUSIGNAL_DEV_DEBUG') == 'True':
         print("name:", func.kernel.name)
         print("max_threads_per_block:", func.kernel.max_threads_per_block)
         print("num_regs:", func.kernel.num_regs)

--- a/python/cusignal/utils/debugtools.py
+++ b/python/cusignal/utils/debugtools.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os


### PR DESCRIPTION
This PR adds logic to print debug information on CuPy RawKernel if an environment variable is set.

Added logic to `debugtools.py`
```python
def print_atts(func):
    if "CUSIGNAL_DEV_DEBUG" in os.environ:
        print("name:", func.kernel.name)
        print("max_threads_per_block:", func.kernel.max_threads_per_block)
        print("num_regs:", func.kernel.num_regs)
        print(
            "max_dynamic_shared_size_bytes:",
            func.kernel.max_dynamic_shared_size_bytes,
        )
        print("shared_size_bytes:", func.kernel.shared_size_bytes)
        print(
            "preferred_shared_memory_carveout:",
            func.kernel.preferred_shared_memory_carveout,
        )
        print("const_size_bytes:", func.kernel.const_size_bytes)
        print("local_size_bytes:", func.kernel.local_size_bytes)
        print("ptx_version:", func.kernel.ptx_version)
        print("binary_version:", func.kernel.binary_version)
        print()

```

If `CUSIGNAL_DEV_DEBUG` is set print the following.

```bash
name: _cupy_sosfilt
max_threads_per_block: 1024
num_regs: 31
max_dynamic_shared_size_bytes: 49152
shared_size_bytes: 0
preferred_shared_memory_carveout: -1
const_size_bytes: 0
local_size_bytes: 0
ptx_version: 75
binary_version: 75
```