### PR TITLE
[REVIEW] Add KF to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #203 - Update build process
 - PR #207 - Add CUDA 10 compatibility with polyphase channelizer
 - PR #211 - Add firfilter and channelize_poly to documentation; remove CPU only version of channelizer
+- PR #212 - Add KF to documentation build
 
 ## Bug Fixes
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,6 +20,17 @@ Correlate
     :undoc-members:
 
 
+Estimation
+============
+
+Kalman Filter
+------------
+
+.. automodule:: cusignal.estimation.filters
+    :members:
+    :undoc-members:
+
+
 Filtering
 ============
 


### PR DESCRIPTION
rapids.ai documentation previously lacked an estimation section.