### PR TITLE
[gpuCI] Auto-merge branch-0.15 to branch-0.16 [skip ci]

### DIFF
--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -5,10 +5,10 @@
 #############################
 
 # Checkout main for comparison
-git checkout --quiet main
+git checkout --force --quiet main
 
 # Switch back to tip of PR branch
-git checkout --quiet current-pr-branch
+git checkout --force --quiet current-pr-branch
 
 # Ignore errors during searching
 set +e

--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -4,8 +4,8 @@
 # cuSignal CHANGELOG Tester #
 #############################
 
-# Checkout master for comparison
-git checkout --quiet master
+# Checkout main for comparison
+git checkout --quiet main
 
 # Switch back to tip of PR branch
 git checkout --quiet current-pr-branch
@@ -14,7 +14,7 @@ git checkout --quiet current-pr-branch
 set +e
 
 # Get list of modified files between matster and PR branch
-CHANGELOG=`git diff --name-only master...current-pr-branch | grep CHANGELOG.md`
+CHANGELOG=`git diff --name-only main...current-pr-branch | grep CHANGELOG.md`
 # Check if CHANGELOG has PR ID
 PRNUM=`cat CHANGELOG.md | grep "$PR_ID"`
 RETVAL=0


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.15` that creates a PR to keep `branch-0.16` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.