### PR TITLE
[Review] Clipping fix for Peak Finding module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PR #218 - Remove fatbins from source code on GH
 - PR #221 - Synchronization issue with cusignal testing 
 - PR #237 - Update conda build files so fatbins are generated
+- PR #239 - Fix mode issue in peak finding module
 
 # cuSignal 0.15.0 (26 Aug 2020)
 

--- a/python/cusignal/test/test_peak_finding.py
+++ b/python/cusignal/test/test_peak_finding.py
@@ -15,105 +15,111 @@ import cupy as cp
 import cusignal
 import numpy as np
 import pytest
-
 from cusignal.test.utils import array_equal, _check_rapids_pytest_benchmark
 from scipy import signal
 
 gpubenchmark = _check_rapids_pytest_benchmark()
 
-# # Missing
-# # argrelmax
-# # argrelextrema
-
 
 class TestPeakFinding:
-	@pytest.mark.benchmark(group="Argrelmin")
-	@pytest.mark.parametrize("num_samps", [2**8])
-	@pytest.mark.parametrize("axis", [0, 1])
-	@pytest.mark.parametrize("order", [1, 2])
-	@pytest.mark.parametrize("mode", ["clip", "wrap"])
-	class TestArgrelmin:
-		def cpu_version(self, sig, axis, order, mode):
-			return signal.argrelmin(sig, axis, order, mode)
+    @pytest.mark.benchmark(group="Argrelmin")
+    @pytest.mark.parametrize("num_samps", [2 ** 8])
+    @pytest.mark.parametrize("axis", [0, 1])
+    @pytest.mark.parametrize("order", [1, 2])
+    @pytest.mark.parametrize("mode", ["clip", "wrap"])
+    class TestArgrelmin:
+        def cpu_version(self, sig, axis, order, mode):
+            return signal.argrelmin(sig, axis, order, mode)
 
-		def gpu_version(self, sig, axis, order, mode):
-			with cp.cuda.Stream.null:
-				out = cusignal.argrelmin(sig, axis, order, mode)
-			cp.cuda.Stream.null.synchronize()
-			return out
+        def gpu_version(self, sig, axis, order, mode):
+            with cp.cuda.Stream.null:
+                out = cusignal.argrelmin(sig, axis, order, mode)
+            cp.cuda.Stream.null.synchronize()
+            return out
 
-		@pytest.mark.cpu
-		def test_argrelmin_cpu(
-			self, rand_2d_data_gen, benchmark, num_samps, axis, order, mode
-		):
-			cpu_sig, _ = rand_2d_data_gen(num_samps)
-			benchmark(self.cpu_version, cpu_sig, axis, order, mode)
+        @pytest.mark.cpu
+        def test_argrelmin_cpu(
+            self, rand_2d_data_gen, benchmark, num_samps, axis, order, mode
+        ):
+            cpu_sig, _ = rand_2d_data_gen(num_samps)
+            benchmark(self.cpu_version, cpu_sig, axis, order, mode)
 
-		def test_argrelmin_gpu(
-			self, rand_2d_data_gen, gpubenchmark, num_samps, axis, order, mode
-		):
+        def test_argrelmin_gpu(
+            self, rand_2d_data_gen, gpubenchmark, num_samps, axis, order, mode
+        ):
+            cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
+            output = gpubenchmark(self.gpu_version, gpu_sig, axis, order, mode)
+            key = self.cpu_version(cpu_sig, axis, order, mode)
+            assert array_equal(cp.asnumpy(output), key)
 
-			cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
-			output = gpubenchmark(self.gpu_version, gpu_sig, axis, order, mode)
+    @pytest.mark.benchmark(group="TestArgrelmax")
+    @pytest.mark.parametrize("num_samps", [2 ** 8])
+    @pytest.mark.parametrize("axis", [0, 1])
+    @pytest.mark.parametrize("order", [1, 2])
+    @pytest.mark.parametrize("mode", ["clip", "wrap"])
+    class TestArgrelmax:
+        def cpu_version(self, sig, axis, order, mode):
+            return signal.argrelmax(sig, axis, order, mode)
 
-			key = self.cpu_version(cpu_sig, axis, order, mode)
-			assert array_equal(cp.asnumpy(output), key)
+        def gpu_version(self, sig, axis, order, mode):
+            with cp.cuda.Stream.null:
+                out = cusignal.argrelmax(sig, axis, order, mode)
+            cp.cuda.Stream.null.synchronize()
+            return out
 
