### PR TITLE
Update conda build files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer
 - PR #218 - Remove fatbins from source code on GH
 - PR #221 - Synchronization issue with cusignal testing 
+- PR #237 - Update conda build files so fatbins are generated
 
 # cuSignal 0.15.0 (26 Aug 2020)
 

--- a/build.sh
+++ b/build.sh
@@ -18,11 +18,12 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean cusignal -v -g -n -p --allgpuarch -h"
+VALIDARGS="clean cusignal -c -v -g -n -p --allgpuarch -h"
 HELP="$0 [clean] [cusignal] [-v] [-g] [-n] [--allgpuarch] [-h]
    clean        - remove all existing build artifacts and configuration (start
                   over)
    cusignal     - build the cusignal Python package
+   -c           - ci build
    -v           - verbose build mode
    -g           - build for debug
    -n           - no install step
@@ -173,6 +174,10 @@ if buildAll || hasArg cusignal; then
 
     cd ${REPODIR}/python
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        python setup.py install
+        if hasArg -c; then
+            python setup.py install --single-version-externally-managed --record record.txt
+        else
+            python setup.py install
+        fi
     fi
 fi

--- a/conda/recipes/cusignal/build.sh
+++ b/conda/recipes/cusignal/build.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd python
-python setup.py install --single-version-externally-managed --record record.txt
+./build.sh cusignal -c

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: ../../..
+  path: ../../..
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}


### PR DESCRIPTION
This PR updates cusignal's conda recipe `build.sh` file to use the `build.sh` file in the project's root directory. This fixes an issue where the `fatbin` files were not being generated for conda package uploads.

I also updated `conda/recipes/cusignal/meta.yaml` to use `path` instead of `git_url`. The differences are outlined in the excerpt below from the conda docs ([src](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#source-from-a-local-path)):

> "If the local path is a git or svn repository, you get the corresponding environment variables defined in your build environment. The only practical difference between git_url or hg_url and path as source arguments is that git_url and hg_url would be clones of a repository, while path would be a copy of the repository. **Using path allows you to build packages with unstaged and uncommitted changes in the working directory. git_url can build only up to the latest commit.**"

In essence, I couldn't test these changes locally when using `git_url` since it kept cloning the latest commit for the `conda build` process instead of using my working directory.
