### PR TITLE
[REVIEW] FIX Fix notebook error handling in gpuCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - PR #246 - Remove lfiltic function
 - PR #248 - Fix channelizer bugs
 - PR #254 - Use CuPy v8 FFT cache plan
+- PR #259 - Fix notebook error handling in gpuCI
+
 
 # cuSignal 0.15.0 (26 Aug 2020)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -41,7 +41,7 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Activate conda env..."
-source activate gdf
+source activate rapids
 conda install -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=${CUDA_REL} \
     "rapids-build-env=$MINOR_VERSION.*" \
@@ -68,6 +68,10 @@ $WORKSPACE/build.sh clean cusignal
 # TEST - Run GoogleTest and py.tests for cusignal
 ################################################################################
 
+set +e -Eo pipefail
+EXITCODE=0
+trap "EXITCODE=1" ERR
+
 if hasArg --skip-tests; then
     logger "Skipping Tests..."
     exit 0
@@ -86,3 +90,7 @@ conda install -y -c pytorch "pytorch>=1.4"
 
 ${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log
 python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
+
+return ${EXITCODE}
+
+


### PR DESCRIPTION
Current functionality does not actually properly handle errors in testing the notebooks.

${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log

Will only error if the last command in the pipe errors.

set +e -Eo pipefail will allow us to detect errors earlier in the pipe and hold the EXITCODE till we need it.