### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 - PR #242 - Add PyTorch disclaimer to notebook
 - PR #243 - Improve Peak Finding function performance
 - PR #249 - Update README to add SDR integration instructions and improved install clarity
-- PR #250 Update ci/local/README.md
+- PR #250 - Update ci/local/README.md
+- PR #256 - Update to CuPy 8.0.0
 
 ## Bug Fixes
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=7.2.0,<8.0.0a0
+    - cupy>=7.2.0,<9.0.0a0
 
 test:
   requires:


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.