### PR TITLE
[REVIEW] Fix channelizer bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #237 - Update conda build files so fatbins are generated
 - PR #239 - Fix mode issue in peak finding module
 - PR #246 - Remove lfiltic function
+- PR #248 - Fix channelizer bugs
 
 # cuSignal 0.15.0 (26 Aug 2020)
 

--- a/cpp/src/filtering/_channelizer.cu
+++ b/cpp/src/filtering/_channelizer.cu
@@ -62,13 +62,12 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
         }
     }
 
-    __syncthreads( );
+    block.sync( );
 
     T local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -98,7 +97,7 @@ __device__ void _cupy_channelizer_8x8( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         T local_reg { s_mem[ty][tx] };
 
@@ -215,13 +214,12 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
         }
     }
 
-    __syncthreads( );
+    block.sync( );
 
     T local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -251,7 +249,7 @@ __device__ void _cupy_channelizer_16x16( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         T local_reg { s_mem[ty][tx] };
 
@@ -367,14 +365,12 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
         }
     }
 
-    __syncthreads( );
+    block.sync( );
 
     T local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
-
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -404,7 +400,7 @@ __device__ void _cupy_channelizer_32x32( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         T local_reg { s_mem[ty][tx] };
 
@@ -526,13 +522,12 @@ __device__ void _cupy_channelizer_float32_complex64( const int n_chans,
         s_mem[tx][ty] = 0.0f;
     }
 
-    __syncthreads( );
+    block.sync( );
 
     float local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -546,7 +541,7 @@ __device__ void _cupy_channelizer_float32_complex64( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         float local_reg { s_mem[ty][tx] };
 
@@ -634,13 +629,12 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
         s_mem[tx][ty] = make_cuFloatComplex( 0.0f, 0.0f );
     }
 
-    __syncthreads( );
+    block.sync( );
 
     cuFloatComplex local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -654,7 +648,7 @@ __device__ void _cupy_channelizer_complex64_complex64( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         cuFloatComplex local_reg { s_mem[ty][tx] };
 
@@ -743,13 +737,12 @@ __device__ void _cupy_channelizer_float64_complex128( const int n_chans,
         s_mem[tx][ty] = 0.0;
     }
 
-    __syncthreads( );
+    block.sync( );
 
     double local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -763,7 +756,7 @@ __device__ void _cupy_channelizer_float64_complex128( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         double local_reg { s_mem[ty][tx] };
 
@@ -851,13 +844,12 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
         s_mem[tx][ty] = make_cuDoubleComplex( 0.0, 0.0 );
     }
 
-    __syncthreads( );
+    block.sync( );
 
     cuDoubleComplex local_h { s_mem[ty][tx] };
 
-    __syncthreads( );
-
     for ( auto bid = blockIdx.y; bid < n_pts; bid += gridDim.y ) {
+        block.sync( );
         // Load data
         if ( bid >= n_taps ) {
             if ( btx < n_chans && ty < n_taps ) {
@@ -871,7 +863,7 @@ __device__ void _cupy_channelizer_complex128_complex128( const int n_chans,
             }
         }
 
-        __syncthreads( );
+        block.sync( );
 
         cuDoubleComplex local_reg { s_mem[ty][tx] };
 

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -661,7 +661,9 @@ def channelize_poly(x, h, n_chans):
     if (x.dtype, n_pts, n_taps, n_chans) in _cupy_fft_cache:
         plan = _cupy_fft_cache[(x.dtype, n_pts, n_taps, n_chans)]
     else:
-        plan = _cupy_fft_cache[(x.dtype, n_pts, n_taps, n_chans)] = fftpack.get_fft_plan(y, axes=-1)
+        plan = _cupy_fft_cache[
+            (x.dtype, n_pts, n_taps, n_chans)
+        ] = fftpack.get_fft_plan(y, axes=-1)
 
     y = cp.conj(fftpack.fft(y, overwrite_x=True, plan=plan)).T
 

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -634,9 +634,13 @@ def channelize_poly(x, h, n_chans):
     # number of taps in each h_n filter
     n_taps = int(len(h) / n_chans)
     if n_taps > 32:
-        raise NotImplementedError('The number of calculated taps ({}) in  \
+        raise NotImplementedError(
+            "The number of calculated taps ({}) in  \
             each filter is currently capped at 32. Please reduce filter \
-                length or number of channels'.format(n_taps))
+                length or number of channels".format(
+                n_taps
+            )
+        )
 
     if n_taps > 32:
         raise NotImplementedError(
@@ -654,10 +658,10 @@ def channelize_poly(x, h, n_chans):
     _channelizer(x, h, y, n_chans, n_taps, n_pts)
 
     # Remove with CuPy v8
-    if (x.dtype) in _cupy_fft_cache:
-        plan = _cupy_fft_cache[(x.dtype)]
+    if (x.dtype, n_pts, n_taps, n_chans) in _cupy_fft_cache:
+        plan = _cupy_fft_cache[(x.dtype, n_pts, n_taps, n_chans)]
     else:
-        plan = _cupy_fft_cache[(x.dtype)] = fftpack.get_fft_plan(y, axes=-1)
+        plan = _cupy_fft_cache[(x.dtype, n_pts, n_taps, n_chans)] = fftpack.get_fft_plan(y, axes=-1)
 
     y = cp.conj(fftpack.fft(y, overwrite_x=True, plan=plan)).T
 


### PR DESCRIPTION
This PR fixes the following:

1. A race condition in shared memory caused by a large grid stride.
2. Adds more keys to fft plan cache to ensure uniqueness.