-	# @pytest.mark.benchmark(group="Argrelmin")
-	# @pytest.mark.parametrize("x", np.array([[1, 2, 1, 2],
-	#                                         [2, 2, 0, 0],
-	#                                         [5, 3, 4, 4]]))
-	# class TestArgrelmin:
-	#     def cpu_version(self, x):
-	#         return signal.argrelmin(x)
+        @pytest.mark.cpu
+        def test_argrelmax_cpu(
+            self, rand_2d_data_gen, benchmark, num_samps, axis, order, mode
+        ):
+            cpu_sig, _ = rand_2d_data_gen(num_samps)
+            benchmark(self.cpu_version, cpu_sig, axis, order, mode)
 
-	#     def gpu_version(self, x):
-	#         with cp.cuda.Stream.null:
-	#             out = cusignal.argrelmin(x)
-	#         cp.cuda.Stream.null.synchronize()
-	#         return out
+        def test_argrelmax_gpu(
+            self, rand_2d_data_gen, gpubenchmark, num_samps, axis, order, mode
+        ):
+            cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
+            output = gpubenchmark(self.gpu_version, gpu_sig, axis, order, mode)
+            key = self.cpu_version(cpu_sig, axis, order, mode)
+            assert array_equal(cp.asnumpy(output), key)
 
-	#     @pytest.mark.cpu
-	#     def test_argrelmin_cpu(self, benchmark, x):
-	#         benchmark(self.cpu_version, x)
+    @pytest.mark.benchmark(group="Argrelextrema")
+    @pytest.mark.parametrize("num_samps", [2 ** 8])
+    @pytest.mark.parametrize("axis", [0, 1])
+    @pytest.mark.parametrize("order", [1, 2])
+    @pytest.mark.parametrize("mode", ["clip", "wrap"])
+    class TestArgrelextrema:
+        def cpu_version(self, sig, axis, order, mode):
+            return signal.argrelextrema(sig, np.less, axis, order, mode)
 
-	#     def test_argrelmin_gpu(self, gpubenchmark, x):
-	#         d_x = cp.array(x)
-	#         #d_x = cp.asarray(x)
-	#         output = gpubenchmark(self.gpu_version, d_x)
+        def gpu_version(self, sig, axis, order, mode):
+            with cp.cuda.Stream.null:
+                out = cusignal.argrelextrema(sig, cp.less, axis, order, mode)
+            cp.cuda.Stream.null.synchronize()
+            return out
 
-	#         key = self.cpu_version(x)
-	#         assert array_equal(cp.asnumpy(output), key)
+        @pytest.mark.cpu
+        def test_argrelextrema_cpu(
+            self,
+            rand_2d_data_gen,
+            benchmark,
+            num_samps,
+            axis,
+            order,
+            mode,
+        ):
+            cpu_sig, _ = rand_2d_data_gen(num_samps)
+            benchmark(self.cpu_version, cpu_sig, axis, order, mode)
 
-
-#     @pytest.mark.benchmark(group="Argrelmax")
-#     class TestArgrelmax:
-#         def cpu_version(self, cpu_sig):
-#             return signal.argrelmax(cpu_sig)
-
-#         @pytest.mark.cpu
-#         def test_argrelmax_cpu(self, benchmark):
-#             benchmark(self.cpu_version, cpu_sig)
-
-#         def test_argrelmax_gpu(self, gpubenchmark):
-
-#             output = gpubenchmark(cusignal.argrelmax, gpu_sig)
-
-#             key = self.cpu_version(cpu_sig)
-#             assert array_equal(cp.asnumpy(output), key)
-
-#     @pytest.mark.benchmark(group="Argrelextrema")
-#     class TestArgrelextrema:
-#         def cpu_version(self, cpu_sig):
-#             return signal.argrelextrema(cpu_sig)
-
-#         @pytest.mark.cpu
-#         def test_argrelextrema_cpu(self, benchmark):
-#             benchmark(self.cpu_version, cpu_sig)
-
-#         def test_argrelextrema_gpu(self, gpubenchmark):
-
-#             output = gpubenchmark(cusignal.argrelextrema, gpu_sig)
-
-#             key = self.cpu_version(cpu_sig)
-#             assert array_equal(cp.asnumpy(output), key)
+        def test_argrelextrema_gpu(
+            self,
+            rand_2d_data_gen,
+            gpubenchmark,
+            num_samps,
+            axis,
+            order,
+            mode,
+        ):
+            cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
+            output = gpubenchmark(self.gpu_version, gpu_sig, axis, order, mode)
+            key = self.cpu_version(cpu_sig, axis, order, mode)
+            assert array_equal(cp.asnumpy(output), key)

