### PR TITLE
[REVIEW] Improve Wavelets functions performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #213 - Graceful handling of filter tap limit for polyphase channelizer
 - PR #215 - Improve doc formating for filtering operations
 - PR #219 - Add missing pytests
+- PR #235 - Improve Wavelets functions performance
 
 ## Bug Fixes
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer

--- a/python/cusignal/convolution/convolution_utils.py
+++ b/python/cusignal/convolution/convolution_utils.py
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cupy import ndarray, array, asarray
 import cupy as cp
+import numpy as np
 
 import timeit
 
@@ -83,7 +83,7 @@ def _numeric_arrays(arrays, kinds="buifc"):
         the ndarrays are not in this string the function returns False and
         otherwise returns True.
     """
-    if type(arrays) == ndarray:
+    if type(arrays) == cp.ndarray:
         return arrays.dtype.kind in kinds
     for array_ in arrays:
         if array_.dtype.kind not in kinds:
@@ -93,8 +93,7 @@ def _numeric_arrays(arrays, kinds="buifc"):
 
 def _centered(arr, newshape):
     # Return the center newshape portion of the array.
-    newshape = asarray(newshape)
-    currshape = array(arr.shape)
+    currshape = arr.shape
     startind = (currshape - newshape) // 2
     endind = startind + newshape
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
@@ -148,7 +147,7 @@ def _fftconv_faster(x, h, mode):
     # convolution method is faster (discussed in scikit-image PR #1792)
     direct_time = x.size * h.size * _prod(out_shape)
     fft_time = sum(
-        n * cp.log(n) for n in (x.shape + h.shape + tuple(out_shape))
+        n * np.log(n) for n in (x.shape + h.shape + tuple(out_shape))
     )
 
     return big_O_constant * fft_time < direct_time

--- a/python/cusignal/convolution/convolve.py
+++ b/python/cusignal/convolution/convolve.py
@@ -309,9 +309,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
         else:
             rplan = _cupy_fft_cache[
                 (str(fshape), str(axes), "R2C")
-            ] = fftpack.get_fft_plan(
-                in1, fshape, axes=axes, value_type="R2C"
-            )
+            ] = fftpack.get_fft_plan(in1, fshape, axes=axes, value_type="R2C")
         try:
             with rplan:
                 sp1 = cp.fft.rfftn(in1, fshape, axes=axes)

--- a/python/cusignal/test/conftest.py
+++ b/python/cusignal/test/conftest.py
@@ -24,6 +24,19 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "cpu: mark CPU test cases")
 
 
+# Generate data for using range
+@pytest.fixture(scope="session")
+def range_data_gen():
+    def _generate(num_samps, endpoint=False):
+
+        cpu_sig = np.arange(num_samps)
+        gpu_sig = cp.asarray(cpu_sig)
+
+        return cpu_sig, gpu_sig
+
+    return _generate
+
+
 # Generate data for using linspace
 @pytest.fixture(scope="session")
 def linspace_data_gen():

--- a/python/cusignal/utils/fftpack_helper.py
+++ b/python/cusignal/utils/fftpack_helper.py
@@ -11,19 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cupy import (
-    arange,
-    array,
-    asarray,
-    atleast_1d,
-    intc,
-    integer,
-    isscalar,
-    issubdtype,
-    take,
-    unique,
-    where,
-)
+import numpy as np
 from bisect import bisect_left
 
 
@@ -317,45 +305,44 @@ def _init_nd_shape_and_axes(x, shape, axes):
         The shape of the result. It is a 1D integer array.
 
     """
-    x = asarray(x)
     noshape = shape is None
     noaxes = axes is None
 
     if noaxes:
-        axes = arange(x.ndim, dtype=intc)
+        axes = np.arange(x.ndim, dtype=np.intc)
     else:
-        axes = atleast_1d(axes)
+        axes = np.atleast_1d(axes)
 
     if axes.size == 0:
-        axes = axes.astype(intc)
+        axes = axes.astype(np.intc)
 
     if not axes.ndim == 1:
         raise ValueError("when given, axes values must be a scalar or vector")
-    if not issubdtype(axes.dtype, integer):
+    if not np.issubdtype(axes.dtype, np.integer):
         raise ValueError("when given, axes values must be integers")
 
-    axes = where(axes < 0, axes + x.ndim, axes)
+    axes = np.where(axes < 0, axes + x.ndim, axes)
 
     if axes.size != 0 and (axes.max() >= x.ndim or axes.min() < 0):
         raise ValueError("axes exceeds dimensionality of input")
