### PR TITLE
Add pytorch installation disclaimer to E2E_Example Notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #219 - Add missing pytests
 - PR #222 - Improved performance for various window functions
 - PR #235 - Improve Wavelets functions performance
+- PR #242 - Add PyTorch disclaimer to notebook
 
 ## Bug Fixes
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer

--- a/notebooks/E2E_Example.ipynb
+++ b/notebooks/E2E_Example.ipynb
@@ -311,6 +311,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Uncomment the line below to ensure PyTorch is installed.\n",
+    "# PyTorch is intentionally excluded from our Docker images due to its size.\n",
+    "# Alternatively, the docker image can be run with the following variable:\n",
+    "#     docker run -e EXTRA_CONDA_PACKAGES=\"-c pytorch pytorch\"...\n",
+    "\n",
+    "#!conda install -c pytorch pytorch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import torch\n",
     "import torch.nn as nn\n",
     "import torch.optim as optim\n",


### PR DESCRIPTION
A user of our Docker images recently opened up issue https://github.com/rapidsai/docker/issues/74 which states that PyTorch is not installed in our containers and therefore the `E2E_Example.ipynb` notebook cannot be successfully run from top to bottom. After speaking with @mike-wendt, he mentioned that we intentionally exclude PyTorch due to its size. Mike recommended adding a disclaimer to the notebook similar to the one introduced in this PR.