### PR TITLE
[REVIEW] Improve Window functions performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #212 - Add KF to documentation build
 - PR #213 - Graceful handling of filter tap limit for polyphase channelizer
 - PR #215 - Improve doc formating for filtering operations
+- PR #222 - Improved performance for various window functions
 
 ## Bug Fixes
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer

--- a/python/cusignal/test/test_windows.py
+++ b/python/cusignal/test/test_windows.py
@@ -76,9 +76,6 @@ class TestWindows:
             key = self.cpu_version(num_samps)
             assert array_equal(cp.asnumpy(output), key)
 
-    """
-    This isn't preferred, but Parzen is technically broken until
-    cuPy 8.0. Commenting out until cuSignal 0.16
     @pytest.mark.benchmark(group="Parzen")
     @pytest.mark.parametrize("num_samps", [2 ** 15])
     class TestParzen:
@@ -94,7 +91,6 @@ class TestWindows:
 
             key = self.cpu_version(num_samps)
             assert array_equal(cp.asnumpy(output), key)
-    """
 
     @pytest.mark.benchmark(group="Bohman")
     @pytest.mark.parametrize("num_samps", [2 ** 15])

--- a/python/cusignal/windows/__init__.py
+++ b/python/cusignal/windows/__init__.py
@@ -33,5 +33,5 @@ from cusignal.windows.windows import (
     chebwin,
     cosine,
     exponential,
-    get_window
+    get_window,
 )

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -361,8 +361,12 @@ _bohman_kernel = cp.ElementwiseKernel(
     "int32 M, float64 delta, float64 start, float64 pi",
     "T w",
     """
-    double fac = abs(start + delta * i);
-    w = (1 - fac) * cos(pi * fac) + 1.0 / pi * sin(pi * fac);
+    double fac = abs(start + delta * ( i - 1 ));
+    if ( i != 0 && i != ( M - 1 ) ) {
+        w = (1 - fac) * cos(pi * fac) + 1.0 / pi * sin(pi * fac);
+    } else {
+        w = 0;
+    }
     """,
     "_bohman_kernel",
 )
@@ -417,12 +421,10 @@ def bohman(M, sym=True):
         return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = cp.empty(M-2, dtype=cp.float)
+    w = cp.empty(M, dtype=cp.float)
     delta = (1 - -1) / (M - 1)
 
     _bohman_kernel(M, delta, (-1 + delta), cp.pi, w)
-
-    w = cp.r_[0, w, 0]
 
     return _truncate(w, needs_trunc)
 

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1718,7 +1718,7 @@ def chebwin(M, at, sym=True):
         p = cp.empty(M, dtype=cp.float64)
 
         _chebwin_kernel_odd(M, order, beta, cp.pi, p)
