### PR TITLE
[REVIEW] Fix bug in channelizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #211 - Add firfilter and channelize_poly to documentation; remove CPU only version of channelizer
 
 ## Bug Fixes
+- PR #214 - Fix grid-stride loop bug in polyphase channelizer
 
 
 # cuSignal 0.15.0 (26 Aug 2020)

--- a/cpp/src/filtering/_channelizer.cu
+++ b/cpp/src/filtering/_channelizer.cu
@@ -68,7 +68,7 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -221,8 +221,7 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
-
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -374,7 +373,7 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
 
         // Load data
         if ( bid >= n_taps ) {
@@ -533,7 +532,7 @@ __device__ void _cupy_channelizer_float32_complex64( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -641,7 +640,7 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -750,7 +749,7 @@ __device__ void _cupy_channelizer_float64_complex128( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -858,7 +857,7 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
 
     __syncthreads( );
 
-    for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+    for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {

--- a/cpp/src/filtering/_channelizer.cu
+++ b/cpp/src/filtering/_channelizer.cu
@@ -56,9 +56,9 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
         }
     } else {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_mem[tx][ty] = T( 0, 0 );
+            s_mem[tx][ty] = T( 0.0, 0.0 );
         } else {
-            s_mem[tx][ty] = 0;
+            s_mem[tx][ty] = 0.0;
         }
     }
 
@@ -91,7 +91,7 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
             } else {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_mem[tx][ty] = T( 0, 0 );
+                    s_mem[tx][ty] = T( 0.0, 0.0 );
                 } else {
                     s_mem[tx][ty] = 0.0;
                 }
@@ -102,12 +102,12 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
 
         T local_reg { s_mem[ty][tx] };
 
-        // T temp {};
+        T temp {};
         U vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            T temp { local_h * local_reg };
+            temp = local_h * local_reg;
             if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
                 vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
                 vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
@@ -209,9 +209,9 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
         }
     } else {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_mem[tx][ty] = T( 0, 0 );
+            s_mem[tx][ty] = T( 0.0, 0.0 );
         } else {
-            s_mem[tx][ty] = 0;
+            s_mem[tx][ty] = 0.0;
         }
     }
 
@@ -245,7 +245,7 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
             } else {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_mem[tx][ty] = T( 0, 0 );
+                    s_mem[tx][ty] = T( 0.0, 0.0 );
                 } else {
                     s_mem[tx][ty] = 0.0;
                 }
@@ -256,12 +256,12 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
 
         T local_reg { s_mem[ty][tx] };
 
-        // T temp {};
+        T temp {};
         U vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            T temp { local_h * local_reg };
+            temp = local_h * local_reg;
             if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
                 vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
                 vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
@@ -362,9 +362,9 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
         }
     } else {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_mem[tx][ty] = T( 0, 0 );
+            s_mem[tx][ty] = T( 0.0, 0.0 );
         } else {
-            s_mem[tx][ty] = 0;
+            s_mem[tx][ty] = 0.0;
         }
     }
 
@@ -398,7 +398,7 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
             } else {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_mem[tx][ty] = T( 0, 0 );
+                    s_mem[tx][ty] = T( 0.0, 0.0 );
                 } else {
                     s_mem[tx][ty] = 0.0;
                 }
@@ -632,7 +632,7 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
     if ( btx < n_chans && ty < n_taps ) {
         s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_mem[tx][ty] = make_cuFloatComplex(0.0f, 0.0f);
+        s_mem[tx][ty] = make_cuFloatComplex( 0.0f, 0.0f );
     }
 
     __syncthreads( );
@@ -651,7 +651,7 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
             if ( btx < n_chans && ty <= bid ) {
                 s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-                s_mem[tx][ty] = make_cuFloatComplex(0.0f, 0.0f);
+                s_mem[tx][ty] = make_cuFloatComplex( 0.0f, 0.0f );
             }
         }
 
@@ -849,7 +849,7 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
     if ( btx < n_chans && ty < n_taps ) {
         s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_mem[tx][ty] = make_cuDoubleComplex(0.0, 0.0);
+        s_mem[tx][ty] = make_cuDoubleComplex( 0.0, 0.0 );
     }
 
     __syncthreads( );
@@ -868,7 +868,7 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
             if ( btx < n_chans && ty <= bid ) {
                 s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-                s_mem[tx][ty] = make_cuDoubleComplex(0.0, 0.0);
+                s_mem[tx][ty] = make_cuDoubleComplex( 0.0, 0.0 );
             }
         }
 

--- a/cpp/src/filtering/_channelizer.cu
+++ b/cpp/src/filtering/_channelizer.cu
@@ -35,8 +35,7 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
                                        const T *__restrict__ x,
                                        const T *__restrict__ h,
                                        U *__restrict__ y,
-                                       T s_h[M][M],
-                                       T s_reg[M][M] ) {
+                                       T s_mem[M][M] ) {
 
     const auto block { cg::this_thread_block( ) };
     const auto tile_32 { cg::tiled_partition<WARPSIZE>( block ) };
@@ -51,17 +50,23 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_h[tx][ty] = thrust::conj( h[ty * n_chans + btx] );
+            s_mem[tx][ty] = thrust::conj( h[ty * n_chans + btx] );
         } else {
-            s_h[tx][ty] = h[ty * n_chans + btx];
+            s_mem[tx][ty] = h[ty * n_chans + btx];
         }
     } else {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_h[tx][ty] = T( 0, 0 );
+            s_mem[tx][ty] = T( 0, 0 );
         } else {
-            s_h[tx][ty] = 0.0;
+            s_mem[tx][ty] = 0;
         }
     }
