### PR TITLE
[REVIEW] Rename channelize_poly_gpu to channelize_poly and remove CPU only version; Update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #202 - Performance improvement to Lombscargle
 - PR #203 - Update build process
 - PR #207 - Add CUDA 10 compatibility with polyphase channelizer
+- PR #211 - Add firfilter and channelize_poly to documentation; remove CPU only version of channelizer
 
 ## Bug Fixes
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -33,10 +33,20 @@ Resample
 FIR Filters
 ------------
 
+.. automodule:: cusignal.filtering.firfilter
+    :members:
+    :undoc-members:
+
 .. automodule:: cusignal.filtering.fir_filter_design
     :members:
     :undoc-members:
 
+Channelizer
+------------
+
+.. automodule:: cusignal.filtering.channelize_poly
+    :members:
+    :undoc-members:
 
 Filter Design
 ============

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -34,7 +34,6 @@ from cusignal.filtering.filtering import (
     hilbert2,
     detrend,
     channelize_poly,
-    channelize_poly_gpu,
     freq_shift,
 )
 from cusignal.convolution.correlate import correlate, correlate2d

--- a/python/cusignal/filtering/__init__.py
+++ b/python/cusignal/filtering/__init__.py
@@ -26,6 +26,5 @@ from cusignal.filtering.filtering import (
     hilbert2,
     detrend,
     channelize_poly,
-    channelize_poly_gpu,
     freq_shift,
 )

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -688,61 +688,6 @@ def channelize_poly(x, h, n_chans):
     spacing is equivalent to the number of channels used
     """
 
-    # number of taps in each h_n filter
-    n_taps = int(len(h) / n_chans)
-
-    # number of outputs
-    n_pts = int(len(x) / n_chans)
-
-    dtype = cp.promote_types(x.dtype, h.dtype)
-
-    # order F if input from MATLAB
-    hh = np.matrix(np.reshape(h, (n_taps, n_chans)), dtype=dtype).T
-    vv = np.empty(n_chans, dtype=dtype)
-
-    if x.dtype == np.float32 or x.dtype == np.complex64:
-        yy = np.empty((n_chans, n_pts), dtype=np.complex64)
-    elif x.dtype == np.float64 or x.dtype == np.complex128:
-        yy = np.empty((n_chans, n_pts), dtype=np.complex128)
-
-    reg = np.zeros((n_chans, n_taps), dtype=dtype)
-
-    # instead of n_chans here, this could be channel separation
-    for i, nn in enumerate(range(0, len(x), n_chans)):
-        reg[:, 1:n_taps] = reg[:, 0 : (n_taps - 1)]
-        reg[:, 0] = np.conj(np.flipud(x[nn : (nn + n_chans)]))
-        for mm in range(n_chans):
-            vv[mm] = np.array(reg[mm, :] * hh[mm, :].H)
-
-        yy[:, i] = np.conj(np.fft.fft(vv))
-
-    return yy
-
-
-def channelize_poly_gpu(x, h, n_chans):
-    """
-    Polyphase channelize signal into n channels
-
-    Parameters
-    ----------
-    x : array_like
-        The input data to be channelized
-    h : array_like
-        The 1-D input filter; will be split into n
-        channels of int number of taps
-    n_chans : int
-        Number of channels for channelizer
-
-    Returns
-    ----------
-    yy : channelized output matrix
-
-    Notes
-    ----------
-    Currently only supports simple channelizer where channel
-    spacing is equivalent to the number of channels used
-    """
-
     dtype = cp.promote_types(x.dtype, h.dtype)
 
     x = asarray(x, dtype=dtype)


### PR DESCRIPTION
`cusignal.filtering` contained 2 separate polyphase channelizers: one CPU version and other GPU. I've removed the legacy CPU only version and renamed `cusignal.filtering.channelize_poly_gpu` to `cusignal.filtering.channelize_poly`. This is a GPU library, so all functions are assumed to run on GPU without the explicit API specification!

I also noticed that the polyphase channelizer and firfilter weren't specifically included in the cuSignal documentation. I've added this.