### PR TITLE
[PR-REVIEW] Fix KF version check bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #152 - Fix error in detrend related to missing indexing support with cp.r_
 - PR #153 - Fix issue with incorrect docker image being used in local build script
 - PR #157 - Add docs for Kalman Filter
+- PR #165 - Fix Kalman Filter version check
 
 # cuSignal 0.14 (03 Jun 2020)
 

--- a/python/cusignal/convolution/correlate.py
+++ b/python/cusignal/convolution/correlate.py
@@ -215,7 +215,8 @@ def correlate2d(
         mode='same')
     >>> y, x = cp.unravel_index(cp.argmax(corr), corr.shape)  # find the match
     >>> import matplotlib.pyplot as plt
-    >>> fig, (ax_orig, ax_template, ax_corr) = plt.subplots(3, 1, figsize=(6, 15))
+    >>> fig, (ax_orig, ax_template, ax_corr) =
+    >>>     plt.subplots(3, 1, figsize=(6, 15))
     >>> ax_orig.imshow(cp.asnumpy(face), cmap='gray')
     >>> ax_orig.set_title('Original')
     >>> ax_orig.set_axis_off()

--- a/python/cusignal/convolution/correlate.py
+++ b/python/cusignal/convolution/correlate.py
@@ -216,7 +216,7 @@ def correlate2d(
     >>> y, x = cp.unravel_index(cp.argmax(corr), corr.shape)  # find the match
     >>> import matplotlib.pyplot as plt
     >>> fig, (ax_orig, ax_template, ax_corr) =
-    >>>     plt.subplots(3, 1, figsize=(6, 15))
+    ...     plt.subplots(3, 1, figsize=(6, 15))
     >>> ax_orig.imshow(cp.asnumpy(face), cmap='gray')
     >>> ax_orig.set_title('Original')
     >>> ax_orig.set_axis_off()

--- a/python/cusignal/estimation/filters.py
+++ b/python/cusignal/estimation/filters.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import cupy as cp
-import pkg_resources
 
 from . import _filters_cuda
 from ..utils.debugtools import print_atts

--- a/python/cusignal/estimation/filters.py
+++ b/python/cusignal/estimation/filters.py
@@ -200,8 +200,14 @@ class KalmanFilter(object):
     ):
 
         # Check CuPy version
-        ver = pkg_resources.get_distribution("cupy").version
-        if ver != "8.0.0b4" and ver != "8.0.0rc1" and ver != "8.0.0":
+        # Update to only check for v8.X in cuSignal 0.16
+        ver = cp.__version__
+        if (
+            ver != "8.0.0b4"
+            and ver != "8.0.0b5"
+            and ver != "8.0.0rc1"
+            and ver != "8.0.0"
+        ):
             raise NotImplementedError(
                 "Kalman Filter only compatible with CuPy v.8.0.0b4+"
             )

--- a/python/cusignal/estimation/filters.py
+++ b/python/cusignal/estimation/filters.py
@@ -200,13 +200,9 @@ class KalmanFilter(object):
 
         # Check CuPy version
         # Update to only check for v8.X in cuSignal 0.16
+        valid = ["8.0.0b4", "8.0.0b5", "8.0.0rc1", "8.0.0"]
         ver = cp.__version__
-        if (
-            ver != "8.0.0b4"
-            and ver != "8.0.0b5"
-            and ver != "8.0.0rc1"
-            and ver != "8.0.0"
-        ):
+        if ver not in valid:
             raise NotImplementedError(
                 "Kalman Filter only compatible with CuPy v.8.0.0b4+"
             )

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1029,7 +1029,8 @@ def general_hamming(M, alpha, sym=True):
     ...     A = fft(window, 2048) / (len(window)/2.0)
     ...     freq = cp.linspace(-0.5, 0.5, len(A))
     ...     response = 20 * cp.log10(cp.abs(fftshift(A / cp.abs(A).max())))