--- a/python/cusignal/test/test_peak_finding.py
+++ b/python/cusignal/test/test_peak_finding.py
@@ -11,38 +11,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import cupy as cp
-# import cusignal
-# import numpy as np
-# import pytest
+import cupy as cp
+import cusignal
+import numpy as np
+import pytest
 
-# from cusignal.test.utils import array_equal, _check_rapids_pytest_benchmark
-# from scipy import signal
+from cusignal.test.utils import array_equal, _check_rapids_pytest_benchmark
+from scipy import signal
 
-# gpubenchmark = _check_rapids_pytest_benchmark()
+gpubenchmark = _check_rapids_pytest_benchmark()
 
 # # Missing
-# # argrelmin
 # # argrelmax
 # # argrelextrema
 
 
-# class TestPeakFinding:
-#     @pytest.mark.benchmark(group="Argrelmin")
-#     class TestArgrelmin:
-#         def cpu_version(self, cpu_sig):
-#             return signal.argrelmin(cpu_sig)
+class TestPeakFinding:
+	@pytest.mark.benchmark(group="Argrelmin")
+	@pytest.mark.parametrize("num_samps", [2**8])
+	@pytest.mark.parametrize("axis", [0, 1])
+	@pytest.mark.parametrize("order", [1, 2])
+	@pytest.mark.parametrize("mode", ["clip", "wrap"])
+	class TestArgrelmin:
+		def cpu_version(self, sig, axis, order, mode):
+			return signal.argrelmin(sig, axis, order, mode)
 
-#         @pytest.mark.cpu
-#         def test_argrelmin_cpu(self, benchmark):
-#             benchmark(self.cpu_version, cpu_sig)
+		def gpu_version(self, sig, axis, order, mode):
+			with cp.cuda.Stream.null:
+				out = cusignal.argrelmin(sig, axis, order, mode)
+			cp.cuda.Stream.null.synchronize()
+			return out
 
-#         def test_argrelmin_gpu(self, gpubenchmark):
+		@pytest.mark.cpu
+		def test_argrelmin_cpu(
+			self, rand_2d_data_gen, benchmark, num_samps, axis, order, mode
+		):
+			cpu_sig, _ = rand_2d_data_gen(num_samps)
+			benchmark(self.cpu_version, cpu_sig, axis, order, mode)
 
-#             output = gpubenchmark(cusignal.argrelmin, gpu_sig)
+		def test_argrelmin_gpu(
+			self, rand_2d_data_gen, gpubenchmark, num_samps, axis, order, mode
+		):
 
-#             key = self.cpu_version(cpu_sig)
-#             assert array_equal(cp.asnumpy(output), key)
+			cpu_sig, gpu_sig = rand_2d_data_gen(num_samps)
+			output = gpubenchmark(self.gpu_version, gpu_sig, axis, order, mode)
+
+			key = self.cpu_version(cpu_sig, axis, order, mode)
+			assert array_equal(cp.asnumpy(output), key)
+
+	# @pytest.mark.benchmark(group="Argrelmin")
+	# @pytest.mark.parametrize("x", np.array([[1, 2, 1, 2],
+	#                                         [2, 2, 0, 0],
+	#                                         [5, 3, 4, 4]]))
+	# class TestArgrelmin:
+	#     def cpu_version(self, x):
+	#         return signal.argrelmin(x)
+
+	#     def gpu_version(self, x):
+	#         with cp.cuda.Stream.null:
+	#             out = cusignal.argrelmin(x)
+	#         cp.cuda.Stream.null.synchronize()
+	#         return out
+
+	#     @pytest.mark.cpu
+	#     def test_argrelmin_cpu(self, benchmark, x):
+	#         benchmark(self.cpu_version, x)
+
+	#     def test_argrelmin_gpu(self, gpubenchmark, x):
+	#         d_x = cp.array(x)
+	#         #d_x = cp.asarray(x)
+	#         output = gpubenchmark(self.gpu_version, d_x)
+
+	#         key = self.cpu_version(x)
+	#         assert array_equal(cp.asnumpy(output), key)
+
 
 #     @pytest.mark.benchmark(group="Argrelmax")
 #     class TestArgrelmax:


