### PR TITLE
[REVIEW] Fix value error using cupy with MappedNDArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - PR #203 - Update build process
 
 ## Bug Fixes
-- PR #204 - Fix value error when using CuPy with MappedNDArray
+- PR #209 - Fix value error when using CuPy with MappedNDArray
 
 
 # cuSignal 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #203 - Update build process
 
 ## Bug Fixes
+- PR #204 - Fix value error when using CuPy with MappedNDArray
 
 
 # cuSignal 0.15.0 (26 Aug 2020)

--- a/python/cusignal/utils/arraytools.py
+++ b/python/cusignal/utils/arraytools.py
@@ -50,7 +50,7 @@ def get_shared_array(
     # Load data into array space
     shared_mem_array[:] = data
 
-    return shared_mem_array
+    return cuda.as_cuda_array(shared_mem_array)
 
 
 # Return shared memory array - similar to np.empty
@@ -79,14 +79,16 @@ def get_shared_mem(
     wc : bool
     """
 
-    return cuda.mapped_array(
-        shape,
-        dtype=dtype,
-        strides=strides,
-        order=order,
-        stream=stream,
-        portable=portable,
-        wc=wc,
+    return cuda.as_cuda_array(
+        cuda.mapped_array(
+            shape,
+            dtype=dtype,
+            strides=strides,
+            order=order,
+            stream=stream,
+            portable=portable,
+            wc=wc,
+        )
     )
 
 


### PR DESCRIPTION
Closes https://github.com/rapidsai/cusignal/issues/178

Cast output array as `numba.cuda.as_cuda_array` to avoid "object not producing array" error.