+
+    __syncthreads( );
+
+    T local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
 
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
         // Load data
@@ -69,40 +74,46 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
             if ( btx < n_chans && ty < n_taps ) {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][( n_taps - 1 ) - ty] =
+                    s_mem[tx][( n_taps - 1 ) - ty] =
                         thrust::conj( x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )] );
                 } else {
-                    s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                    s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
                 }
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][bid - ty] = thrust::conj( x[ty * n_chans + ( n_chans - 1 - btx )] );
+                    s_mem[tx][bid - ty] = thrust::conj( x[ty * n_chans + ( n_chans - 1 - btx )] );
                 } else {
-                    s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                    s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
                 }
             } else {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][ty] = T( 0, 0 );
+                    s_mem[tx][ty] = T( 0, 0 );
                 } else {
-                    s_reg[tx][ty] = 0.0;
+                    s_mem[tx][ty] = 0.0;
                 }
             }
         }
 
         __syncthreads( );
 
-        U temp {};
+        T local_reg { s_mem[ty][tx] };
+
+        // T temp {};
         U vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp = s_h[ty][tx] * s_reg[ty][tx];
-            vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
-            vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
+            T temp { local_h * local_reg };
+            if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
+                vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
+                vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
+            } else {
+                vv.real( cg::reduce( tile, temp, cg::plus<typename U::value_type>( ) ) );
+            }
         }
 
         // Store output
@@ -120,10 +131,9 @@ extern "C" __global__ void __launch_bounds__( 64 )
                                              const float *__restrict__ h,
                                              thrust::complex<float> *__restrict__ y ) {
 
-    __shared__ float s_h[8][8];
-    __shared__ float s_reg[8][8];
+    __shared__ float s_mem[8][8];
 
-    _cupy_channelizer_8x8<float, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_8x8<float, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 64 )
@@ -134,11 +144,9 @@ extern "C" __global__ void __launch_bounds__( 64 )
                                                const thrust::complex<float> *__restrict__ h,
                                                thrust::complex<float> *__restrict__ y ) {
 
-    __shared__ thrust::complex<float> s_h[8][8];
-    __shared__ thrust::complex<float> s_reg[8][8];
+    __shared__ thrust::complex<float> s_mem[8][8];
 
-    _cupy_channelizer_8x8<thrust::complex<float>, thrust::complex<float>>(
-        n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_8x8<thrust::complex<float>, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 64 )
@@ -149,10 +157,9 @@ extern "C" __global__ void __launch_bounds__( 64 )
                                               const double *__restrict__ h,
                                               thrust::complex<double> *__restrict__ y ) {
 
-    __shared__ double s_h[8][8];
-    __shared__ double s_reg[8][8];
+    __shared__ double s_mem[8][8];
 
-    _cupy_channelizer_8x8<double, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_8x8<double, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 64 )
@@ -163,11 +170,9 @@ extern "C" __global__ void __launch_bounds__( 64 )
                                                  const thrust::complex<double> *__restrict__ h,
                                                  thrust::complex<double> *__restrict__ y ) {
 
-    __shared__ thrust::complex<double> s_h[8][8];
-    __shared__ thrust::complex<double> s_reg[8][8];
+    __shared__ thrust::complex<double> s_mem[8][8];
 
-    _cupy_channelizer_8x8<thrust::complex<double>, thrust::complex<double>>(
-        n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_8x8<thrust::complex<double>, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -183,8 +188,7 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
                                          const T *__restrict__ x,
                                          const T *__restrict__ h,
                                          U *__restrict__ y,
-                                         T s_h[M][M],
-                                         T s_reg[M][M] ) {
+                                         T s_mem[M][M] ) {
 
     const auto block { cg::this_thread_block( ) };
     const auto tile_32 { cg::tiled_partition<WARPSIZE>( block ) };
@@ -199,58 +203,71 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_h[tx][ty] = thrust::conj( h[ty * n_chans + btx] );
+            s_mem[tx][ty] = thrust::conj( h[ty * n_chans + btx] );
         } else {
-            s_h[tx][ty] = h[ty * n_chans + btx];
+            s_mem[tx][ty] = h[ty * n_chans + btx];
         }
     } else {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_h[tx][ty] = T( 0, 0 );
+            s_mem[tx][ty] = T( 0, 0 );
         } else {
-            s_h[tx][ty] = 0.0;
+            s_mem[tx][ty] = 0;
         }
     }
 
+    __syncthreads( );
+
+    T local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
+
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][( n_taps - 1 ) - ty] =
+                    s_mem[tx][( n_taps - 1 ) - ty] =
                         thrust::conj( x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )] );
                 } else {
-                    s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                    s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
                 }
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][bid - ty] = thrust::conj( x[ty * n_chans + ( n_chans - 1 - btx )] );
+                    s_mem[tx][bid - ty] = thrust::conj( x[ty * n_chans + ( n_chans - 1 - btx )] );
                 } else {
-                    s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                    s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
                 }
             } else {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][ty] = T( 0, 0 );
