### PR TITLE
[REVIEW] Fix formatting in Docs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #207 - Add CUDA 10 compatibility with polyphase channelizer
 - PR #211 - Add firfilter and channelize_poly to documentation; remove CPU only version of channelizer
 - PR #213 - Graceful handling of filter tap limit for polyphase channelizer
+- PR #215 - Improve doc formating for filtering operations
 
 ## Bug Fixes
 

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -145,6 +145,7 @@ def firfilter(b, x, axis=None, zi=None):
     >>> b = cp.asarray(b)
     >>> x = cp.random.randn(2**8)
     >>> y = cusignal.firfilter(b, x)
+
     """
 
     if zi is not None:
@@ -685,7 +686,9 @@ def channelize_poly(x, h, n_chans):
     Notes
     ----------
     Currently only supports simple channelizer where channel
-    spacing is equivalent to the number of channels used
+    spacing is equivalent to the number of channels used (zero overlap).
+    Number of filter taps (len of filter / n_chans) must be <=32.
+
     """
 
     dtype = cp.promote_types(x.dtype, h.dtype)


### PR DESCRIPTION
Need to add a whitespace before the closing function description to correctly render sphinx docs.