-    ...     freq_plot.plot(cp.asnumpy(freq), cp.asnumpy(response), label="{:.2f}".format(alpha))
+    ...     freq_plot.plot(cp.asnumpy(freq), cp.asnumpy(response),
+    ...         label="{:.2f}".format(alpha))
     >>> freq_plot.legend(loc="upper right")
     >>> spatial_plot.legend(loc="upper right")
 

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -13,8 +13,19 @@
 
 import cupy as cp
 from cupyx.scipy import fftpack, special
-from cupy import (array, ones, zeros, cos, arange, sqrt, pi, linspace, abs,
-                  sin, exp)
+from cupy import (
+    array,
+    ones,
+    zeros,
+    cos,
+    arange,
+    sqrt,
+    pi,
+    linspace,
+    abs,
+    sin,
+    exp,
+)
 
 import warnings
 
@@ -22,7 +33,7 @@ import warnings
 def _len_guards(M):
     """Handle small or incorrect window lengths"""
     if int(M) != M or M < 0:
-        raise ValueError('Window length M must be a non-negative integer')
+        raise ValueError("Window length M must be a non-negative integer")
     return M <= 1
 
 
@@ -302,8 +313,9 @@ def parzen(M, sym=True):
     na = cp.extract(n < -(M - 1) / 4.0, n)
     nb = cp.extract(abs(n) <= (M - 1) / 4.0, n)
     wa = 2 * (1 - abs(na) / (M / 2.0)) ** 3.0
-    wb = (1 - 6 * (abs(nb) / (M / 2.0)) ** 2.0 +
-          6 * (abs(nb) / (M / 2.0)) ** 3.0)
+    wb = (
+        1 - 6 * (abs(nb) / (M / 2.0)) ** 2.0 + 6 * (abs(nb) / (M / 2.0)) ** 3.0
+    )
     w = cp.r_[wa, wb, wa[::-1]]
 
     return _truncate(w, needs_trunc)
@@ -715,8 +727,11 @@ def bartlett(M, sym=True):
     M, needs_trunc = _extend(M, sym)
 
     n = arange(0, M)
-    w = cp.where(cp.less_equal(n, (M - 1) / 2.0),
-                 2.0 * n / (M - 1), 2.0 - 2.0 * n / (M - 1))
+    w = cp.where(
+        cp.less_equal(n, (M - 1) / 2.0),
+        2.0 * n / (M - 1),
+        2.0 - 2.0 * n / (M - 1),
+    )
 
     return _truncate(w, needs_trunc)
 
@@ -867,7 +882,7 @@ def tukey(M, alpha=0.5, sym=True):
         return ones(M)
 
     if alpha <= 0:
-        return ones(M, 'd')
+        return ones(M, "d")
     elif alpha >= 1.0:
         return hann(M, sym=sym)
 
@@ -875,9 +890,9 @@ def tukey(M, alpha=0.5, sym=True):
 
     n = arange(0, M)
     width = int(cp.floor(alpha * (M - 1) / 2.0))
-    n1 = n[0:width + 1]
-    n2 = n[width + 1:M - width - 1]
-    n3 = n[M - width - 1:]
+    n1 = n[0 : width + 1]
+    n2 = n[width + 1 : M - width - 1]
+    n3 = n[M - width - 1 :]
 
     w1 = 0.5 * (1 + cos(pi * (-1 + 2.0 * n1 / alpha / (M - 1))))
     w2 = ones(n2.shape)