+                    s_mem[tx][ty] = T( 0, 0 );
                 } else {
-                    s_reg[tx][ty] = 0.0;
+                    s_mem[tx][ty] = 0.0;
                 }
             }
         }
 
         __syncthreads( );
 
-        U temp {};
+        T local_reg { s_mem[ty][tx] };
+
+        // T temp {};
         U vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp = s_h[ty][tx] * s_reg[ty][tx];
-            vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
-            vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
+            T temp { local_h * local_reg };
+            if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
+                vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
+                vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
+            } else {
+                vv.real( cg::reduce( tile, temp, cg::plus<typename U::value_type>( ) ) );
+            }
         }
 
         // Store output
@@ -268,10 +285,9 @@ extern "C" __global__ void __launch_bounds__( 256 )
                                                const float *__restrict__ h,
                                                thrust::complex<float> *__restrict__ y ) {
 
-    __shared__ float s_h[16][16];
-    __shared__ float s_reg[16][16];
+    __shared__ float s_mem[16][16];
 
-    _cupy_channelizer_16x16<float, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_16x16<float, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 256 )
@@ -282,11 +298,9 @@ extern "C" __global__ void __launch_bounds__( 256 )
                                                  const thrust::complex<float> *__restrict__ h,
                                                  thrust::complex<float> *__restrict__ y ) {
 
-    __shared__ thrust::complex<float> s_h[16][16];
-    __shared__ thrust::complex<float> s_reg[16][16];
+    __shared__ thrust::complex<float> s_mem[16][16];
 
-    _cupy_channelizer_16x16<thrust::complex<float>, thrust::complex<float>>(
-        n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_16x16<thrust::complex<float>, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 256 )
@@ -297,10 +311,9 @@ extern "C" __global__ void __launch_bounds__( 256 )
                                                 const double *__restrict__ h,
                                                 thrust::complex<double> *__restrict__ y ) {
 
-    __shared__ double s_h[16][16];
-    __shared__ double s_reg[16][16];
+    __shared__ double s_mem[16][16];
 
-    _cupy_channelizer_16x16<double, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_16x16<double, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 256 )
@@ -311,11 +324,9 @@ extern "C" __global__ void __launch_bounds__( 256 )
                                                    const thrust::complex<double> *__restrict__ h,
                                                    thrust::complex<double> *__restrict__ y ) {
 
-    __shared__ thrust::complex<double> s_h[16][16];
-    __shared__ thrust::complex<double> s_reg[16][16];
+    __shared__ thrust::complex<double> s_mem[16][16];
 
-    _cupy_channelizer_16x16<thrust::complex<double>, thrust::complex<double>>(
-        n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_16x16<thrust::complex<double>, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -331,8 +342,7 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
                                          const T *__restrict__ x,
                                          const T *__restrict__ h,
                                          U *__restrict__ y,
-                                         T s_h[M][M],
-                                         T s_reg[M][M] ) {
+                                         T s_mem[M][M] ) {
 
     const auto block { cg::this_thread_block( ) };
     const auto tile { cg::tiled_partition<WARPSIZE>( block ) };
@@ -346,58 +356,71 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_h[tx][ty] = thrust::conj( h[ty * n_chans + btx] );
+            s_mem[tx][ty] = thrust::conj( h[ty * n_chans + btx] );
         } else {
-            s_h[tx][ty] = h[ty * n_chans + btx];
+            s_mem[tx][ty] = h[ty * n_chans + btx];
         }
     } else {
         if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
-            s_h[tx][ty] = T( 0, 0 );
+            s_mem[tx][ty] = T( 0, 0 );
         } else {
-            s_h[tx][ty] = 0.0;
+            s_mem[tx][ty] = 0;
         }
     }
 
+    __syncthreads( );
+
+    T local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
+
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
+
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][( n_taps - 1 ) - ty] =
+                    s_mem[tx][( n_taps - 1 ) - ty] =
                         thrust::conj( x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )] );
                 } else {
-                    s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                    s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
                 }
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][bid - ty] = thrust::conj( x[ty * n_chans + ( n_chans - 1 - btx )] );
+                    s_mem[tx][bid - ty] = thrust::conj( x[ty * n_chans + ( n_chans - 1 - btx )] );
                 } else {
-                    s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                    s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
                 }
             } else {
                 if constexpr ( std::is_same_v<T, thrust::complex<float>> ||
                                std::is_same_v<T, thrust::complex<double>> ) {
-                    s_reg[tx][ty] = T( 0, 0 );
+                    s_mem[tx][ty] = T( 0, 0 );
                 } else {
-                    s_reg[tx][ty] = 0.0;
+                    s_mem[tx][ty] = 0.0;
                 }
             }
         }
 
         __syncthreads( );
 
-        U temp {};
+        T local_reg { s_mem[ty][tx] };
+
+        T temp {};
         U vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp = s_h[ty][tx] * s_reg[ty][tx];
-            vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
-            vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
+            temp = local_h * local_reg;
+            if constexpr ( std::is_same_v<T, thrust::complex<float>> || std::is_same_v<T, thrust::complex<double>> ) {
+                vv.real( cg::reduce( tile, temp.real( ), cg::plus<typename U::value_type>( ) ) );
+                vv.imag( cg::reduce( tile, temp.imag( ), cg::plus<typename U::value_type>( ) ) );
+            } else {
+                vv.real( cg::reduce( tile, temp, cg::plus<typename U::value_type>( ) ) );
+            }
         }
 
         // Store output
