### PR TITLE
[REVIEW] Fix build error with cupy 8.0dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #165 - Fix Kalman Filter version check
 - PR #174 - Fix bug in KF script
 - PR #175 - Update E2E Notebook for PyTorch 1.4, Fix SegFault
+- PR #176 - Fix CuPy 8.0dev CI build error
 
 # cuSignal 0.14 (03 Jun 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - PR #165 - Fix Kalman Filter version check
 - PR #174 - Fix bug in KF script
 - PR #175 - Update E2E Notebook for PyTorch 1.4, Fix SegFault
-- PR #176 - Fix CuPy 8.0dev CI build error
+- PR #179 - Fix CuPy 8.0dev CI build error
 
 # cuSignal 0.14 (03 Jun 2020)
 

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=7.2.0
+    - cupy>=7.2.0,<8.0.0a0
 
 test:
   imports:

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -2,6 +2,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
 
 package:
   name: {{ name|lower }}
@@ -30,6 +31,8 @@ requirements:
     - cupy>=7.2.0,<8.0.0a0
 
 test:
+  requires:
+    - cudatoolkit {{ cuda_version}}.*
   imports:
     - cusignal
 


### PR DESCRIPTION
Don't include CuPy 8.0 in Conda recipe to fix cuSignal build error.