@@ -1030,7 +1045,7 @@ def general_hamming(M, alpha, sym=True):
     .. [4] Matthieu Bourbigot ESA, "Sentinel-1 Product Definition",
            https://sentinel.esa.int/documents/247904/1877131/Sentinel-1-Product-Definition
     """
-    return general_cosine(M, [alpha, 1. - alpha], sym)
+    return general_cosine(M, [alpha, 1.0 - alpha], sym)
 
 
 def hamming(M, sym=True):
@@ -1112,7 +1127,7 @@ def hamming(M, sym=True):
     if M < 1:
         return array([])
     if M == 1:
-        return ones(1, 'd')
+        return ones(1, "d")
     odd = M % 2
     if not sym and not odd:
         M = M + 1
@@ -1233,14 +1248,15 @@ def kaiser(M, beta, sym=True):
     if M < 1:
         return array([])
     if M == 1:
-        return ones(1, 'd')
+        return ones(1, "d")
     odd = M % 2
     if not sym and not odd:
         M = M + 1
     n = arange(0, M)
     alpha = (M - 1) / 2.0
-    w = (special.i0(beta * sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
-         special.i0(beta))
+    w = special.i0(beta * sqrt(1 - ((n - alpha) / alpha) ** 2.0)) / special.i0(
+        beta
+    )
     if not sym and not odd:
         w = w[:-1]
     return w
@@ -1305,7 +1321,7 @@ def gaussian(M, std, sym=True):
 
     n = arange(0, M) - (M - 1.0) / 2.0
     sig2 = 2 * std * std
-    w = exp(-n ** 2 / sig2)
+    w = exp(-(n ** 2) / sig2)
 
     return _truncate(w, needs_trunc)
 
@@ -1469,19 +1485,21 @@ def chebwin(M, at, sym=True):
 
     """
     if abs(at) < 45:
-        warnings.warn("This window is not suitable for spectral analysis "
-                      "for attenuation values lower than about 45dB because "
-                      "the equivalent noise bandwidth of a Chebyshev window "
-                      "does not grow monotonically with increasing sidelobe "
-                      "attenuation when the attenuation is smaller than "
-                      "about 45 dB.")
+        warnings.warn(
+            "This window is not suitable for spectral analysis "
+            "for attenuation values lower than about 45dB because "
+            "the equivalent noise bandwidth of a Chebyshev window "
+            "does not grow monotonically with increasing sidelobe "
+            "attenuation when the attenuation is smaller than "
+            "about 45 dB."
+        )
     if _len_guards(M):
         return ones(M)
     M, needs_trunc = _extend(M, sym)
 
     # compute the parameter beta
     order = M - 1.0
-    beta = cp.cosh(1.0 / order * cp.arccosh(10 ** (abs(at) / 20.)))
+    beta = cp.cosh(1.0 / order * cp.arccosh(10 ** (abs(at) / 20.0)))
     k = cp.arange(0, M) * 1.0
     x = beta * cp.cos(pi * k / M)
     # Find the window's DFT coefficients
@@ -1498,12 +1516,12 @@ def chebwin(M, at, sym=True):
         w = cp.real(fftpack.fft(p))
         n = (M + 1) // 2
         w = w[:n]
-        w = cp.concatenate((w[n - 1:0:-1], w))
+        w = cp.concatenate((w[n - 1 : 0 : -1], w))
     else:
-        p = p * exp(1.j * pi / M * cp.arange(0, M))
+        p = p * exp(1.0j * pi / M * cp.arange(0, M))
         w = cp.real(fftpack.fft(p))
         n = M // 2 + 1
-        w = cp.concatenate((w[n - 1:0:-1], w[1:n]))
+        w = cp.concatenate((w[n - 1 : 0 : -1], w[1:n]))
     w = w / cp.max(w)
 
     return _truncate(w, needs_trunc)
@@ -1564,12 +1582,12 @@ def cosine(M, sym=True):
         return ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = sin(pi / M * (arange(0, M) + .5))
+    w = sin(pi / M * (arange(0, M) + 0.5))
 
     return _truncate(w, needs_trunc)
 
 
