### PR TITLE
[REVIEW] Support cupy 8.0 and beyond in conda builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 - PR #242 - Add PyTorch disclaimer to notebook
 - PR #243 - Improve Peak Finding function performance
 - PR #249 - Update README to add SDR integration instructions and improved install clarity
-- PR #250 Update ci/local/README.md
+- PR #250 - Update ci/local/README.md
+- PR #256 - Update to CuPy 8.0.0
 
 ## Bug Fixes
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=7.2.0,<9.0
+    - cupy>=7.2.0,<9.0.0a
 
 test:
   requires:

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=7.2.0,<9.0.0a
+    - cupy>=7.2.0,<9.0.0a0
 
 test:
   requires:

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=7.2.0,<8.0.0a0
+    - cupy>=7.2.0,<9.0
 
 test:
   requires:


### PR DESCRIPTION
Now that CuPy 8.0 is out, we need to bump our top-requirement beyond 8.0.0a... otherwise, cuSignal will pull in CuPy 7.8 as a dependency.