-    if axes.size != 0 and unique(axes).shape != axes.shape:
+    if axes.size != 0 and np.unique(axes).shape != axes.shape:
         raise ValueError("all axes must be unique")
 
     if not noshape:
-        shape = atleast_1d(shape)
-    elif isscalar(x):
-        shape = array([], dtype=intc)
+        shape = np.atleast_1d(shape)
+    elif np.isscalar(x):
+        shape = np.array([], dtype=np.intc)
     elif noaxes:
-        shape = array(x.shape, dtype=intc)
+        shape = np.array(x.shape, dtype=np.intc)
     else:
-        shape = take(x.shape, axes)
+        shape = np.take(x.shape, axes)
 
     if shape.size == 0:
-        shape = shape.astype(intc)
+        shape = shape.astype(np.intc)
 
     if shape.ndim != 1:
         raise ValueError("when given, shape values must be a scalar or vector")
-    if not issubdtype(shape.dtype, integer):
+    if not np.issubdtype(shape.dtype, np.integer):
         raise ValueError("when given, shape values must be integers")
     if axes.shape != shape.shape:
         raise ValueError(
@@ -363,7 +350,7 @@ def _init_nd_shape_and_axes(x, shape, axes):
             " have to be of the same length"
         )
 
-    shape = where(shape == -1, array(x.shape)[axes], shape)
+    shape = np.where(shape == -1, np.array(x.shape)[axes], shape)
 
     if shape.size != 0 and (shape < 1).any():
         raise ValueError(
@@ -403,7 +390,6 @@ def _init_nd_shape_and_axes_sorted(x, shape, axes):
         The shape of the result. It is a 1D integer array.
 
     """
-    x = asarray(x)
     noaxes = axes is None
     shape, axes = _init_nd_shape_and_axes(x, shape, axes)
 

--- a/python/cusignal/wavelets/__init__.py
+++ b/python/cusignal/wavelets/__init__.py
@@ -11,9 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cusignal.wavelets.wavelets import (
-    qmf,
-    morlet,
-    ricker,
-    cwt
-)
+from cusignal.wavelets.wavelets import qmf, morlet, ricker, cwt

--- a/python/cusignal/wavelets/wavelets.py
+++ b/python/cusignal/wavelets/wavelets.py
@@ -120,16 +120,16 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     start = -s * 2 * np.pi
     delta = (end - start) / (M - 1)
 
-    _morlet_kernel(delta, start, w, np.pi, complete, output)
+    _morlet_kernel(delta, start, w, np.pi, complete, output, size=M)
 
     return output
 
 
 _ricker_kernel = cp.ElementwiseKernel(
-    "int64 points, T A, T wsq",
+    "T A, T wsq",
     "T total",
     """
-    T vec = i - (points - 1.0) / 2;
+    T vec = i - (_ind.size() - 1.0) / 2;
     T xsq = vec * vec;
     T mod = ( 1 - xsq / wsq );
     T gauss = exp( -xsq / ( 2 * wsq ) );
@@ -182,7 +182,7 @@ def ricker(points, a):
     A = 2 / (np.sqrt(3 * a) * (np.pi ** 0.25))
     wsq = a ** 2
 
-    _ricker_kernel(points, float(A), float(wsq), total)
+    _ricker_kernel(float(A), float(wsq), total, size=points)
 
     return total
 

--- a/python/cusignal/wavelets/wavelets.py
+++ b/python/cusignal/wavelets/wavelets.py
@@ -167,12 +167,12 @@ def ricker(points, a):
     >>> plt.show()
 
     """
-    total = cp.empty(points, dtype=cp.float64)
+    total = cp.empty(int(points), dtype=cp.float64)
 
     A = 2 / (np.sqrt(3 * a) * (np.pi ** 0.25))
     wsq = a ** 2
 
-    _ricker_kernel(points, A, wsq, total)
+    _ricker_kernel(points, float(A), float(wsq), total)
 
     return total
 
@@ -228,7 +228,7 @@ def cwt(data, wavelet, widths):
     >>> plt.show()
 
     """
-    output = cp.zeros([len(widths), len(data)])
+    output = cp.empty([len(widths), len(data)])
     for ind, width in enumerate(widths):
         wavelet_data = wavelet(min(10 * width, len(data)), width)
         output[ind, :] = convolve(data, wavelet_data, mode="same")

--- a/python/cusignal/windows/__init__.py
+++ b/python/cusignal/windows/__init__.py
@@ -33,5 +33,5 @@ from cusignal.windows.windows import (
     chebwin,
     cosine,
     exponential,
-    get_window
+    get_window,
 )


### PR DESCRIPTION
Closes #223 
Closes #234 

This PR improves performance for all wavelets functions.

### branch-0.16
```bash
-------------- benchmark 'CWT': 4 tests --------------
Name (time in ms, mem in bytes)         Mean          
------------------------------------------------------
test_cwt_gpu[31-16384]               72.6608 (5.04)   
test_cwt_gpu[127-16384]             310.6303 (21.54)  
------------------------------------------------------

---------- benchmark 'CWTComplex': 4 tests -----------
Name (time in ms, mem in bytes)         Mean          
------------------------------------------------------
test_cwt_complex_gpu[31-16384]       71.0334 (3.05)   
test_cwt_complex_gpu[127-16384]     300.4632 (12.91)  
------------------------------------------------------

------------ benchmark 'Morlet': 2 tests -------------
Name (time in us, mem in bytes)         Mean          
------------------------------------------------------
test_morlet_gpu[16384]              166.5411 (1.0)    
------------------------------------------------------

------------ benchmark 'Ricker': 4 tests -------------
Name (time in us, mem in bytes)         Mean          
------------------------------------------------------
test_ricker_gpu[1000-16384]         216.0455 (1.53)   
test_ricker_gpu[10-16384]           216.7407 (1.54)   
------------------------------------------------------

```

### This PR
```
-------------- benchmark 'CWT': 4 tests -------------
Name (time in ms, mem in bytes)        Mean          
-----------------------------------------------------
test_cwt_gpu[31-16384]              16.6778 (1.17)   
test_cwt_gpu[127-16384]             67.9339 (4.77)   
-----------------------------------------------------

---------- benchmark 'CWTComplex': 4 tests -----------
Name (time in ms, mem in bytes)         Mean          
------------------------------------------------------
test_cwt_complex_gpu[31-16384]       14.6283 (1.0)    
test_cwt_complex_gpu[127-16384]      61.4721 (4.20)   
------------------------------------------------------

------------ benchmark 'Morlet': 2 tests -------------
Name (time in us, mem in bytes)         Mean          
------------------------------------------------------
test_morlet_gpu[16384]               28.6952 (1.0)    
------------------------------------------------------

--------------- benchmark 'Qmf': 2 tests ---------------
Name (time in us, mem in bytes)           Mean          
--------------------------------------------------------
test_qmf_gpu[16384]                    13.3289 (1.0)    
--------------------------------------------------------

------------ benchmark 'Ricker': 4 tests -------------
Name (time in us, mem in bytes)         Mean          
------------------------------------------------------
test_ricker_gpu[1000-16384]          23.1164 (1.0)    
test_ricker_gpu[10-16384]            23.1946 (1.00)   
------------------------------------------------------
```

Improvements in this PR are made by move many arithmetic calculation from CuPy functions to a CuPy Elementwise kernel. This minimize kernel launch overhead. 

Replace
```python
def morlet(M, w=5.0, s=1.0, complete=True):
    x = cp.linspace(-s * 2 * cp.pi, s * 2 * cp.pi, M)
    output = cp.exp(1j * w * x)

    if complete:
        output -= cp.exp(-0.5 * (w**2))

    output *= cp.exp(-0.5 * (x**2)) * cp.pi**(-0.25)

    return output
```

with
```
_morlet_kernel = cp.ElementwiseKernel(
    "float64 delta, float64 start, float64 w, float64 pi, bool complete",
    "T output",
    """
    double x = start + delta * i;
    T temp = T(0, w * x);
    temp = exp(temp);
    if (complete) {
        temp -= exp( -0.5 * (w * w) );
    }
    output = temp * exp( -0.5 * (x * x)) * pow(pi, -0.25)
    """,
    "_morlet_kernel",
)

def morlet(M, w=5.0, s=1.0, complete=True):
    output = cp.empty(M, dtype=cp.complex128)
    end = s * 2 * np.pi
    start = -s * 2 * np.pi
    delta = (end - start) / (M - 1)

    _morlet_kernel(delta, start, w, np.pi, complete, output, size=M)

    return output
```

For functions like `cwt`, improvements are made by moving operations like scalar arithmetic and/or comparison back to the CPU using NumPy. Along with add a FFT cache dictionary to remove redundant FFT plan creations!