-def exponential(M, center=None, tau=1., sym=True):
+def exponential(M, center=None, tau=1.0, sym=True):
     r"""Return an exponential (or Poisson) window.
 
     Parameters
@@ -1671,28 +1689,32 @@ def _fftautocorr(x):
 
 
 _win_equiv_raw = {
-    ('barthann', 'brthan', 'bth'): (barthann, False),
-    ('bartlett', 'bart', 'brt'): (bartlett, False),
-    ('blackman', 'black', 'blk'): (blackman, False),
-    ('blackmanharris', 'blackharr', 'bkh'): (blackmanharris, False),
-    ('bohman', 'bman', 'bmn'): (bohman, False),
-    ('boxcar', 'box', 'ones',
-        'rect', 'rectangular'): (boxcar, False),
-    ('chebwin', 'cheb'): (chebwin, True),
-    ('cosine', 'halfcosine'): (cosine, False),
-    ('exponential', 'poisson'): (exponential, True),
-    ('flattop', 'flat', 'flt'): (flattop, False),
-    ('gaussian', 'gauss', 'gss'): (gaussian, True),
-    ('general gaussian', 'general_gaussian',
-        'general gauss', 'general_gauss', 'ggs'): (general_gaussian, True),
-    ('hamming', 'hamm', 'ham'): (hamming, False),
-    ('hanning', 'hann', 'han'): (hann, False),
-    ('kaiser', 'ksr'): (kaiser, True),
-    ('nuttall', 'nutl', 'nut'): (nuttall, False),
-    ('parzen', 'parz', 'par'): (parzen, False),
+    ("barthann", "brthan", "bth"): (barthann, False),
+    ("bartlett", "bart", "brt"): (bartlett, False),
+    ("blackman", "black", "blk"): (blackman, False),
+    ("blackmanharris", "blackharr", "bkh"): (blackmanharris, False),
+    ("bohman", "bman", "bmn"): (bohman, False),
+    ("boxcar", "box", "ones", "rect", "rectangular"): (boxcar, False),
+    ("chebwin", "cheb"): (chebwin, True),
+    ("cosine", "halfcosine"): (cosine, False),
+    ("exponential", "poisson"): (exponential, True),
+    ("flattop", "flat", "flt"): (flattop, False),
+    ("gaussian", "gauss", "gss"): (gaussian, True),
+    (
+        "general gaussian",
+        "general_gaussian",
+        "general gauss",
+        "general_gauss",
+        "ggs",
+    ): (general_gaussian, True),
+    ("hamming", "hamm", "ham"): (hamming, False),
+    ("hanning", "hann", "han"): (hann, False),
+    ("kaiser", "ksr"): (kaiser, True),
+    ("nuttall", "nutl", "nut"): (nuttall, False),
+    ("parzen", "parz", "par"): (parzen, False),
     # ('slepian', 'slep', 'optimal', 'dpss', 'dss'): (slepian, True),
-    ('triangle', 'triang', 'tri'): (triang, False),
-    ('tukey', 'tuk'): (tukey, True),
+    ("triangle", "triang", "tri"): (triang, False),
+    ("tukey", "tuk"): (tukey, True),
 }
 
 # Fill dict with all valid window name strings
@@ -1793,13 +1815,16 @@ def get_window(window, Nx, fftbins=True):
                 args = window[1:]
         elif isinstance(window, str):
             if window in _needs_param:
-                raise ValueError("The '" + window + "' window needs one or "
-                                 "more parameters -- pass a tuple.")
+                raise ValueError(
+                    "The '" + window + "' window needs one or "
+                    "more parameters -- pass a tuple."
+                )
             else:
                 winstr = window
         else:
-            raise ValueError("%s as window type is not supported." %
-                             str(type(window)))
+            raise ValueError(
+                "%s as window type is not supported." % str(type(window))
+            )
 
         try:
             winfunc = _win_equiv[winstr]


### PR DESCRIPTION
This PR fixes a bug found by @JasonAtNVIDIA.

If CuPy was not installed by source, say like `pip install cupy-cuda102` the version returned by `pkg_resources` didn't return **cupy**.

New version check
```python
# Check CuPy version
# Update to only check for v8.X in cuSignal 0.16
ver = cp.__version__
if (
    ver != "8.0.0b4"
    and ver != "8.0.0b5"
    and ver != "8.0.0rc1"
    and ver != "8.0.0"
):
    raise NotImplementedError(
         "Kalman Filter only compatible with CuPy v.8.0.0b4+"
    )
```

Per the comment, CuPy v8.0 should be officially release before cuSignal 0.16. In cuSignal 0.16, for KalmanFilter, minimal CuPy will be force to v.8.0.0.