-        
+
         w = cp.real(fftpack.fft(p))
         n = (M + 1) // 2
         w = w[:n]

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -42,12 +42,12 @@ def _truncate(w, needed):
 
 
 _general_cosine_kernel = cp.ElementwiseKernel(
-    "float64 delta, float64 start, raw T a, int32 N",
+    "T delta, T start, raw T a, int64 n",
     "T w",
     """
     double fac = start + delta * i;
     T temp = 0.0;
-    for (int k = 0; k < N; k++) {
+    for (int k = 0; k < n; k++) {
         temp += a[k] * cos(k * fac);
     }
     w = temp;
@@ -195,7 +195,7 @@ def boxcar(M, sym=True):
 
 
 _triang_kernel_true = cp.ElementwiseKernel(
-    "int32 M",
+    "int64 M",
     "T w",
     """
     int n;
@@ -211,7 +211,7 @@ _triang_kernel_true = cp.ElementwiseKernel(
 )
 
 _triang_kernel_false = cp.ElementwiseKernel(
-    "int32 M",
+    "int64 M",
     "T w",
     """
     int n;
@@ -358,7 +358,7 @@ def parzen(M, sym=True):
 
 
 _bohman_kernel = cp.ElementwiseKernel(
-    "int32 M, float64 delta, float64 start, float64 pi",
+    "int64 M, T delta, T start, T pi",
     "T w",
     """
     double fac = abs(start + delta * ( i - 1 ));
@@ -687,7 +687,7 @@ def flattop(M, sym=True):
 
 
 _bartlett_kernel = cp.ElementwiseKernel(
-    "int32 M",
+    "int64 M",
     "T w",
     """
     double temp = ( M - 1 ) / 2.0;
@@ -884,8 +884,8 @@ def hann(M, sym=True):
 
 
 _tukey_kernel = cp.ElementwiseKernel(
-    "int32 M, int32 width, float64 alpha, float64 pi",
-    "W w",
+    "int64 M, int64 width, T alpha, T pi",
+    "T w",
     """
     if (i < (width + 1)) {
         w = 0.5 * (1 + cos(pi * (-1 + 2.0 * i / alpha / (M - 1))));
@@ -978,8 +978,8 @@ def tukey(M, alpha=0.5, sym=True):
 
 
 _barthann_kernel = cp.ElementwiseKernel(
-    "int32 M, float64 pi",
-    "W w",
+    "int64 M, T pi",
+    "T w",
     """
     double fac = abs(i / (M - 1.0) - 0.5);
     w = 0.62 - 0.48 * fac + 0.38 * cos(2 * pi * fac);
@@ -1137,8 +1137,8 @@ def general_hamming(M, alpha, sym=True):
 
 
 _hamming_kernel = cp.ElementwiseKernel(
-    "int32 M, float64 pi",
-    "W w",
+    "int64 M, T pi",
+    "T w",
     """
     w = 0.54 - 0.46 * cos(2.0 * pi * i / (M - 1));
     """,
@@ -1240,8 +1240,8 @@ def hamming(M, sym=True):
 
 
 _kaiser_kernel = cp.ElementwiseKernel(
-    "float64 alpha, float64 beta",
-    "W w",
+    "T alpha, T beta",
+    "T w",
     """
     double temp = ( i - alpha ) / alpha;
     w = cyl_bessel_i0(beta * sqrt( 1 - ( temp * temp ) ) ) /
@@ -1377,8 +1377,8 @@ def kaiser(M, beta, sym=True):
 
 
 _gaussian_kernel = cp.ElementwiseKernel(
-    "int32 M, float64 std",
-    "W w",
+    "int64 M, T std",
+    "T w",
     """
     double n = i - (M - 1.0) / 2.0;
     double sig2 = 2 * std * std;
@@ -1454,8 +1454,8 @@ def gaussian(M, std, sym=True):
 
 
 _general_gaussian_kernel = cp.ElementwiseKernel(
-    "int32 M, float64 p, float64 sig",
-    "W w",
+    "int64 M, T p, T sig",
+    "T w",
     """
     double n = i - (M - 1.0) / 2.0;
     w = exp( -0.5 * pow( abs( n / sig ), 2 * p ) );
@@ -1537,7 +1537,7 @@ def general_gaussian(M, p, sig, sym=True):
 
 
 _chebwin_kernel = cp.ElementwiseKernel(
-    "int32 M, T order, T beta, T pi",
+    "int64 M, T order, T beta, T pi",
     "T p",
     """
     double x = beta * cos(pi * i / M);
@@ -1678,7 +1678,7 @@ def chebwin(M, at, sym=True):
 
 
 _cosine_kernel = cp.ElementwiseKernel(
-    "int32 M, float64 pi",
+    "int64 M, T pi",
     "T w",
     """
     double n = i + 0.5;
@@ -1751,7 +1751,7 @@ def cosine(M, sym=True):
 
 
 _exponential_kernel = cp.ElementwiseKernel(
-    "float64 center, float64 tau",
+    "T center, T tau",
     "T w",
     """
     w = exp(-abs(i - center) / tau);

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -13,19 +13,6 @@
 
 import cupy as cp
 from cupyx.scipy import fftpack, special
-from cupy import (
-    array,
-    ones,
-    zeros,
-    cos,
-    arange,
-    sqrt,
-    pi,
-    linspace,
-    abs,
-    sin,
-    exp,
-)
 
 import warnings
 
@@ -125,13 +112,13 @@ def general_cosine(M, a, sym=True):
     >>> plt.show()
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    fac = linspace(-pi, pi, M)
-    w = zeros(M)
+    fac = cp.linspace(-cp.pi, cp.pi, M)
+    w = cp.zeros(M)
     for k in range(len(a)):
-        w += a[k] * cos(k * fac)
+        w += a[k] * cp.cos(k * fac)
 
     return _truncate(w, needs_trunc)
 
@@ -182,10 +169,10 @@ def boxcar(M, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = ones(M, float)
+    w = cp.ones(M, float)
 
     return _truncate(w, needs_trunc)
 
@@ -241,10 +228,10 @@ def triang(M, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(1, (M + 1) // 2 + 1)
+    n = cp.arange(1, (M + 1) // 2 + 1)
     if M % 2 == 0:
         w = (2 * n - 1.0) / M
         w = cp.r_[w, w[::-1]]
@@ -306,10 +293,10 @@ def parzen(M, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(-(M - 1) / 2.0, (M - 1) / 2.0 + 0.5, 1.0)
+    n = cp.arange(-(M - 1) / 2.0, (M - 1) / 2.0 + 0.5, 1.0)
     na = cp.extract(n < -(M - 1) / 4.0, n)
     nb = cp.extract(abs(n) <= (M - 1) / 4.0, n)
     wa = 2 * (1 - abs(na) / (M / 2.0)) ** 3.0
@@ -367,11 +354,11 @@ def bohman(M, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    fac = abs(linspace(-1, 1, M)[1:-1])
-    w = (1 - fac) * cos(pi * fac) + 1.0 / pi * sin(pi * fac)
+    fac = abs(cp.linspace(-1, 1, M)[1:-1])
+    w = (1 - fac) * cp.cos(cp.pi * fac) + 1.0 / cp.pi * cp.sin(pi * fac)
     w = cp.r_[0, w, 0]
 
     return _truncate(w, needs_trunc)
@@ -723,10 +710,10 @@ def bartlett(M, sym=True):
     """
     # Docstring adapted from NumPy's bartlett function
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(0, M)
+    n = cp.arange(0, M)
     w = cp.where(
         cp.less_equal(n, (M - 1) / 2.0),
         2.0 * n / (M - 1),
@@ -879,24 +866,24 @@ def tukey(M, alpha=0.5, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
 
     if alpha <= 0:
-        return ones(M, "d")
+        return cp.ones(M, "d")
     elif alpha >= 1.0:
         return hann(M, sym=sym)
 
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(0, M)
+    n = cp.arange(0, M)
     width = int(cp.floor(alpha * (M - 1) / 2.0))
     n1 = n[0 : width + 1]
     n2 = n[width + 1 : M - width - 1]
     n3 = n[M - width - 1 :]
 
-    w1 = 0.5 * (1 + cos(pi * (-1 + 2.0 * n1 / alpha / (M - 1))))
-    w2 = ones(n2.shape)
-    w3 = 0.5 * (1 + cos(pi * (-2.0 / alpha + 1 + 2.0 * n3 / alpha / (M - 1))))
+    w1 = 0.5 * (1 + cp.cos(cp.pi * (-1 + 2.0 * n1 / alpha / (M - 1))))
+    w2 = cp.ones(n2.shape)
+    w3 = 0.5 * (1 + cp.cos(cp.pi * (-2.0 / alpha + 1 + 2.0 * n3 / alpha / (M - 1))))
 
     w = cp.concatenate((w1, w2, w3))
 
@@ -949,12 +936,12 @@ def barthann(M, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(0, M)
+    n = cp.arange(0, M)
     fac = abs(n / (M - 1.0) - 0.5)
-    w = 0.62 - 0.48 * fac + 0.38 * cos(2 * pi * fac)
+    w = 0.62 - 0.48 * fac + 0.38 * cp.cos(2 * cp.pi * fac)
 
     return _truncate(w, needs_trunc)
 
@@ -1128,14 +1115,14 @@ def hamming(M, sym=True):
 
     """
     if M < 1:
-        return array([])
+        return cp.array([])
     if M == 1:
-        return ones(1, "d")
+        return cp.ones(1, "d")
     odd = M % 2
     if not sym and not odd:
         M = M + 1
-    n = arange(0, M)
-    w = 0.54 - 0.46 * cos(2.0 * pi * n / (M - 1))
+    n = cp.arange(0, M)
+    w = 0.54 - 0.46 * cp.cos(2.0 * cp.pi * n / (M - 1))
     if not sym and not odd:
         w = w[:-1]
     return w
@@ -1249,15 +1236,15 @@ def kaiser(M, beta, sym=True):
 
     """
     if M < 1:
-        return array([])
+        return cp.array([])
     if M == 1:
-        return ones(1, "d")
+        return cp.ones(1, "d")
     odd = M % 2
     if not sym and not odd:
         M = M + 1
-    n = arange(0, M)
+    n = cp.arange(0, M)
     alpha = (M - 1) / 2.0
-    w = special.i0(beta * sqrt(1 - ((n - alpha) / alpha) ** 2.0)) / special.i0(
+    w = special.i0(beta * cp.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) / special.i0(
         beta
     )
     if not sym and not odd:
@@ -1319,12 +1306,12 @@ def gaussian(M, std, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(0, M) - (M - 1.0) / 2.0
+    n = cp.arange(0, M) - (M - 1.0) / 2.0
     sig2 = 2 * std * std
-    w = exp(-(n ** 2) / sig2)
+    w = cp.exp(-(n ** 2) / sig2)
 
     return _truncate(w, needs_trunc)
 
@@ -1391,11 +1378,11 @@ def general_gaussian(M, p, sig, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    n = arange(0, M) - (M - 1.0) / 2.0
-    w = exp(-0.5 * abs(n / sig) ** (2 * p))
+    n = cp.arange(0, M) - (M - 1.0) / 2.0
+    w = cp.exp(-0.5 * abs(n / sig) ** (2 * p))
 
     return _truncate(w, needs_trunc)
 
@@ -1497,21 +1484,21 @@ def chebwin(M, at, sym=True):
             "about 45 dB."
         )
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
     # compute the parameter beta
     order = M - 1.0
     beta = cp.cosh(1.0 / order * cp.arccosh(10 ** (abs(at) / 20.0)))
     k = cp.arange(0, M) * 1.0
-    x = beta * cp.cos(pi * k / M)
+    x = beta * cp.cos(cp.pi * k / M)
     # Find the window's DFT coefficients
     # Use analytic definition of Chebyshev polynomial instead of expansion
     # from scipy.special. Using the expansion in scipy.special leads to errors.
-    p = zeros(x.shape)
+    p = cp.zeros(x.shape)
     p[x > 1] = cp.cosh(order * cp.arccosh(x[x > 1]))
     p[x < -1] = (2 * (M % 2) - 1) * cp.cosh(order * cp.arccosh(-x[x < -1]))
-    p[abs(x) <= 1] = cos(order * cp.arccos(x[abs(x) <= 1]))
+    p[abs(x) <= 1] = cp.cos(order * cp.arccos(x[abs(x) <= 1]))
 
     # Appropriate IDFT and filling up
     # depending on even/odd M
@@ -1521,7 +1508,7 @@ def chebwin(M, at, sym=True):
         w = w[:n]
         w = cp.concatenate((w[n - 1 : 0 : -1], w))
     else:
-        p = p * exp(1.0j * pi / M * cp.arange(0, M))
+        p = p * cp.exp(1.0j * cp.pi / M * cp.arange(0, M))
         w = cp.real(fftpack.fft(p))
         n = M // 2 + 1
         w = cp.concatenate((w[n - 1 : 0 : -1], w[1:n]))
@@ -1582,10 +1569,10 @@ def cosine(M, sym=True):
 
     """
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = sin(pi / M * (arange(0, M) + 0.5))
+    w = cp.sin(cp.pi / M * (cp.arange(0, M) + 0.5))
 
     return _truncate(w, needs_trunc)
 
@@ -1667,14 +1654,14 @@ def exponential(M, center=None, tau=1.0, sym=True):
     if sym and center is not None:
         raise ValueError("If sym==True, center must be None.")
     if _len_guards(M):
-        return ones(M)
+        return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
     if center is None:
         center = (M - 1) / 2
 
-    n = arange(0, M)
-    w = exp(-abs(n - center) / tau)
+    n = cp.arange(0, M)
+    w = cp.exp(-abs(n - center) / tau)
 
     return _truncate(w, needs_trunc)
 

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -396,7 +396,7 @@ _bohman_kernel = cp.ElementwiseKernel(
     "T w",
     """
     double fac = abs(start + delta * ( i - 1 ));
-    if ( i != 0 && i != ( ind.size() - 1 ) ) {
+    if ( i != 0 && i != ( _ind.size() - 1 ) ) {
         w = (1 - fac) * cos(pi * fac) + 1.0 / pi * sin(pi * fac);
     } else {
         w = 0;

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1698,6 +1698,17 @@ def cosine(M, sym=True):
     return _truncate(w, needs_trunc)
 
 
+_exponential_kernel = cp.ElementwiseKernel(
+    'N n, float64 center, float64 tau',
+    'W w',
+    '''
+    w = exp(-abs(n - center) / tau);
+    ''',
+    '_exponential_kernel'
+)
+
+
+
 def exponential(M, center=None, tau=1.0, sym=True):
     r"""Return an exponential (or Poisson) window.
 
@@ -1781,8 +1792,10 @@ def exponential(M, center=None, tau=1.0, sym=True):
     if center is None:
         center = (M - 1) / 2
 
+    w = cp.empty(M, dtype=cp.float64)
     n = cp.arange(0, M)
-    w = cp.exp(-abs(n - center) / tau)
+
+    _exponential_kernel(n, center, tau, w)
 
     return _truncate(w, needs_trunc)
 

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -45,7 +45,7 @@ _general_cosine_kernel = cp.ElementwiseKernel(
     "T delta, T start, raw T a, int64 n",
     "T w",
     """
-    double fac = start + delta * i;
+    T fac = start + delta * i;
     T temp = 0.0;
     for (int k = 0; k < n; k++) {
         temp += a[k] * cos(k * fac);
@@ -981,7 +981,7 @@ _barthann_kernel = cp.ElementwiseKernel(
     "int64 M, T pi",
     "T w",
     """
-    double fac = abs(i / (M - 1.0) - 0.5);
+    T fac = abs(i / (M - 1.0) - 0.5);
     w = 0.62 - 0.48 * fac + 0.38 * cos(2 * pi * fac);
     """,
     "_barthann_kernel",
@@ -1243,7 +1243,7 @@ _kaiser_kernel = cp.ElementwiseKernel(
     "T alpha, T beta",
     "T w",
     """
-    double temp = ( i - alpha ) / alpha;
+    T temp = ( i - alpha ) / alpha;
     w = cyl_bessel_i0(beta * sqrt( 1 - ( temp * temp ) ) ) /
         cyl_bessel_i0( beta );
     """,
@@ -1380,8 +1380,8 @@ _gaussian_kernel = cp.ElementwiseKernel(
     "int64 M, T std",
     "T w",
     """
-    double n = i - (M - 1.0) / 2.0;
-    double sig2 = 2 * std * std;
+    T n = i - (M - 1.0) / 2.0;
+    T sig2 = 2 * std * std;
     w = exp( - ( n * n ) / sig2 );
 
     """,
@@ -1457,7 +1457,7 @@ _general_gaussian_kernel = cp.ElementwiseKernel(
     "int64 M, T p, T sig",
     "T w",
     """
-    double n = i - (M - 1.0) / 2.0;
+    T n = i - (M - 1.0) / 2.0;
     w = exp( -0.5 * pow( abs( n / sig ), 2 * p ) );
     """,
     "_general_gaussian_kernel",
@@ -1540,7 +1540,7 @@ _chebwin_kernel = cp.ElementwiseKernel(
     "int64 M, T order, T beta, T pi",
     "T p",
     """
-    double x = beta * cos(pi * i / M);
+    T x = beta * cos(pi * i / M);
     if (x > 1) {
         p = cosh(order * acosh(x));
     } else if (x < -1) {
@@ -1681,7 +1681,7 @@ _cosine_kernel = cp.ElementwiseKernel(
     "int64 M, T pi",
     "T w",
     """
-    double n = i + 0.5;
+    T n = i + 0.5;
     w = sin( pi / M * n );
     """,
     "_cosine_kernel",

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -269,7 +269,8 @@ def triang(M, sym=True):
         return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = cp.empty((M + 1) // 2 + 1, dtype=cp.float64)
+    w = cp.empty((M + 1) // 2, dtype=cp.float64)
+    
     if M % 2 == 0:
         _triang_kernel_true(M, w)
         w = cp.r_[w, w[::-1]]

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1387,6 +1387,7 @@ def general_gaussian(M, p, sig, sym=True):
 
     return _truncate(w, needs_trunc)
 
+
 _chebwin_kernel = cp.ElementwiseKernel(
     'T k, int32 M, T order, T beta, T pi',
     'T p',
@@ -1507,7 +1508,7 @@ def chebwin(M, at, sym=True):
     # compute the parameter beta
     order = M - 1.0
     beta = np.cosh(1.0 / order * np.arccosh(10 ** (abs(at) / 20.0)))
-    k = cp.arange(0, M, dtype=np.float64)
+    k = cp.arange(0, M, dtype=cp.float64)
     p = cp.empty(k.shape)
     _chebwin_kernel(k, M, order, beta, cp.pi, p)
 

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -42,17 +42,17 @@ def _truncate(w, needed):
 
 
 _general_cosine_kernel = cp.ElementwiseKernel(
-    'T fac, raw T a, int32 N',
-    'T w',
-    '''
+    "T fac, raw T a, int32 N",
+    "T w",
+    """
     T temp = 0.0;
     for (int k = 0; k < N; k++) {
         temp += a[k] * cos(k * fac);
     }
     w = temp;
                                                                                                                  
-    ''',
-    '_general_cosine_kernel'
+    """,
+    "_general_cosine_kernel",
 )
 
 
@@ -825,9 +825,9 @@ def hann(M, sym=True):
 
 
 _tukey_kernel = cp.ElementwiseKernel(
-    'N n, int32 M, int32 width, float64 alpha, float64 pi',
-    'W w',
-    '''
+    "N n, int32 M, int32 width, float64 alpha, float64 pi",
+    "W w",
+    """
     if (n < (width + 1)) {                                                                                                         
         w = 0.5 * (1 + cos(pi * (-1 + 2.0 * n / alpha / (M - 1))));                                                                                      
     } else if ( n > (width + 1) && n < (M-width-1) ) {                                                                                                 
@@ -835,8 +835,8 @@ _tukey_kernel = cp.ElementwiseKernel(
     } else {                                                                                                             
         w = 0.5 * (1 + cos(pi * (-2.0 / alpha + 1 + 2.0 * n / alpha / (M - 1))));                                                                                        
     }                                                                                                                  
-    ''',
-    '_tukey_kernel'
+    """,
+    "_tukey_kernel",
 )
 
 
@@ -919,13 +919,13 @@ def tukey(M, alpha=0.5, sym=True):
 
 
 _barthann_kernel = cp.ElementwiseKernel(
-    'N n, int32 M, float64 pi',
-    'W w',
-    '''
+    "N n, int32 M, float64 pi",
+    "W w",
+    """
     double fac = abs(n / (M - 1.0) - 0.5);
     w = 0.62 - 0.48 * fac + 0.38 * cos(2 * pi * fac);                                                                                                    
-    ''',
-    '_barthann_kernel'
+    """,
+    "_barthann_kernel",
 )
 
 
@@ -1079,12 +1079,12 @@ def general_hamming(M, alpha, sym=True):
 
 
 _hamming_kernel = cp.ElementwiseKernel(
-    'N n, int32 M, float64 pi',
-    'W w',
-    '''
+    "N n, int32 M, float64 pi",
+    "W w",
+    """
     w = 0.54 - 0.46 * cos(2.0 * pi * n / (M - 1));
-    ''',
-    '_hamming_kernel'
+    """,
+    "_hamming_kernel",
 )
 
 
@@ -1183,14 +1183,14 @@ def hamming(M, sym=True):
 
 
 _kaiser_kernel = cp.ElementwiseKernel(
-    'N n, float64 alpha, float64 beta',
-    'W w',
-    '''
+    "N n, float64 alpha, float64 beta",
+    "W w",
+    """
     double temp = ( n - alpha ) / alpha;
     w = cyl_bessel_i0(beta * sqrt( 1 - ( temp * temp ) ) ) /
         cyl_bessel_i0( beta );
-    ''',
-    '_kaiser_kernel'
+    """,
+    "_kaiser_kernel",
 )
 
 
@@ -1321,15 +1321,15 @@ def kaiser(M, beta, sym=True):
 
 
 _gaussian_kernel = cp.ElementwiseKernel(
-    'N n, int32 M, float64 std',
-    'W w',
-    '''
+    "N n, int32 M, float64 std",
+    "W w",
+    """
     double new_n = n - (M - 1.0) / 2.0;
     double sig2 = 2 * std * std;
     w = exp( - ( new_n * new_n ) / sig2 );
 
-    ''',
-    '_gaussian_kernel'
+    """,
+    "_gaussian_kernel",
 )
 
 
@@ -1399,13 +1399,13 @@ def gaussian(M, std, sym=True):
 
 
 _general_gaussian_kernel = cp.ElementwiseKernel(
-    'N n, int32 M, float64 p, float64 sig',
-    'W w',
-    '''
+    "N n, int32 M, float64 p, float64 sig",
+    "W w",
+    """
     double new_n = n - (M - 1.0) / 2.0;
     w = exp( -0.5 * pow( abs( new_n / sig ), 2 * p ) );
-    ''',
-    '_general_gaussian_kernel'
+    """,
+    "_general_gaussian_kernel",
 )
 
 
@@ -1474,7 +1474,7 @@ def general_gaussian(M, p, sig, sym=True):
         return cp.ones(M)
     M, needs_trunc = _extend(M, sym)
 
-    w = cp.empty(M, dtype=cp.float64);
+    w = cp.empty(M, dtype=cp.float64)
     n = cp.arange(0, M, dtype=cp.int64)
 
     _general_gaussian_kernel(n, M, p, sig, w)
@@ -1483,9 +1483,9 @@ def general_gaussian(M, p, sig, sym=True):
 
 
 _chebwin_kernel = cp.ElementwiseKernel(
-    'T k, int32 M, T order, T beta, T pi',
-    'T p',
-    '''
+    "T k, int32 M, T order, T beta, T pi",
+    "T p",
+    """
     double x = beta * cos(pi * k / M);                                                                                                                  
     if (x > 1) {                                                                                                         
         p = cosh(order * acosh(x));                                                                                      
@@ -1494,8 +1494,8 @@ _chebwin_kernel = cp.ElementwiseKernel(
     } else {                                                                                                             
         p = cos(order * acos(x));                                                                                        
     }                                                                                                                    
-    ''',
-    '_chebwin_kernel'
+    """,
+    "_chebwin_kernel",
 )
 
 
@@ -1625,13 +1625,13 @@ def chebwin(M, at, sym=True):
 
 
 _cosine_kernel = cp.ElementwiseKernel(
-    'N n, int32 M, float64 pi',
-    'W w',
-    '''
+    "N n, int32 M, float64 pi",
+    "W w",
+    """
     double new_n = n + 0.5;
     w = sin( pi / M * new_n );
-    ''',
-    '_cosine_kernel'
+    """,
+    "_cosine_kernel",
 )
 
 
@@ -1699,14 +1699,13 @@ def cosine(M, sym=True):
 
 
 _exponential_kernel = cp.ElementwiseKernel(
-    'N n, float64 center, float64 tau',
-    'W w',
-    '''
+    "N n, float64 center, float64 tau",
+    "W w",
+    """
     w = exp(-abs(n - center) / tau);
-    ''',
-    '_exponential_kernel'
+    """,
+    "_exponential_kernel",
 )
-
 
 
 def exponential(M, center=None, tau=1.0, sym=True):

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -370,7 +370,7 @@ def parzen(M, sym=True):
     M, needs_trunc = _extend(M, sym)
 
     start = -(M - 1) / 2.0
-    if (M % 2):
+    if M % 2:
         s1 = math.floor(-(M - 1) / 4.0)
         s2 = math.floor((M - 1) / 4.0)
         sizeS1 = s1 - start + 1
@@ -382,7 +382,7 @@ def parzen(M, sym=True):
     sizeS2 = s2 - start + 1 - sizeS1
     totalSize = int(sizeS1 * 2 + sizeS2)
 
-    den = 1/(M*0.5)
+    den = 1 / (M * 0.5)
 
     w = cp.empty(totalSize, dtype=cp.float64)
 

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -13,7 +13,7 @@
 
 import cupy as cp
 import numpy as np
-from cupyx.scipy import fftpack, special
+from cupyx.scipy import fftpack
 
 import warnings
 
@@ -50,7 +50,7 @@ _general_cosine_kernel = cp.ElementwiseKernel(
     for (int k = 0; k < N; k++) {
         temp += a[k] * cos(k * fac);
     }
-    w = temp;                                                                                                   
+    w = temp;
     """,
     "_general_cosine_kernel",
 )
@@ -887,13 +887,14 @@ _tukey_kernel = cp.ElementwiseKernel(
     "int32 M, int32 width, float64 alpha, float64 pi",
     "W w",
     """
-    if (i < (width + 1)) {                                                                                                         
-        w = 0.5 * (1 + cos(pi * (-1 + 2.0 * i / alpha / (M - 1))));                                                                                      
-    } else if ( i > (width + 1) && i < (M-width-1) ) {                                                                                                 
-        w = 1.0;                                                                 
-    } else {                                                                                                             
-        w = 0.5 * (1 + cos(pi * (-2.0 / alpha + 1 + 2.0 * i / alpha / (M - 1))));                                                                                        
-    }                                                                                                                  
+    if (i < (width + 1)) {
+        w = 0.5 * (1 + cos(pi * (-1 + 2.0 * i / alpha / (M - 1))));
+    } else if ( i > (width + 1) && i < (M-width-1) ) {
+        w = 1.0;
+    } else {
+        w = 0.5 *
+            (1 + cos(pi * (-2.0 / alpha + 1 + 2.0 * i / alpha / (M - 1))));
+    }
     """,
     "_tukey_kernel",
 )
@@ -981,7 +982,7 @@ _barthann_kernel = cp.ElementwiseKernel(
     "W w",
     """
     double fac = abs(i / (M - 1.0) - 0.5);
-    w = 0.62 - 0.48 * fac + 0.38 * cos(2 * pi * fac);                                                                                                    
+    w = 0.62 - 0.48 * fac + 0.38 * cos(2 * pi * fac);
     """,
     "_barthann_kernel",
 )
@@ -1539,14 +1540,14 @@ _chebwin_kernel = cp.ElementwiseKernel(
     "int32 M, T order, T beta, T pi",
     "T p",
     """
-    double x = beta * cos(pi * i / M);                                                                                                                  
-    if (x > 1) {                                                                                                         
-        p = cosh(order * acosh(x));                                                                                      
-    } else if (x < -1) {                                                                                                 
-        p = (2 * (M % 2) - 1) * cosh(order * acosh(-x));                                                                 
-    } else {                                                                                                             
-        p = cos(order * acos(x));                                                                                        
-    }                                                                                                                    
+    double x = beta * cos(pi * i / M);
+    if (x > 1) {
+        p = cosh(order * acosh(x));
+    } else if (x < -1) {
+        p = (2 * (M % 2) - 1) * cosh(order * acosh(-x));
+    } else {
+        p = cos(order * acos(x));
+    }
     """,
     "_chebwin_kernel",
 )

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -358,7 +358,7 @@ def bohman(M, sym=True):
     M, needs_trunc = _extend(M, sym)
 
     fac = abs(cp.linspace(-1, 1, M)[1:-1])
-    w = (1 - fac) * cp.cos(cp.pi * fac) + 1.0 / cp.pi * cp.sin(pi * fac)
+    w = (1 - fac) * cp.cos(cp.pi * fac) + 1.0 / cp.pi * cp.sin(cp.pi * fac)
     w = cp.r_[0, w, 0]
 
     return _truncate(w, needs_trunc)


### PR DESCRIPTION
This PR will reevaluate performance of all window functions implementations.

As an example, *chebwin* was performing multiple operations on scalars and array slicing.
Below is a screenshot from Systems. There are 76 API calls
![chebwin_original](https://user-images.githubusercontent.com/50021634/93670645-ea251e80-fa6a-11ea-9341-076a762501cb.png)

Moving scalar operations to the CPU and combining multiple arithmetic operations with a CuPy ElementwiseKernel, the number of call is reduced to 14, all memcpys are elimination and the performance in increased by roughly 4x.
![chebwin_modified](https://user-images.githubusercontent.com/50021634/93670673-28224280-fa6b-11ea-99bb-a2ce17546799.png)
