### PR TITLE
[REVIEW] Add connection to PyCUDA gpuarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # cuSignal 0.16.0 (Date TBD)
 
 ## New Features
-- PR #183 - Add function to translate PyCUDA gpuarray to CuPy ndarray
+- PR #185 - Add function to translate PyCUDA gpuarray to CuPy ndarray
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuSignal 0.16.0 (Date TBD)
 
 ## New Features
+- PR #183 - Add function to translate PyCUDA gpuarray to CuPy ndarray
 
 ## Improvements
 

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -104,6 +104,7 @@ from cusignal.utils.arraytools import (
     get_shared_mem,
     get_pinned_array,
     get_pinned_mem,
+    from_pycuda,
 )
 from cusignal.io.reader import (
     read_bin,

--- a/python/cusignal/utils/__init__.py
+++ b/python/cusignal/utils/__init__.py
@@ -16,4 +16,5 @@ from cusignal.utils.arraytools import (
     get_shared_mem,
     get_pinned_array,
     get_pinned_mem,
+    from_pycuda,
 )

--- a/python/cusignal/utils/arraytools.py
+++ b/python/cusignal/utils/arraytools.py
@@ -133,6 +133,37 @@ def get_pinned_mem(shape, dtype):
     return ret
 
 
+def from_pycuda(pycuda_arr, device=0):
+    """ Read in gpuarray from PyCUDA and output CuPy array
+
+    Parameters
+    ----------
+    pycuda_arr : PyCUDA gpuarray
+    device : int
+        GPU Device ID
+
+    Returns
+    -------
+    cupy_arr : CuPy ndarray
+
+    """
+
+    cupy_arr = cp.ndarray(
+        pycuda_arr.shape,
+        cp.dtype(pycuda_arr.dtype),
+        cp.cuda.MemoryPointer(
+            cp.cuda.UnownedMemory(
+                pycuda_arr.ptr,
+                pycuda_arr.size,
+                pycuda_arr,
+                device
+            ), 0),
+        strides=pycuda_arr.strides
+    )
+
+    return cupy_arr
+
+
 def _axis_slice(a, start=None, stop=None, step=None, axis=-1):
     """Take a slice along axis 'axis' from 'a'.
 


### PR DESCRIPTION
Community requested. If a user wants to integrate existing PyCUDA code into cuSignal, this new `cusignal.from_pycuda` function will return a cupy `ndarray`.

Example usage:

```python
import pycuda.gpuarray as gpuarray
import pycuda.driver as cuda
import pycuda.autoinit

import cupy as cp
import numpy as np

pycuda_arr = gpuarray.to_gpu(np.random.randn(10).astype(np.float32))
cupy_arr = cusignal.from_pycuda(pycuda_arr)

# Confirm pointers
print(pycuda_arr.ptr)
print(cupy_arr.__cuda_array_interface__['data']
```