### PR DESCRIPTION
Closes #238 

This PR currently provides a quick fix for clipping. The idea is to do clipping manually because it is not native to `cupy.take`

### Quick Results
```bash
(cusignal) belt@orion:~/workStuff/rapids/cusignal$ pytest python -v --benchmark-enable --benchmark-columns=mean -k TestPeakFinding
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /home/belt/anaconda3/envs/cusignal/bin/python
cachedir: .pytest_cache
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=True min_rounds=25 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=True warmup_iterations=10)
rootdir: /home/belt/workStuff/rapids/cusignal/python, configfile: setup.cfg
plugins: benchmark-3.2.3
collected 858 items / 810 deselected / 48 selected                                                                                                                                          

python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[clip-1-0-256] PASSED                                                                    [  2%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[clip-1-1-256] PASSED                                                                    [  4%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[clip-2-0-256] PASSED                                                                    [  6%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[clip-2-1-256] PASSED                                                                    [  8%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[wrap-1-0-256] PASSED                                                                    [ 10%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[wrap-1-1-256] PASSED                                                                    [ 12%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[wrap-2-0-256] PASSED                                                                    [ 14%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_cpu[wrap-2-1-256] PASSED                                                                    [ 16%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[clip-1-0-256] PASSED                                                                    [ 18%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[clip-1-1-256] PASSED                                                                    [ 20%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[clip-2-0-256] PASSED                                                                    [ 22%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[clip-2-1-256] PASSED                                                                    [ 25%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[wrap-1-0-256] PASSED                                                                    [ 27%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[wrap-1-1-256] PASSED                                                                    [ 29%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[wrap-2-0-256] PASSED                                                                    [ 31%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmin::test_argrelmin_gpu[wrap-2-1-256] PASSED                                                                    [ 33%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[clip-1-0-256] PASSED                                                                    [ 35%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[clip-1-1-256] PASSED                                                                    [ 37%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[clip-2-0-256] PASSED                                                                    [ 39%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[clip-2-1-256] PASSED                                                                    [ 41%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[wrap-1-0-256] PASSED                                                                    [ 43%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[wrap-1-1-256] PASSED                                                                    [ 45%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[wrap-2-0-256] PASSED                                                                    [ 47%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_cpu[wrap-2-1-256] PASSED                                                                    [ 50%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[clip-1-0-256] PASSED                                                                    [ 52%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[clip-1-1-256] PASSED                                                                    [ 54%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[clip-2-0-256] PASSED                                                                    [ 56%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[clip-2-1-256] PASSED                                                                    [ 58%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[wrap-1-0-256] PASSED                                                                    [ 60%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[wrap-1-1-256] PASSED                                                                    [ 62%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[wrap-2-0-256] PASSED                                                                    [ 64%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelmax::test_argrelmax_gpu[wrap-2-1-256] PASSED                                                                    [ 66%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[clip-1-0-256] PASSED                                                            [ 68%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[clip-1-1-256] PASSED                                                            [ 70%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[clip-2-0-256] PASSED                                                            [ 72%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[clip-2-1-256] PASSED                                                            [ 75%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[wrap-1-0-256] PASSED                                                            [ 77%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[wrap-1-1-256] PASSED                                                            [ 79%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[wrap-2-0-256] PASSED                                                            [ 81%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_cpu[wrap-2-1-256] PASSED                                                            [ 83%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[clip-1-0-256] PASSED                                                            [ 85%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[clip-1-1-256] PASSED                                                            [ 87%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[clip-2-0-256] PASSED                                                            [ 89%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[clip-2-1-256] PASSED                                                            [ 91%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[wrap-1-0-256] PASSED                                                            [ 93%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[wrap-1-1-256] PASSED                                                            [ 95%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[wrap-2-0-256] PASSED                                                            [ 97%]
python/cusignal/test/test_peak_finding.py::TestPeakFinding::TestArgrelextrema::test_argrelextrema_gpu[wrap-2-1-256] PASSED                                                            [100%]


----------- benchmark 'Argrelextrema': 16 tests -----------
Name (time in us)                            Mean          
-----------------------------------------------------------
test_argrelextrema_gpu[wrap-1-1-256]     343.7113 (1.0)    
test_argrelextrema_gpu[wrap-1-0-256]     343.8282 (1.00)   
test_argrelextrema_gpu[clip-1-0-256]     402.7226 (1.17)   
test_argrelextrema_gpu[clip-1-1-256]     405.4959 (1.18)   
test_argrelextrema_cpu[clip-2-0-256]     408.9565 (1.19)   
test_argrelextrema_cpu[clip-1-0-256]     410.8784 (1.20)   
test_argrelextrema_cpu[wrap-1-0-256]     412.2442 (1.20)   
test_argrelextrema_cpu[wrap-2-0-256]     413.6792 (1.20)   
test_argrelextrema_cpu[wrap-1-1-256]     422.5903 (1.23)   
test_argrelextrema_cpu[wrap-2-1-256]     486.6696 (1.42)   
test_argrelextrema_cpu[clip-1-1-256]     496.4618 (1.44)   
test_argrelextrema_gpu[wrap-2-1-256]     496.7175 (1.45)   
test_argrelextrema_gpu[wrap-2-0-256]     508.1904 (1.48)   
test_argrelextrema_cpu[clip-2-1-256]     603.1852 (1.75)   
test_argrelextrema_gpu[clip-2-0-256]     611.6793 (1.78)   
test_argrelextrema_gpu[clip-2-1-256]     621.4523 (1.81)   
-----------------------------------------------------------

----------- benchmark 'Argrelmin': 16 tests -----------
Name (time in us)                        Mean          
-------------------------------------------------------
test_argrelmin_gpu[wrap-1-0-256]     345.4856 (1.0)    
test_argrelmin_gpu[wrap-1-1-256]     351.4767 (1.02)   
test_argrelmin_gpu[clip-1-0-256]     405.2707 (1.17)   
test_argrelmin_gpu[clip-1-1-256]     406.4385 (1.18)   
test_argrelmin_cpu[wrap-1-0-256]     415.6927 (1.20)   
test_argrelmin_cpu[clip-1-0-256]     416.3985 (1.21)   
test_argrelmin_cpu[wrap-2-0-256]     419.7294 (1.21)   
test_argrelmin_cpu[wrap-1-1-256]     421.5392 (1.22)   
test_argrelmin_cpu[clip-2-0-256]     429.4233 (1.24)   
test_argrelmin_cpu[wrap-2-1-256]     492.1774 (1.42)   
test_argrelmin_gpu[wrap-2-0-256]     492.5698 (1.43)   
test_argrelmin_gpu[wrap-2-1-256]     496.1663 (1.44)   
test_argrelmin_cpu[clip-1-1-256]     500.1869 (1.45)   
test_argrelmin_gpu[clip-2-0-256]     607.9458 (1.76)   
test_argrelmin_gpu[clip-2-1-256]     609.4416 (1.76)   
test_argrelmin_cpu[clip-2-1-256]     620.5978 (1.80)   
-------------------------------------------------------

--------- benchmark 'TestArgrelmax': 16 tests ---------
Name (time in us)                        Mean          
-------------------------------------------------------
test_argrelmax_gpu[wrap-1-0-256]     342.6778 (1.0)    
test_argrelmax_gpu[wrap-1-1-256]     351.4933 (1.03)   
test_argrelmax_gpu[clip-1-0-256]     398.9561 (1.16)   
test_argrelmax_gpu[clip-1-1-256]     401.9639 (1.17)   
test_argrelmax_cpu[clip-1-0-256]     404.1723 (1.18)   
test_argrelmax_cpu[clip-2-0-256]     411.3217 (1.20)   
test_argrelmax_cpu[wrap-1-0-256]     420.0963 (1.23)   
test_argrelmax_cpu[wrap-2-0-256]     426.0548 (1.24)   
test_argrelmax_cpu[wrap-1-1-256]     434.5563 (1.27)   
test_argrelmax_cpu[wrap-2-1-256]     488.5723 (1.43)   
test_argrelmax_gpu[wrap-2-0-256]     492.1686 (1.44)   
test_argrelmax_cpu[clip-1-1-256]     498.8134 (1.46)   
test_argrelmax_gpu[wrap-2-1-256]     500.5939 (1.46)   
test_argrelmax_cpu[clip-2-1-256]     613.5894 (1.79)   
test_argrelmax_gpu[clip-2-1-256]     618.2062 (1.80)   
test_argrelmax_gpu[clip-2-0-256]     630.2188 (1.84)   
-------------------------------------------------------
```

Shootout to @z-ryan1 for finding and debugging the issue.