### PR TITLE
[REVIEW] fix typos in example code in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #160 - Update KF functionality
 
 ## Bug Fixes
+- PR #164 - Fix typos in the rest of the example code.
 - PR #162 - Fix typo in example plotting code
 - PR #116 - Fix stream usage on CuPy raw kernels
 - PR #124 - Remove cp_stream and autosync

--- a/python/cusignal/convolution/convolve.py
+++ b/python/cusignal/convolution/convolve.py
@@ -208,13 +208,15 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     --------
     Autocorrelation of white noise is an impulse.
 
-    >>> from scipy import signal
-    >>> sig = np.random.randn(1000)
-    >>> autocorr = signal.fftconvolve(sig, sig[::-1], mode='full')
+    >>> import cusignal
+    >>> import cupy as cp
+    >>> import numpy as np
+    >>> sig = cp.random.randn(1000)
+    >>> autocorr = cusignal.fftconvolve(sig, sig[::-1], mode='full')
 
     >>> import matplotlib.pyplot as plt
     >>> fig, (ax_orig, ax_mag) = plt.subplots(2, 1)
-    >>> ax_orig.plot(sig)
+    >>> ax_orig.plot(cp.asnumpy(sig))
     >>> ax_orig.set_title('White noise')
     >>> ax_mag.plot(np.arange(-len(sig)+1,len(sig)), autocorr)
     >>> ax_mag.set_title('Autocorrelation')
@@ -228,18 +230,18 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
     >>> from scipy import misc
     >>> face = misc.face(gray=True)
-    >>> kernel = np.outer(signal.gaussian(70, 8), signal.gaussian(70, 8))
-    >>> blurred = signal.fftconvolve(face, kernel, mode='same')
+    >>> kernel = cp.outer(cusignal.gaussian(70, 8), cusignal.gaussian(70, 8))
+    >>> blurred = cusignal.fftconvolve(face, kernel, mode='same')
 
     >>> fig, (ax_orig, ax_kernel, ax_blurred) = plt.subplots(3, 1,
     ...                                                      figsize=(6, 15))
     >>> ax_orig.imshow(face, cmap='gray')
     >>> ax_orig.set_title('Original')
     >>> ax_orig.set_axis_off()
-    >>> ax_kernel.imshow(kernel, cmap='gray')
+    >>> ax_kernel.imshow(cp.asnumpy(kernel), cmap='gray')
     >>> ax_kernel.set_title('Gaussian kernel')
     >>> ax_kernel.set_axis_off()
-    >>> ax_blurred.imshow(blurred, cmap='gray')
+    >>> ax_blurred.imshow(cp.asnumpy(blurred), cmap='gray')
     >>> ax_blurred.set_title('Blurred')
     >>> ax_blurred.set_axis_off()
     >>> fig.show()
@@ -387,7 +389,7 @@ def convolve2d(
                 mode='same')
     >>> import matplotlib.pyplot as plt
     >>> fig, (ax_orig, ax_mag, ax_ang) = plt.subplots(3, 1, figsize=(6, 15))
-    >>> ax_orig.imshow(ascent, cmap='gray')
+    >>> ax_orig.imshow(cp.asnumpy(ascent), cmap='gray')
     >>> ax_orig.set_title('Original')
     >>> ax_orig.set_axis_off()
     >>> ax_mag.imshow(cp.asnumpy(cp.absolute(grad)), cmap='gray')