@@ -415,10 +438,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                const float *__restrict__ h,
                                                thrust::complex<float> *__restrict__ y ) {
 
-    __shared__ float s_h[32][32];
-    __shared__ float s_reg[32][32];
+    __shared__ float s_mem[32][32];
 
-    _cupy_channelizer_32x32<float, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_32x32<float, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -429,11 +451,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                  const thrust::complex<float> *__restrict__ h,
                                                  thrust::complex<float> *__restrict__ y ) {
 
-    __shared__ thrust::complex<float> s_h[32][32];
-    __shared__ thrust::complex<float> s_reg[32][32];
+    __shared__ thrust::complex<float> s_mem[32][32];
 
-    _cupy_channelizer_32x32<thrust::complex<float>, thrust::complex<float>>(
-        n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_32x32<thrust::complex<float>, thrust::complex<float>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -444,10 +464,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                 const double *__restrict__ h,
                                                 thrust::complex<double> *__restrict__ y ) {
 
-    __shared__ double s_h[32][32];
-    __shared__ double s_reg[32][32];
+    __shared__ double s_mem[32][32];
 
-    _cupy_channelizer_32x32<double, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_32x32<double, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -458,17 +477,18 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                    const thrust::complex<double> *__restrict__ h,
                                                    thrust::complex<double> *__restrict__ y ) {
 
-    __shared__ thrust::complex<double> s_h[32][32];
-    __shared__ thrust::complex<double> s_reg[32][32];
+    __shared__ thrust::complex<double> s_mem[32][32];
 
-    _cupy_channelizer_32x32<thrust::complex<double>, thrust::complex<double>>(
-        n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_32x32<thrust::complex<double>, thrust::complex<double>>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 #else  // C++11 being used
+///////////////////////////////////////////////////////////////////////////////
+//                        CUDA 10.1/10.2                                     //
+///////////////////////////////////////////////////////////////////////////////
 #include <cuComplex.h>
 
-template<typename T, int tile_sz>
-__device__ T reduce_sum_tile_shfl( cg::thread_block_tile<tile_sz> g, T val ) {
+template<typename T, int M>
+__device__ T reduce_sum_tile_shfl( cg::thread_block_tile<M> g, T val ) {
     // Each iteration halves the number of active threads
     // Each thread adds its partial sum[i] to sum[lane+i]
     for ( int i = g.size( ) / 2; i > 0; i /= 2 ) {
@@ -482,18 +502,17 @@ __device__ T reduce_sum_tile_shfl( cg::thread_block_tile<tile_sz> g, T val ) {
 //                        CHANNELIZER F/CF                                   //
 ///////////////////////////////////////////////////////////////////////////////
 
-template<int M = 32, int WARPSIZE = 32>
-__device__ void _cupy_channelizer_32x32_float32_complex64( const int n_chans,
-                                                           const int n_taps,
-                                                           const int n_pts,
-                                                           const float *__restrict__ x,
-                                                           const float *__restrict__ h,
-                                                           cuFloatComplex *__restrict__ y,
-                                                           float s_h[M][M],
-                                                           float s_reg[M][M] ) {
+template<int M>
+__device__ void _cupy_channelizer_float32_complex64( const int n_chans,
+                                                     const int n_taps,
+                                                     const int n_pts,
+                                                     const float *__restrict__ x,
+                                                     const float *__restrict__ h,
+                                                     cuFloatComplex *__restrict__ y,
+                                                     float s_mem[M][M] ) {
 
     const auto block = cg::this_thread_block( );
-    const auto tile  = cg::tiled_partition<WARPSIZE>( block );
+    const auto tile  = cg::tiled_partition<M>( block );
 
     const unsigned int btx { blockIdx.x * blockDim.x + threadIdx.x };
 
@@ -503,35 +522,42 @@ __device__ void _cupy_channelizer_32x32_float32_complex64( const int n_chans,
     // Initialize shared memory
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
-        s_h[tx][ty] = h[ty * n_chans + btx];
+        s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_h[tx][ty] = 0.0f;
+        s_mem[tx][ty] = 0.0f;
     }
+
+    __syncthreads( );
+
+    float local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
 
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
-                s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
-                s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-
-                s_reg[tx][ty] = 0.0f;
+                s_mem[tx][ty] = 0.0f;
             }
         }
 
         __syncthreads( );
 
-        cuFloatComplex temp {};
+        float local_reg { s_mem[ty][tx] };
+
+        float          temp {};
         cuFloatComplex vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp.x = s_h[ty][tx] * s_reg[ty][tx];
-            vv.x   = reduce_sum_tile_shfl<float, WARPSIZE>( tile, temp.x );
+            temp = local_h * local_reg;
+            vv.x = reduce_sum_tile_shfl<float, M>( tile, temp );
         }
 
         // Store output
@@ -541,7 +567,7 @@ __device__ void _cupy_channelizer_32x32_float32_complex64( const int n_chans,
     }
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 64 )
     _cupy_channelizer_8x8_float32_complex64( const int n_chans,
                                              const int n_taps,
                                              const int n_pts,
@@ -549,13 +575,12 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                              const float *__restrict__ h,
                                              cuFloatComplex *__restrict__ y ) {
 
-    __shared__ float s_h[32][32];
-    __shared__ float s_reg[32][32];
+    __shared__ float s_mem[8][8];
 
-    _cupy_channelizer_32x32_float32_complex64( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_float32_complex64<8>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 256 )
     _cupy_channelizer_16x16_float32_complex64( const int n_chans,
                                                const int n_taps,
                                                const int n_pts,
@@ -563,10 +588,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                const float *__restrict__ h,
                                                cuFloatComplex *__restrict__ y ) {
 
-    __shared__ float s_h[32][32];
-    __shared__ float s_reg[32][32];
+    __shared__ float s_mem[16][16];
 
-    _cupy_channelizer_32x32_float32_complex64( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_float32_complex64<16>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -577,28 +601,26 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                const float *__restrict__ h,
                                                cuFloatComplex *__restrict__ y ) {
 
-    __shared__ float s_h[32][32];
-    __shared__ float s_reg[32][32];
+    __shared__ float s_mem[32][32];
 
-    _cupy_channelizer_32x32_float32_complex64( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_float32_complex64<32>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //                        CHANNELIZER CF/CF                                  //
 ///////////////////////////////////////////////////////////////////////////////
 
-template<int M = 32, int WARPSIZE = 32>
-__device__ void _cupy_channelizer_32x32_complex64_complex64( const int n_chans,
-                                                             const int n_taps,
-                                                             const int n_pts,
-                                                             const cuFloatComplex *__restrict__ x,
-                                                             const cuFloatComplex *__restrict__ h,
-                                                             cuFloatComplex *__restrict__ y,
-                                                             cuFloatComplex s_h[M][M],
-                                                             cuFloatComplex s_reg[M][M] ) {
+template<int M>
+__device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
+                                                       const int n_taps,
+                                                       const int n_pts,
+                                                       const cuFloatComplex *__restrict__ x,
+                                                       const cuFloatComplex *__restrict__ h,
+                                                       cuFloatComplex *__restrict__ y,
+                                                       cuFloatComplex s_mem[M][M] ) {
 
     const auto block = cg::this_thread_block( );
-    const auto tile  = cg::tiled_partition<WARPSIZE>( block );
+    const auto tile  = cg::tiled_partition<M>( block );
 
     const unsigned int btx { blockIdx.x * blockDim.x + threadIdx.x };
 
@@ -608,37 +630,45 @@ __device__ void _cupy_channelizer_32x32_complex64_complex64( const int n_chans,
     // Initialize shared memory
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
-        s_h[tx][ty] = h[ty * n_chans + btx];
+        s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_h[tx][ty].x = 0.0f;
-        s_h[tx][ty].y = 0.0f;
+        s_mem[tx][ty].x = 0.0f;
+        s_mem[tx][ty].y = 0.0f;
     }
+
+    __syncthreads( );
+
+    cuFloatComplex local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
 
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
-                s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
-                s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-                s_reg[tx][ty].x = 0.0f;
-                s_reg[tx][ty].y = 0.0f;
+                s_mem[tx][ty].x = 0.0f;
+                s_mem[tx][ty].y = 0.0f;
             }
         }
 
         __syncthreads( );
+
+        cuFloatComplex local_reg { s_mem[ty][tx] };
 
         cuFloatComplex temp {};
         cuFloatComplex vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp = cuCmulf( s_h[ty][tx], s_reg[ty][tx] );
-            vv.x = reduce_sum_tile_shfl<float, WARPSIZE>( tile, temp.x );
-            vv.y = reduce_sum_tile_shfl<float, WARPSIZE>( tile, temp.y );
+            temp = cuCmulf( local_h, local_reg );
+            vv.x = reduce_sum_tile_shfl<float, M>( tile, temp.x );
+            vv.y = reduce_sum_tile_shfl<float, M>( tile, temp.y );
         }
 
         // Store output
@@ -648,7 +678,7 @@ __device__ void _cupy_channelizer_32x32_complex64_complex64( const int n_chans,
     }
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 64 )
     _cupy_channelizer_8x8_complex64_complex64( const int n_chans,
                                                const int n_taps,
                                                const int n_pts,
@@ -656,13 +686,12 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                const cuFloatComplex *__restrict__ h,
                                                cuFloatComplex *__restrict__ y ) {
 
-    __shared__ cuFloatComplex s_h[32][32];
-    __shared__ cuFloatComplex s_reg[32][32];
+    __shared__ cuFloatComplex s_mem[8][8];
 
-    _cupy_channelizer_32x32_complex64_complex64( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_complex64_complex64<8>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 256 )
     _cupy_channelizer_16x16_complex64_complex64( const int n_chans,
                                                  const int n_taps,
                                                  const int n_pts,
@@ -670,10 +699,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                  const cuFloatComplex *__restrict__ h,
                                                  cuFloatComplex *__restrict__ y ) {
 
-    __shared__ cuFloatComplex s_h[32][32];
-    __shared__ cuFloatComplex s_reg[32][32];
+    __shared__ cuFloatComplex s_mem[16][16];
 
-    _cupy_channelizer_32x32_complex64_complex64( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_complex64_complex64<16>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -684,28 +712,26 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                  const cuFloatComplex *__restrict__ h,
                                                  cuFloatComplex *__restrict__ y ) {
 
-    __shared__ cuFloatComplex s_h[32][32];
-    __shared__ cuFloatComplex s_reg[32][32];
+    __shared__ cuFloatComplex s_mem[32][32];
 
-    _cupy_channelizer_32x32_complex64_complex64( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_complex64_complex64<32>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //                        CHANNELIZER D/CD                                   //
 ///////////////////////////////////////////////////////////////////////////////
 
-template<int M = 32, int WARPSIZE = 32>
-__device__ void _cupy_channelizer_32x32_float64_complex128( const int n_chans,
-                                                            const int n_taps,
-                                                            const int n_pts,
-                                                            const double *__restrict__ x,
-                                                            const double *__restrict__ h,
-                                                            cuDoubleComplex *__restrict__ y,
-                                                            double s_h[M][M],
-                                                            double s_reg[M][M] ) {
+template<int M>
+__device__ void _cupy_channelizer_float64_complex128( const int n_chans,
+                                                      const int n_taps,
+                                                      const int n_pts,
+                                                      const double *__restrict__ x,
+                                                      const double *__restrict__ h,
+                                                      cuDoubleComplex *__restrict__ y,
+                                                      double s_mem[M][M] ) {
 
     const auto block = cg::this_thread_block( );
-    const auto tile  = cg::tiled_partition<WARPSIZE>( block );
+    const auto tile  = cg::tiled_partition<M>( block );
 
     const unsigned int btx { blockIdx.x * blockDim.x + threadIdx.x };
 
@@ -715,34 +741,42 @@ __device__ void _cupy_channelizer_32x32_float64_complex128( const int n_chans,
     // Initialize shared memory
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
-        s_h[tx][ty] = h[ty * n_chans + btx];
+        s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_h[tx][ty] = 0.0f;
+        s_mem[tx][ty] = 0.0;
     }
+
+    __syncthreads( );
+
+    double local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
 
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
-                s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
-                s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-                s_reg[tx][ty] = 0.0f;
+                s_mem[tx][ty] = 0.0;
             }
         }
 
         __syncthreads( );
 
-        cuDoubleComplex temp {};
+        double local_reg { s_mem[ty][tx] };
+
+        double          temp {};
         cuDoubleComplex vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp.x = s_h[ty][tx] * s_reg[ty][tx];
-            vv.x   = reduce_sum_tile_shfl<double, WARPSIZE>( tile, temp.x );
+            temp = local_h * local_reg;
+            vv.x = reduce_sum_tile_shfl<double, M>( tile, temp );
         }
 
         // Store output
@@ -752,7 +786,7 @@ __device__ void _cupy_channelizer_32x32_float64_complex128( const int n_chans,
     }
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 64 )
     _cupy_channelizer_8x8_float64_complex128( const int n_chans,
                                               const int n_taps,
                                               const int n_pts,
@@ -760,13 +794,12 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                               const double *__restrict__ h,
                                               cuDoubleComplex *__restrict__ y ) {
 
-    __shared__ double s_h[32][32];
-    __shared__ double s_reg[32][32];
+    __shared__ double s_mem[8][8];
 
-    _cupy_channelizer_32x32_float64_complex128( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_float64_complex128<8>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 256 )
     _cupy_channelizer_16x16_float64_complex128( const int n_chans,
                                                 const int n_taps,
                                                 const int n_pts,
@@ -774,10 +807,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                 const double *__restrict__ h,
                                                 cuDoubleComplex *__restrict__ y ) {
 
-    __shared__ double s_h[32][32];
-    __shared__ double s_reg[32][32];
+    __shared__ double s_mem[16][16];
 
-    _cupy_channelizer_32x32_float64_complex128( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_float64_complex128<16>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -788,28 +820,26 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                 const double *__restrict__ h,
                                                 cuDoubleComplex *__restrict__ y ) {
 
-    __shared__ double s_h[32][32];
-    __shared__ double s_reg[32][32];
+    __shared__ double s_mem[32][32];
 
-    _cupy_channelizer_32x32_float64_complex128( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_float64_complex128<32>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //                        CHANNELIZER CD/CD                                  //
 ///////////////////////////////////////////////////////////////////////////////
 
-template<int M = 32, int WARPSIZE = 32>
-__device__ void _cupy_channelizer_32x32_complex128_complex128( const int n_chans,
-                                                               const int n_taps,
-                                                               const int n_pts,
-                                                               const cuDoubleComplex *__restrict__ x,
-                                                               const cuDoubleComplex *__restrict__ h,
-                                                               cuDoubleComplex *__restrict__ y,
-                                                               cuDoubleComplex s_h[M][M],
-                                                               cuDoubleComplex s_reg[M][M] ) {
+template<int M>
+__device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
+                                                         const int n_taps,
+                                                         const int n_pts,
+                                                         const cuDoubleComplex *__restrict__ x,
+                                                         const cuDoubleComplex *__restrict__ h,
+                                                         cuDoubleComplex *__restrict__ y,
+                                                         cuDoubleComplex s_mem[M][M] ) {
 
     const auto block = cg::this_thread_block( );
-    const auto tile  = cg::tiled_partition<WARPSIZE>( block );
+    const auto tile  = cg::tiled_partition<M>( block );
 
     const unsigned int btx { blockIdx.x * blockDim.x + threadIdx.x };
 
@@ -819,38 +849,45 @@ __device__ void _cupy_channelizer_32x32_complex128_complex128( const int n_chans
     // Initialize shared memory
     // Evaluate type at compile-time
     if ( btx < n_chans && ty < n_taps ) {
-        s_h[tx][ty] = h[ty * n_chans + btx];
+        s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_h[tx][ty].x = 0.0;
-        s_h[tx][ty].y = 0.0;
+        s_mem[tx][ty].x = 0.0;
+        s_mem[tx][ty].y = 0.0;
     }
+
+    __syncthreads( );
+
+    cuDoubleComplex local_h { s_mem[ty][tx] };
+
+    __syncthreads( );
 
     for ( auto bid = blockIdx.y; bid < n_pts; bid += blockDim.y ) {
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
-                s_reg[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][( n_taps - 1 ) - ty] = x[( ( bid - n_taps + 1 ) + ty ) * n_chans + ( n_chans - 1 - btx )];
             }
         } else {
             if ( btx < n_chans && ty <= bid ) {
-                s_reg[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
+                s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-
-                s_reg[tx][ty].x = 0.0;
-                s_reg[tx][ty].y = 0.0;
+                s_mem[tx][ty].x = 0.0;
+                s_mem[tx][ty].y = 0.0;
             }
         }
 
         __syncthreads( );
+
+        cuDoubleComplex local_reg { s_mem[ty][tx] };
 
         cuDoubleComplex temp {};
         cuDoubleComplex vv {};
 
         // Perform compute
         if ( ( blockIdx.x * M + ty ) < n_chans ) {
-            temp = cuCmul( s_h[ty][tx], s_reg[ty][tx] );
-            vv.x = reduce_sum_tile_shfl<double, WARPSIZE>( tile, temp.x );
-            vv.y = reduce_sum_tile_shfl<double, WARPSIZE>( tile, temp.y );
+            temp = cuCmul( local_h, local_reg );
+            vv.x = reduce_sum_tile_shfl<double, M>( tile, temp.x );
+            vv.y = reduce_sum_tile_shfl<double, M>( tile, temp.y );
         }
 
         // Store output
@@ -860,7 +897,7 @@ __device__ void _cupy_channelizer_32x32_complex128_complex128( const int n_chans
     }
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 64 )
     _cupy_channelizer_8x8_complex128_complex128( const int n_chans,
                                                  const int n_taps,
                                                  const int n_pts,
@@ -868,13 +905,12 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                  const cuDoubleComplex *__restrict__ h,
                                                  cuDoubleComplex *__restrict__ y ) {
 
-    __shared__ cuDoubleComplex s_h[32][32];
-    __shared__ cuDoubleComplex s_reg[32][32];
+    __shared__ cuDoubleComplex s_mem[8][8];
 
-    _cupy_channelizer_32x32_complex128_complex128( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_complex128_complex128<8>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
-extern "C" __global__ void __launch_bounds__( 1024 )
+extern "C" __global__ void __launch_bounds__( 256 )
     _cupy_channelizer_16x16_complex128_complex128( const int n_chans,
                                                    const int n_taps,
                                                    const int n_pts,
@@ -882,10 +918,9 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                    const cuDoubleComplex *__restrict__ h,
                                                    cuDoubleComplex *__restrict__ y ) {
 
-    __shared__ cuDoubleComplex s_h[32][32];
-    __shared__ cuDoubleComplex s_reg[32][32];
+    __shared__ cuDoubleComplex s_mem[16][16];
 
-    _cupy_channelizer_32x32_complex128_complex128( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_complex128_complex128<16>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 
 extern "C" __global__ void __launch_bounds__( 1024 )
@@ -896,9 +931,8 @@ extern "C" __global__ void __launch_bounds__( 1024 )
                                                    const cuDoubleComplex *__restrict__ h,
                                                    cuDoubleComplex *__restrict__ y ) {
 
-    __shared__ cuDoubleComplex s_h[32][32];
-    __shared__ cuDoubleComplex s_reg[32][32];
+    __shared__ cuDoubleComplex s_mem[32][32];
 
-    _cupy_channelizer_32x32_complex128_complex128( n_chans, n_taps, n_pts, x, h, y, s_h, s_reg );
+    _cupy_channelizer_complex128_complex128<32>( n_chans, n_taps, n_pts, x, h, y, s_mem );
 }
 #endif

--- a/cpp/src/filtering/_channelizer.cu
+++ b/cpp/src/filtering/_channelizer.cu
@@ -632,8 +632,7 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
     if ( btx < n_chans && ty < n_taps ) {
         s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_mem[tx][ty].x = 0.0f;
-        s_mem[tx][ty].y = 0.0f;
+        s_mem[tx][ty] = make_cuFloatComplex(0.0f, 0.0f);
     }
 
     __syncthreads( );
@@ -652,8 +651,7 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
             if ( btx < n_chans && ty <= bid ) {
                 s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-                s_mem[tx][ty].x = 0.0f;
-                s_mem[tx][ty].y = 0.0f;
+                s_mem[tx][ty] = make_cuFloatComplex(0.0f, 0.0f);
             }
         }
 
@@ -851,8 +849,7 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
     if ( btx < n_chans && ty < n_taps ) {
         s_mem[tx][ty] = h[ty * n_chans + btx];
     } else {
-        s_mem[tx][ty].x = 0.0;
-        s_mem[tx][ty].y = 0.0;
+        s_mem[tx][ty] = make_cuDoubleComplex(0.0, 0.0);
     }
 
     __syncthreads( );
@@ -871,8 +868,7 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
             if ( btx < n_chans && ty <= bid ) {
                 s_mem[tx][bid - ty] = x[ty * n_chans + ( n_chans - 1 - btx )];
             } else {
-                s_mem[tx][ty].x = 0.0;
-                s_mem[tx][ty].y = 0.0;
+                s_mem[tx][ty] = make_cuDoubleComplex(0.0, 0.0);
             }
         }
 

--- a/python/cusignal/filtering/_channelizer_cuda.py
+++ b/python/cusignal/filtering/_channelizer_cuda.py
@@ -84,7 +84,10 @@ def _channelizer(x, h, y, n_chans, n_taps, n_pts):
         _populate_kernel_cache(np_type, k_type)
 
         kernel = _get_backend_kernel(
-            np_type, blockspergrid, threadsperblock, k_type,
+            np_type,
+            blockspergrid,
+            threadsperblock,
+            k_type,
         )
 
     elif n_taps <= 16:
@@ -96,7 +99,10 @@ def _channelizer(x, h, y, n_chans, n_taps, n_pts):
         _populate_kernel_cache(np_type, k_type)
 
         kernel = _get_backend_kernel(
-            np_type, blockspergrid, threadsperblock, k_type,
+            np_type,
+            blockspergrid,
+            threadsperblock,
+            k_type,
         )
 
     elif n_taps <= 32:
@@ -108,12 +114,10 @@ def _channelizer(x, h, y, n_chans, n_taps, n_pts):
         _populate_kernel_cache(np_type, k_type)
 
         kernel = _get_backend_kernel(
-            np_type, blockspergrid, threadsperblock, k_type,
-        )
-
-    else:
-        raise NotImplementedError(
-            "Number of taps ({}) must be less than (32).".format(n_taps)
+            np_type,
+            blockspergrid,
+            threadsperblock,
+            k_type,
         )
 
     kernel(n_chans, n_taps, n_pts, x, h, y)

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -226,7 +226,10 @@ def lfiltic(b, a, y, x=None):
 
 
 def sosfilt(
-    sos, x, axis=-1, zi=None,
+    sos,
+    x,
+    axis=-1,
+    zi=None,
 ):
     """
     Filter data along one dimension using cascaded second-order sections.
@@ -696,6 +699,11 @@ def channelize_poly(x, h, n_chans):
     # number of taps in each h_n filter
     n_taps = int(len(h) / n_chans)
 
+    if n_taps > 32:
+        raise NotImplementedError(
+            "Number of taps ({}) must be less than (32).".format(n_taps)
+        )
+
     # number of outputs
     n_pts = int(len(x) / n_chans)
 
@@ -706,6 +714,7 @@ def channelize_poly(x, h, n_chans):
 
     _channelizer(x, h, y, n_chans, n_taps, n_pts)
 
+    # Remove with CuPy v8
     if (x.dtype) in _cupy_fft_cache:
         plan = _cupy_fft_cache[(x.dtype)]
     else:


### PR DESCRIPTION
This PR fixes a bug in channelizer and reduces the shared memory by 50%

1. Reduce shared memory
- Because data copied from shared memory to a register before reduce operation. We can do it manually for `h` and reuse `s_mem` for `reg`

2. Bug
- The wrong stride was chosen for the grid-stride loop causing more work to be done.

## Updated performance
### branch 0.16
```bash
Generating CUDA Kernel Statistics...
CUDA Kernel Statistics (nanoseconds)

Time(%)      Total Time   Instances         Average         Minimum         Maximum  Name                                                                                                                                                                                                                                                                                                                                         
-------  --------------  ----------  --------------  --------------  --------------  --------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                                                         
   99.8      9083414294           5    1816682858.8      1802494087      1837629122  _cupy_channelizer_8x8_complex128_complex128                                                                                                                                                                                                                                                                                                  
    0.1        10588983           5       2117796.6         2107511         2123608  void vector_fft<256u, 8u, 2u, (padding_t)6, (twiddle_t)0, (loadstore_modifier_t)2, (layout_t)0, unsigned int, double>(kernel_arguments_t<unsigned int>)                                                                                                                                                                                      
    0.1         4834286           5        966857.2          966493          967644  cupy_conj__complex128_complex128
```

### PR
```bash
Generating CUDA Kernel Statistics...
CUDA Kernel Statistics (nanoseconds)

Time(%)      Total Time   Instances         Average         Minimum         Maximum  Name                                                                                                                                                                                                                                                                                                                                         
-------  --------------  ----------  --------------  --------------  --------------  --------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                                                         
   70.1        42431416           5       8486283.2         6419531         9006819  _cupy_channelizer_8x8_complex128_complex128                                                                                                                                                                                                                                                                                                  
   22.0        13291318           5       2658263.6         2114009         2964375  void vector_fft<256u, 8u, 2u, (padding_t)6, (twiddle_t)0, (loadstore_modifier_t)2, (layout_t)0, unsigned int, double>(kernel_arguments_t<unsigned int>)                                                                                                                                                                                      
    7.9         4764209           5        952841.8          942813          968317  cupy_conj__complex128_complex128
```

