### PR TITLE
[REVIEW] Use CuPy v8 FFT cache plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #245 - Reduce number of default build architectures
 - PR #246 - Remove lfiltic function
 - PR #248 - Fix channelizer bugs
+- PR #254 - Use CuPy v8 FFT cache plan
 
 # cuSignal 0.15.0 (26 Aug 2020)
 

--- a/python/cusignal/convolution/convolve.py
+++ b/python/cusignal/convolution/convolve.py
@@ -303,9 +303,6 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     fshape = [next_fast_len(d) for d in shape[axes]]
     fslice = tuple([slice(sz) for sz in shape])
 
-    ver = cp.__version__
-    print(ver)
-    print(ver.split("."))
     major_ver = cp.__version__.split(".")
 
     if int(major_ver[0]) >= 8:

--- a/python/cusignal/convolution/convolve.py
+++ b/python/cusignal/convolution/convolve.py
@@ -305,9 +305,9 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
     ver = cp.__version__
     print(ver)
-    print(ver.split('.'))
-    major_ver = cp.__version__.split('.')
-    
+    print(ver.split("."))
+    major_ver = cp.__version__.split(".")
+
     if int(major_ver[0]) >= 8:
         if not complex_result:
             sp1 = cp.fft.rfftn(in1, fshape, axes=axes)
@@ -317,14 +317,16 @@ def fftconvolve(in1, in2, mode="full", axes=None):
             sp1 = fftpack.fftn(in1, fshape, axes=axes)
             sp2 = fftpack.fftn(in2, fshape, axes=axes)
             ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
-    else: # CuPy v7
+    else:  # CuPy v7
         if not complex_result:
             if (str(fshape), str(axes), "R2C") in _cupy_fft_cache:
                 rplan = _cupy_fft_cache[(str(fshape), str(axes), "R2C")]
             else:
                 rplan = _cupy_fft_cache[
                     (str(fshape), str(axes), "R2C")
-                ] = fftpack.get_fft_plan(in1, fshape, axes=axes, value_type="R2C")
+                ] = fftpack.get_fft_plan(
+                    in1, fshape, axes=axes, value_type="R2C"
+                )
             try:
                 with rplan:
                     sp1 = cp.fft.rfftn(in1, fshape, axes=axes)
@@ -351,7 +353,6 @@ def fftconvolve(in1, in2, mode="full", axes=None):
                 sp1 = fftpack.fftn(in1, fshape, axes=axes)
                 sp2 = fftpack.fftn(in2, fshape, axes=axes)
                 ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
-
 
     if mode == "full":
         return ret

--- a/python/cusignal/convolution/convolve.py
+++ b/python/cusignal/convolution/convolve.py
@@ -303,39 +303,55 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     fshape = [next_fast_len(d) for d in shape[axes]]
     fslice = tuple([slice(sz) for sz in shape])
 
-    if not complex_result:
-        if (str(fshape), str(axes), "R2C") in _cupy_fft_cache:
-            rplan = _cupy_fft_cache[(str(fshape), str(axes), "R2C")]
-        else:
-            rplan = _cupy_fft_cache[
-                (str(fshape), str(axes), "R2C")
-            ] = fftpack.get_fft_plan(in1, fshape, axes=axes, value_type="R2C")
-        try:
-            with rplan:
-                sp1 = cp.fft.rfftn(in1, fshape, axes=axes)
-                sp2 = cp.fft.rfftn(in2, fshape, axes=axes)
-        except Exception:
+    ver = cp.__version__
+    print(ver)
+    print(ver.split('.'))
+    major_ver = cp.__version__.split('.')
+    
+    if int(major_ver[0]) >= 8:
+        if not complex_result:
             sp1 = cp.fft.rfftn(in1, fshape, axes=axes)
             sp2 = cp.fft.rfftn(in2, fshape, axes=axes)
-
-        ret = cp.fft.irfftn(sp1 * sp2, fshape, axes=axes)[fslice].copy()
-    else:
-        # Need to move to cupyx.scipy.fft with CuPy v8
-        if (str(fshape), str(axes)) in _cupy_fft_cache:
-            plan = _cupy_fft_cache[(str(fshape), str(axes))]
+            ret = cp.fft.irfftn(sp1 * sp2, fshape, axes=axes)[fslice].copy()
         else:
-            plan = _cupy_fft_cache[
-                (str(fshape), str(axes))
-            ] = fftpack.get_fft_plan(in1, fshape, axes=axes)
-        try:
-            with plan:
-                sp1 = fftpack.fftn(in1, fshape, axes=axes)
-                sp2 = fftpack.fftn(in2, fshape, axes=axes)
-                ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
-        except Exception:
             sp1 = fftpack.fftn(in1, fshape, axes=axes)
             sp2 = fftpack.fftn(in2, fshape, axes=axes)
             ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