--- a/python/cusignal/convolution/correlate.py
+++ b/python/cusignal/convolution/correlate.py
@@ -103,16 +103,15 @@ def correlate(
 
     >>> import cusignal
     >>> import cupy as cp
-    >>> sig = cp.repeat([0., 1., 1., 0., 1., 0., 0., 1.], 128)
+    >>> sig = cp.repeat(cp.array([0., 1., 1., 0., 1., 0., 0., 1.]), 128)
     >>> sig_noise = sig + cp.random.randn(len(sig))
     >>> corr = cusignal.correlate(sig_noise, cp.ones(128), mode='same') / 128
 
     >>> import matplotlib.pyplot as plt
     >>> clock = cp.arange(64, len(sig), 128)
-    >>> fig, (cp.asnumpy(ax_orig), cp.asnumpy(ax_noise), \
-        cp.asnumpy(ax_corr)) = plt.subplots(3, 1, sharex=True)
-    >>> ax_orig.plot(sig)
-    >>> ax_orig.plot(clock, sig[clock], 'ro')
+    >>> fig, (ax_orig, ax_noise, ax_corr) = plt.subplots(3, 1, sharex=True)
+    >>> ax_orig.plot(cp.asnumpy(sig))
+    >>> ax_orig.plot(cp.asnumpy(clock), cp.asnumpy(sig[clock]), 'ro')
     >>> ax_orig.set_title('Original signal')
     >>> ax_noise.plot(cp.asnumpy(sig_noise))
     >>> ax_noise.set_title('Signal with noise')
@@ -216,8 +215,7 @@ def correlate2d(
         mode='same')
     >>> y, x = cp.unravel_index(cp.argmax(corr), corr.shape)  # find the match
     >>> import matplotlib.pyplot as plt
-    >>> fig, (cp.asnumpy(ax_orig), cp.asnumpy(ax_template), \
-        cp.asnumpy(ax_corr)) = plt.subplots(3, 1, figsize=(6, 15))
+    >>> fig, (ax_orig, ax_template, ax_corr) = plt.subplots(3, 1, figsize=(6, 15))
     >>> ax_orig.imshow(cp.asnumpy(face), cmap='gray')
     >>> ax_orig.set_title('Original')
     >>> ax_orig.set_axis_off()

--- a/python/cusignal/filter_design/fir_filter_design.py
+++ b/python/cusignal/filter_design/fir_filter_design.py
@@ -172,42 +172,42 @@ def firwin(numtaps, cutoff, width=None, window='hamming', pass_zero=True,
     --------
     Low-pass from 0 to f:
 
-    >>> from scipy import signal
+    >>> import cusignal
     >>> numtaps = 3
     >>> f = 0.1
-    >>> signal.firwin(numtaps, f)
+    >>> cusignal.firwin(numtaps, f)
     array([ 0.06799017,  0.86401967,  0.06799017])
 
     Use a specific window function:
 
-    >>> signal.firwin(numtaps, f, window='nuttall')
+    >>> cusignal.firwin(numtaps, f, window='nuttall')
     array([  3.56607041e-04,   9.99286786e-01,   3.56607041e-04])
 
     High-pass ('stop' from 0 to f):
 
-    >>> signal.firwin(numtaps, f, pass_zero=False)
+    >>> cusignal.firwin(numtaps, f, pass_zero=False)
     array([-0.00859313,  0.98281375, -0.00859313])
 
     Band-pass:
 
     >>> f1, f2 = 0.1, 0.2
-    >>> signal.firwin(numtaps, [f1, f2], pass_zero=False)
+    >>> cusignal.firwin(numtaps, [f1, f2], pass_zero=False)
     array([ 0.06301614,  0.88770441,  0.06301614])
 
     Band-stop:
 
-    >>> signal.firwin(numtaps, [f1, f2])
+    >>> cusignal.firwin(numtaps, [f1, f2])
     array([-0.00801395,  1.0160279 , -0.00801395])
 
     Multi-band (passbands are [0, f1], [f2, f3] and [f4, 1]):
 
     >>> f3, f4 = 0.3, 0.4
-    >>> signal.firwin(numtaps, [f1, f2, f3, f4])
+    >>> cusignal.firwin(numtaps, [f1, f2, f3, f4])
     array([-0.01376344,  1.02752689, -0.01376344])
 
     Multi-band (passbands are [f1, f2] and [f3,f4]):
 
-    >>> signal.firwin(numtaps, [f1, f2, f3, f4], pass_zero=False)
+    >>> cusignal.firwin(numtaps, [f1, f2, f3, f4], pass_zero=False)
     array([ 0.04890915,  0.91284326,  0.04890915])
 
     """
@@ -292,9 +292,9 @@ def cmplx_sort(p):
 
     Examples
     --------
-    >>> from scipy import signal
+    >>> import cusignal
     >>> vals = [1, 4, 1+1.j, 3]
-    >>> p_sorted, indx = signal.cmplx_sort(vals)
+    >>> p_sorted, indx = cusignal.cmplx_sort(vals)
     >>> p_sorted
     array([1.+0.j, 1.+1.j, 3.+0.j, 4.+0.j])
     >>> indx

--- a/python/cusignal/filtering/resample.py
+++ b/python/cusignal/filtering/resample.py
@@ -227,7 +227,8 @@ def resample(x, num, t=None, axis=0, window=None, domain="time"):
     >>> xnew = cp.linspace(0, 10, 100, endpoint=False)
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(x, y, 'go-', xnew, f, '.-', 10, y[0], 'ro')
+    >>> plt.plot(cp.asnumpy(x), cp.asnumpy(y), 'go-', cp.asnumpy(xnew), \
+                cp.asnumpy(f), '.-', 10, cp.asnumpy(y[0]), 'ro')
     >>> plt.legend(['data', 'resampled'], loc='best')
     >>> plt.show()
     """
@@ -345,7 +346,8 @@ def resample_poly(
     sample of the next cycle for the FFT method, and gets closer to zero
     for the polyphase method:
 
-    >>> from scipy import signal
+    >>> import cusignal
+    >>> import cupy as cp
 
     >>> x = cp.linspace(0, 10, 20, endpoint=False)
     >>> y = cp.cos(-x**2/6.0)
@@ -354,9 +356,10 @@ def resample_poly(
     >>> xnew = cp.linspace(0, 10, 100, endpoint=False)
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(xnew, f_fft, 'b.-', xnew, f_poly, 'r.-')
-    >>> plt.plot(x, y, 'ko-')
-    >>> plt.plot(10, y[0], 'bo', 10, 0., 'ro')  # boundaries
+    >>> plt.plot(cp.asnumpy(xnew), cp.asnumpy(f_fft), 'b.-', \
+                 cp.asnumpy(xnew), cp.asnumpy(f_poly), 'r.-')
+    >>> plt.plot(cp.asnumpy(x), cp.asnumpy(y), 'ko-')
+    >>> plt.plot(10, cp.asnumpy(y[0]), 'bo', 10, 0., 'ro')  # boundaries
     >>> plt.legend(['resample', 'resamp_poly', 'data'], loc='best')
     >>> plt.show()
     """

--- a/python/cusignal/peak_finding/peak_finding.py
+++ b/python/cusignal/peak_finding/peak_finding.py
@@ -105,13 +105,13 @@ def argrelmin(data, axis=0, order=1):
     >>> import cupy as cp
     >>> x = cp.array([2, 1, 2, 3, 2, 0, 1, 0])
     >>> argrelmin(x)
-    (array([1, 5]),)
+    (array([1, 5, 7]),)
     >>> y = cp.array([[1, 2, 1, 2],
     ...               [2, 2, 0, 0],
     ...               [5, 3, 4, 4]])
     ...
     >>> argrelmin(y, axis=1)
-    (array([0, 2]), array([2, 1]))
+    (array([0, 0, 2]), array([0, 2, 1]))
 
     """
     data = cp.asarray(data)
@@ -157,13 +157,13 @@ def argrelmax(data, axis=0, order=1):
     >>> import cupy as cp
     >>> x = cp.array([2, 1, 2, 3, 2, 0, 1, 0])
     >>> argrelmax(x)
-    (array([3, 6]),)
+    (array([0, 3, 6]),)
     >>> y = cp.array([[1, 2, 1, 2],
     ...               [2, 2, 0, 0],
     ...               [5, 3, 4, 4]])
     ...
     >>> argrelmax(y, axis=1)
-    (array([0]), array([1]))
+    (array([0, 0, 2]), array([1 ,3, 0]))
     """
     data = cp.asarray(data)
     return argrelextrema(data, cp.greater, axis, order)
@@ -202,14 +202,14 @@ def argrelextrema(data, comparator, axis=0, order=1):
     >>> from cusignal import argrelextrema
     >>> import cupy as cp
     >>> x = cp.array([2, 1, 2, 3, 2, 0, 1, 0])
-    >>> argrelextrema(x, np.greater)
-    (array([3, 6]),)
+    >>> argrelextrema(x, cp.greater)
+    (array([0, 3, 6]),)
     >>> y = cp.array([[1, 2, 1, 2],
     ...               [2, 2, 0, 0],
     ...               [5, 3, 4, 4]])
     ...
     >>> argrelextrema(y, cp.less, axis=1)
-    (array([0, 2]), array([2, 1]))
+    (array([0, 0, 2]), array([0, 2, 1]))
 
     """
     data = cp.asarray(data)

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1009,12 +1009,12 @@ def general_hamming(M, alpha, sym=True):
     >>> freq_plot.set_xlabel("Normalized frequency [cycles per sample]")
 
     >>> for alpha in [0.75, 0.7, 0.52]:
-    ...     window = general_hamming(41, alpha)
-    ...     spatial_plot.plot(window, label="{:.2f}".format(alpha))
+    ...     window = cusignal.general_hamming(41, alpha)
+    ...     spatial_plot.plot(cp.asnumpy(window), label="{:.2f}".format(alpha))
     ...     A = fft(window, 2048) / (len(window)/2.0)
     ...     freq = cp.linspace(-0.5, 0.5, len(A))
     ...     response = 20 * cp.log10(cp.abs(fftshift(A / cp.abs(A).max())))
-    ...     freq_plot.plot(freq, response, label="{:.2f}".format(alpha))
+    ...     freq_plot.plot(cp.asnumpy(freq), cp.asnumpy(response), label="{:.2f}".format(alpha))
     >>> freq_plot.legend(loc="upper right")
     >>> spatial_plot.legend(loc="upper right")
 
@@ -1637,9 +1637,9 @@ def exponential(M, center=None, tau=1., sym=True):
     This function can also generate non-symmetric windows:
 
     >>> tau2 = -(M-1) / np.log(0.01)
-    >>> window2 = signal.exponential(M, 0, tau2, False)
+    >>> window2 = cusignal.exponential(M, 0, tau2, False)
     >>> plt.figure()
-    >>> plt.plot(window2)
+    >>> plt.plot(cp.asnumpy(window2))
     >>> plt.ylabel("Amplitude")
     >>> plt.xlabel("Sample")
     """
@@ -1775,11 +1775,11 @@ def get_window(window, Nx, fftbins=True):
     >>> cusignal.get_window('triang', 7)
     array([ 0.125,  0.375,  0.625,  0.875,  0.875,  0.625,  0.375])
     >>> cusignal.get_window(('kaiser', 4.0), 9)
-    array([ 0.08848053,  0.29425961,  0.56437221,  0.82160913,  0.97885093,
-            0.97885093,  0.82160913,  0.56437221,  0.29425961])
+    array([0.08848053, 0.32578323, 0.63343178, 0.89640418, 1.,
+           0.89640418, 0.63343178, 0.32578323, 0.08848053])
     >>> cusignal.get_window(4.0, 9)
-    array([ 0.08848053,  0.29425961,  0.56437221,  0.82160913,  0.97885093,
-            0.97885093,  0.82160913,  0.56437221,  0.29425961])
+    array([0.08848053, 0.32578323, 0.63343178, 0.89640418, 1.,
+           0.89640418, 0.63343178, 0.32578323, 0.08848053])
 
     """
     sym = not fftbins


### PR DESCRIPTION
I went through the docs and updated references to scipy signal, np and typecasting for plotting.
A few problems remained:
- Example code for using welch with `median`
- Coherence example code tries to use `butter` method, which doesn't exist
- Parzen window tries to use `extract` method of `cupy`
- I didn't address formatting, which is a mess for some functions here: https://docs.rapids.ai/api/cusignal/stable/api.html#cusignal.convolution.convolve.convolve2d