+    else: # CuPy v7
+        if not complex_result:
+            if (str(fshape), str(axes), "R2C") in _cupy_fft_cache:
+                rplan = _cupy_fft_cache[(str(fshape), str(axes), "R2C")]
+            else:
+                rplan = _cupy_fft_cache[
+                    (str(fshape), str(axes), "R2C")
+                ] = fftpack.get_fft_plan(in1, fshape, axes=axes, value_type="R2C")
+            try:
+                with rplan:
+                    sp1 = cp.fft.rfftn(in1, fshape, axes=axes)
+                    sp2 = cp.fft.rfftn(in2, fshape, axes=axes)
+            except Exception:
+                sp1 = cp.fft.rfftn(in1, fshape, axes=axes)
+                sp2 = cp.fft.rfftn(in2, fshape, axes=axes)
+
+            ret = cp.fft.irfftn(sp1 * sp2, fshape, axes=axes)[fslice].copy()
+        else:
+            # Need to move to cupyx.scipy.fft with CuPy v8
+            if (str(fshape), str(axes)) in _cupy_fft_cache:
+                plan = _cupy_fft_cache[(str(fshape), str(axes))]
+            else:
+                plan = _cupy_fft_cache[
+                    (str(fshape), str(axes))
+                ] = fftpack.get_fft_plan(in1, fshape, axes=axes)
+            try:
+                with plan:
+                    sp1 = fftpack.fftn(in1, fshape, axes=axes)
+                    sp2 = fftpack.fftn(in2, fshape, axes=axes)
+                    ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
+            except Exception:
+                sp1 = fftpack.fftn(in1, fshape, axes=axes)
+                sp2 = fftpack.fftn(in2, fshape, axes=axes)
+                ret = fftpack.ifftn(sp1 * sp2, axes=axes)[fslice].copy()
+
 
     if mode == "full":
         return ret


### PR DESCRIPTION
Closes #253 

This PR adds a check for CuPy v7 or v8, and uses version 8's internal FFT cache.

```bash
Without cache + CuPy v7.8
-------------------------------------------------------------------------------- benchmark 'FFTConvolve': 3 tests --------------------------------------------------------------------------------
Name (time in ms)                        Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fftconvolve_gpu[same-32768]      0.9265 (1.0)      2.3050 (1.37)     1.0593 (1.0)      0.1013 (1.16)     1.0293 (1.0)      0.0479 (1.0)       103;130  943.9904 (1.0)         967           1
test_fftconvolve_gpu[full-32768]      0.9506 (1.03)     1.9485 (1.16)     1.0928 (1.03)     0.0870 (1.0)      1.0477 (1.02)     0.0912 (1.90)       148;39  915.0630 (0.97)       1039           1
test_fftconvolve_gpu[valid-32768]     0.9488 (1.02)     1.6771 (1.0)      1.1023 (1.04)     0.0895 (1.03)     1.0592 (1.03)     0.1142 (2.38)       182;25  907.2237 (0.96)        963           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

With cache + CuPy v7.8
---------------------------------------------------------------------------------------- benchmark 'FFTConvolve': 3 tests ----------------------------------------------------------------------------------------
Name (time in us)                          Min                   Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fftconvolve_gpu[same-32768]      664.1870 (1.01)     1,199.3530 (1.0)      691.5575 (1.0)      31.8148 (1.0)      688.4840 (1.0)      25.0215 (1.0)         78;65        1.4460 (1.0)        1464           1
test_fftconvolve_gpu[full-32768]      675.1820 (1.02)     1,245.5840 (1.04)     707.1642 (1.02)     33.9103 (1.07)     697.7085 (1.01)     40.2040 (1.61)       113;17        1.4141 (0.98)       1394           1
test_fftconvolve_gpu[valid-32768]     659.9210 (1.0)      1,539.0550 (1.28)     708.1542 (1.02)     52.8239 (1.66)     691.9645 (1.01)     27.5100 (1.10)        55;56        1.4121 (0.98)       1460           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Without cache + CuPy v8.0
----------------------------------------------------------------------------------------- benchmark 'FFTConvolve': 3 tests ----------------------------------------------------------------------------------------
Name (time in us)                          Min                   Max                Mean             StdDev              Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fftconvolve_gpu[same-32768]      404.8580 (1.01)     1,034.3980 (1.19)     423.5631 (1.0)      26.2704 (1.0)      419.7810 (1.0)       11.3210 (1.0)       183;262        2.3609 (1.0)        2450           1
test_fftconvolve_gpu[valid-32768]     417.4070 (1.04)       869.7810 (1.0)      436.5062 (1.03)     28.0625 (1.07)     430.5310 (1.03)      13.3815 (1.18)      175;314        2.2909 (0.97)       2308           1
test_fftconvolve_gpu[full-32768]      400.9510 (1.0)      1,124.1380 (1.29)     458.4183 (1.08)     66.2477 (2.52)     423.2620 (1.01)     140.0130 (12.37)       476;1        2.1814 (0.92)       1798           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

With cache + CuPy v8.0
----------------------------------------------------------------------------------------- benchmark 'FFTConvolve': 3 tests ----------------------------------------------------------------------------------------
Name (time in us)                          Min                   Max                Mean             StdDev              Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fftconvolve_gpu[same-32768]      473.9490 (1.0)      1,200.2100 (1.39)     491.7297 (1.0)      26.6978 (1.24)     481.9450 (1.0)       15.4428 (1.14)      238;245        2.0336 (1.0)        2073           1
test_fftconvolve_gpu[valid-32768]     489.1830 (1.03)       866.0560 (1.0)      507.5161 (1.03)     21.5673 (1.0)      498.9190 (1.04)      13.5545 (1.0)       275;267        1.9704 (0.97)       1968           1
test_fftconvolve_gpu[full-32768]      475.2700 (1.00)     1,209.9800 (1.40)     540.0543 (1.10)     61.9996 (2.87)     511.7405 (1.06)     106.6135 (7.87)        314;3        1.8517 (0.91)       1592           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```