### PR TITLE
[REVIEW] Optimize waveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 - PR #242 - Add PyTorch disclaimer to notebook
 - PR #243 - Improve Peak Finding function performance
 - PR #249 - Update README to add SDR integration instructions and improved install clarity
-- PR #250 Update ci/local/README.md
+- PR #250 - Update ci/local/README.md
+- PR #260 - Optimize waveform functions
 
 ## Bug Fixes
 - PR #214 - Fix grid-stride loop bug in polyphase channelizer

--- a/python/cusignal/test/test_waveforms.py
+++ b/python/cusignal/test/test_waveforms.py
@@ -73,7 +73,7 @@ class TestWaveforms:
         ):
 
             cpu_sig, gpu_sig = time_data_gen(0, 10, num_samps)
-            _, _, output = gpubenchmark(self.cpu_version, gpu_sig, fc)
+            _, _, output = gpubenchmark(self.gpu_version, gpu_sig, fc)
 
             _, _, key = self.cpu_version(cpu_sig, fc)
             assert array_equal(cp.asnumpy(output), key)

--- a/python/cusignal/test/test_waveforms.py
+++ b/python/cusignal/test/test_waveforms.py
@@ -83,7 +83,7 @@ class TestWaveforms:
     @pytest.mark.parametrize("f0", [6])
     @pytest.mark.parametrize("t1", [1])
     @pytest.mark.parametrize("f1", [10])
-    @pytest.mark.parametrize("method", ["linear", "quadratic"])
+    @pytest.mark.parametrize("method", ["lin", "quad", "log", "hyp"])
     class TestChirp:
         def cpu_version(self, sig, f0, t1, f1, method):
             return signal.chirp(sig, f0, t1, f1, method)

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -21,26 +21,26 @@ _square_kernel = cp.ElementwiseKernel(
     "T t, T w, T pi",
     "T y",
     """
-    T tmod;
-    bool mask1 = ( ( w > 1 ) || ( w < 0 ) );
+    bool mask1 { ( ( w > 1 ) || ( w < 0 ) ) };
     if ( mask1 ) {
         y = nan("0xfff8000000000000ULL");
     }
 
-    tmod = fmod(t, 2 * pi);
-    bool mask2 = ( ( 1 - mask1 ) && ( tmod < ( w * 2 * pi ) ) );
+    T tmod { fmod(t, 2 * pi) };
+    bool mask2 { ( ( 1 - mask1 ) && ( tmod < ( w * 2 * pi ) ) ) };
 
     if ( mask2 ) {
         y = 1;
     }
 
-    bool mask3 = ( ( 1 - mask1 ) && ( 1 - mask2 ) );
+    bool mask3 { ( ( 1 - mask1 ) && ( 1 - mask2 ) ) };
     if ( mask3 ) {
         y = -1;
     }
 
     """,
     "_square_kernel",
+    options=('-std=c++11',)
 )
 
 
@@ -114,6 +114,7 @@ _gausspulse_kernel_F_F = cp.ElementwiseKernel(
     yenv = exp(-a * t * t);
     """,
     "_gausspulse_kernel",
+    options=('-std=c++11',)
 )
 
 _gausspulse_kernel_F_T = cp.ElementwiseKernel(
@@ -124,17 +125,19 @@ _gausspulse_kernel_F_T = cp.ElementwiseKernel(
     yI = yenv * cos( 2 * pi * fc * t);
     """,
     "_gausspulse_kernel",
+    options=('-std=c++11',)
 )
 
 _gausspulse_kernel_T_F = cp.ElementwiseKernel(
     "T t, T a, T fc, T pi",
     "T yI, T yQ",
     """
-    T yenv = exp(-a * t * t);
+    T yenv { exp(-a * t * t) };
     yI = yenv * cos( 2 * pi * fc * t);
     yQ = yenv * sin( 2 * pi * fc * t);
     """,
     "_gausspulse_kernel",
+    options=('-std=c++11',)
 )
 
 _gausspulse_kernel_T_T = cp.ElementwiseKernel(
@@ -146,6 +149,7 @@ _gausspulse_kernel_T_T = cp.ElementwiseKernel(
     yQ = yenv * sin( 2 * pi * fc * t);
     """,
     "_gausspulse_kernel",
+    options=('-std=c++11',)
 )
 
 
@@ -257,23 +261,22 @@ _chirp_phase_lin_kernel = cp.ElementwiseKernel(
     "T t, T f0, T t1, T f1, T phi, T pi",
     "T phase",
     """
-    T l_phi = phi;
-    T beta = (f1 - f0) / t1;
-    T temp = 2 * pi * (f0 * t + 0.5 * beta * t * t);
+    T beta { (f1 - f0) / t1 };
+    T temp { 2 * pi * (f0 * t + 0.5 * beta * t * t) };
 
     // Convert  phi to radians.
     phase = cos(temp + phi);
     """,
     "_chirp_phase_lin_kernel",
+    options=('-std=c++11',)
 )
 
 _chirp_phase_quad_kernel = cp.ElementwiseKernel(
     "T t, T f0, T t1, T f1, T phi, T pi, bool vertex_zero",
     "T phase",
     """
-    T l_phi = phi;
-    T temp = 0;
-    T beta = (f1 - f0) / (t1 * t1);
+    T temp {};
+    T beta { (f1 - f0) / (t1 * t1) };
 
     if ( vertex_zero ) {
         temp = 2 * pi * (f0 * t + beta * (t * t * t) / 3);
@@ -287,19 +290,19 @@ _chirp_phase_quad_kernel = cp.ElementwiseKernel(
     phase = cos(temp + phi);
     """,
     "_chirp_phase_quad_kernel",
+    options=('-std=c++11',)
 )
 
 _chirp_phase_log_kernel = cp.ElementwiseKernel(
     "T t, T f0, T t1, T f1, T phi, T pi",
     "T phase",
     """
-    T l_phi = phi;
-    T temp = 0;
+    T temp {};
 
     if ( f0 == f1 ) {
         temp = 2 * pi * f0 * t;
     } else {
-        T beta = t1 / log(f1 / f0);
+        T beta { t1 / log(f1 / f0) };
         temp = 2 * pi * beta * f0 * ( pow(f1 / f0, t / t1) - 1.0 );
     }
 
@@ -307,19 +310,19 @@ _chirp_phase_log_kernel = cp.ElementwiseKernel(
     phase = cos(temp + phi);
     """,
     "_chirp_phase_log_kernel",
+    options=('-std=c++11',)
 )
 
 _chirp_phase_hyp_kernel = cp.ElementwiseKernel(
     "T t, T f0, T t1, T f1, T phi, T pi",
     "T phase",
     """
-    T l_phi = phi;
-    T temp = 0;
+    T temp {};
 
     if ( f0 == f1 ) {
         temp = 2 * pi * f0 * t;
     } else {
-        T sing = -f1 * t1 / (f0 - f1);
+        T sing { -f1 * t1 / (f0 - f1) };
         temp = 2 * pi * ( -sing * f0 ) * log( abs( 1 - t / sing ) );
     }
 
@@ -327,6 +330,7 @@ _chirp_phase_hyp_kernel = cp.ElementwiseKernel(
     phase = cos(temp + phi);
     """,
     "_chirp_phase_hyp_kernel",
+    options=('-std=c++11',)
 )
 
 
@@ -452,6 +456,7 @@ _unit_impulse_kernel = cp.ElementwiseKernel(
     }
     """,
     "_unit_impulse_kernel",
+    options=('-std=c++11',)
 )
 
 

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -12,9 +12,36 @@
 # limitations under the License.
 
 import cupy as cp
-from cupy import asarray, zeros, place, nan, mod, pi, log, sqrt, exp, cos, sin
+import numpy as np
 
 from six import string_types
+
+
+_square_kernel = cp.ElementwiseKernel(
+    "T t, T w, T pi",
+    "T y",
+    """
+    T tmod;
+    bool mask1 = ( ( w > 1 ) || ( w < 0 ) );
+    if ( mask1 ) {
+        y = nan("0xfff8000000000000ULL");
+    }
+
+    tmod = fmod(t, 2 * pi);
+    bool mask2 = ( ( 1 - mask1 ) && ( tmod < ( w * 2 * pi ) ) );
+
+    if ( mask2 ) {
+        y = 1;
+    }
+
+    bool mask3 = ( ( 1 - mask1 ) && ( 1 - mask2 ) );
+    if ( mask3 ) {
+        y = -1;
+    }
+
+    """,
+    "_square_kernel",
+)
 
 
 def square(t, duty=0.5):
@@ -66,29 +93,17 @@ def square(t, duty=0.5):
     >>> plt.ylim(-1.5, 1.5)
 
     """
-    t, w = asarray(t), asarray(duty)
-    w = asarray(w + (t - t))
-    t = asarray(t + (w - w))
+    t, w = cp.asarray(t), cp.asarray(duty)
+
     if t.dtype.char in ["fFdD"]:
         ytype = t.dtype.char
     else:
         ytype = "d"
 
-    y = zeros(t.shape, ytype)
+    y = cp.zeros(t.shape, ytype)
 
-    # width must be between 0 and 1 inclusive
-    mask1 = (w > 1) | (w < 0)
-    place(y, mask1, nan)
+    _square_kernel(t, w, cp.pi, y)
 
-    # on the interval 0 to duty*2*pi function is 1
-    tmod = mod(t, 2 * pi)
-    mask2 = (1 - mask1) & (tmod < w * 2 * pi)
-    place(y, mask2, 1)
-
-    # on the interval duty*2*pi to 2*pi function is
-    #  (pi*(w+1)-tmod) / (pi*(1-w))
-    mask3 = (1 - mask1) & (1 - mask2)
-    place(y, mask3, -1)
     return y
 
 
@@ -169,7 +184,7 @@ def gausspulse(
     # fdel = fc*bw/2:  g(fdel) = ref --- solve this for a
     #
     # pi^2/a * fc^2 * bw^2 /4=-log(ref)
-    a = -((pi * fc * bw) ** 2) / (4.0 * log(ref))
+    a = -((cp.pi * fc * bw) ** 2) / (4.0 * cp.log(ref))
 
     if isinstance(t, string_types):
         if t == "cutoff":  # compute cut_off point
@@ -180,13 +195,13 @@ def gausspulse(
                     "Reference level for time cutoff must " "be < 0 dB"
                 )
             tref = pow(10.0, tpr / 20.0)
-            return sqrt(-log(tref) / a)
+            return cp.sqrt(-cp.log(tref) / a)
         else:
             raise ValueError("If `t` is a string, it must be 'cutoff'")
 
-    yenv = exp(-a * t * t)
-    yI = yenv * cos(2 * pi * fc * t)
-    yQ = yenv * sin(2 * pi * fc * t)
+    yenv = cp.exp(-a * t * t)
+    yI = yenv * cp.cos(2 * cp.pi * fc * t)
+    yQ = yenv * cp.sin(2 * cp.pi * fc * t)
     if not retquad and not retenv:
         return yI
     if not retquad and retenv:
@@ -276,8 +291,8 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
     # 'phase' is computed in _chirp_phase, to make testing easier.
     phase = _chirp_phase(t, f0, t1, f1, method, vertex_zero)
     # Convert  phi to radians.
-    phi *= pi / 180
-    return cos(phase + phi)
+    phi *= cp.pi / 180
+    return cp.cos(phase + phi)
 
 
 def _chirp_phase(t, f0, t1, f1, method="linear", vertex_zero=True):
@@ -287,20 +302,20 @@ def _chirp_phase(t, f0, t1, f1, method="linear", vertex_zero=True):
     See `chirp` for a description of the arguments.
 
     """
-    t = asarray(t)
+    t = cp.asarray(t)
     f0 = float(f0)
     t1 = float(t1)
     f1 = float(f1)
     if method in ["linear", "lin", "li"]:
         beta = (f1 - f0) / t1
-        phase = 2 * pi * (f0 * t + 0.5 * beta * t * t)
+        phase = 2 * cp.pi * (f0 * t + 0.5 * beta * t * t)
 
     elif method in ["quadratic", "quad", "q"]:
         beta = (f1 - f0) / (t1 ** 2)
         if vertex_zero:
-            phase = 2 * pi * (f0 * t + beta * t ** 3 / 3)
+            phase = 2 * cp.pi * (f0 * t + beta * t ** 3 / 3)
         else:
-            phase = 2 * pi * (f1 * t + beta * ((t1 - t) ** 3 - t1 ** 3) / 3)
+            phase = 2 * cp.pi * (f1 * t + beta * ((t1 - t) ** 3 - t1 ** 3) / 3)
 
     elif method in ["logarithmic", "log", "lo"]:
         if f0 * f1 <= 0.0:
@@ -309,10 +324,10 @@ def _chirp_phase(t, f0, t1, f1, method="linear", vertex_zero=True):
                 "nonzero and have the same sign."
             )
         if f0 == f1:
-            phase = 2 * pi * f0 * t
+            phase = 2 * cp.pi * f0 * t
         else:
-            beta = t1 / log(f1 / f0)
-            phase = 2 * pi * beta * f0 * (pow(f1 / f0, t / t1) - 1.0)
+            beta = t1 / cp.log(f1 / f0)
+            phase = 2 * cp.pi * beta * f0 * (pow(f1 / f0, t / t1) - 1.0)
 
     elif method in ["hyperbolic", "hyp"]:
         if f0 == 0 or f1 == 0:
@@ -321,12 +336,12 @@ def _chirp_phase(t, f0, t1, f1, method="linear", vertex_zero=True):
             )
         if f0 == f1:
             # Degenerate case: constant frequency.
-            phase = 2 * pi * f0 * t
+            phase = 2 * cp.pi * f0 * t
         else:
             # Singular point: the instantaneous frequency blows up
             # when t == sing.
             sing = -f1 * t1 / (f0 - f1)
-            phase = 2 * pi * (-sing * f0) * log(cp.abs(1 - t / sing))
+            phase = 2 * cp.pi * (-sing * f0) * cp.log(cp.abs(1 - t / sing))
 
     else:
         raise ValueError(
@@ -393,7 +408,7 @@ def unit_impulse(shape, idx=None, dtype=float):
            [ 0.,  0.,  1.,  0.],
            [ 0.,  0.,  0.,  0.]])
     """
-    out = zeros(shape, dtype)
+    out = cp.zeros(shape, dtype)
 
     shape = cp.atleast_1d(shape)
 

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import cupy as cp
+import numpy as np
 
 from six import string_types
 
@@ -106,9 +107,39 @@ def square(t, duty=0.5):
     return y
 
 
-_gausspulse_kernel = cp.ElementwiseKernel(
-    "T t, T a, int32 fc, T pi",
-    "T yenv, T yI, T yQ",
+_gausspulse_kernel_F_F = cp.ElementwiseKernel(
+    "T t, T a, T fc, T pi",
+    "T yenv",
+    """
+    yenv = exp(-a * t * t);
+    """,
+    "_gausspulse_kernel",
+)
+
+_gausspulse_kernel_F_T = cp.ElementwiseKernel(
+    "T t, T a, T fc, T pi",
+    "T yI, T yenv",
+    """
+    yenv = exp(-a * t * t);
+    yI = yenv * cos( 2 * pi * fc * t);
+    """,
+    "_gausspulse_kernel",
+)
+
+_gausspulse_kernel_T_F = cp.ElementwiseKernel(
+    "T t, T a, T fc, T pi",
+    "T yI, T yQ",
+    """
+    T yenv = exp(-a * t * t);
+    yI = yenv * cos( 2 * pi * fc * t);
+    yQ = yenv * sin( 2 * pi * fc * t);
+    """,
+    "_gausspulse_kernel",
+)
+
+_gausspulse_kernel_T_T = cp.ElementwiseKernel(
+    "T t, T a, T fc, T pi",
+    "T yI, T yQ, T yenv",
     """
     yenv = exp(-a * t * t);
     yI = yenv * cos( 2 * pi * fc * t);
@@ -180,58 +211,46 @@ def gausspulse(
                  cp.asnumpy(t), cp.asnumpy(e), '--')
 
     """
-    # print('ehy')
-    # if fc < 0:
-    #     raise ValueError("Center frequency (fc=%.2f) must be >=0." % fc)
-    # if bw <= 0:
-    #     raise ValueError("Fractional bandwidth (bw=%.2f) must be > 0." % bw)
-    # if bwr >= 0:
-    #     raise ValueError(
-    #         "Reference level for bandwidth (bwr=%.2f) must " "be < 0 dB" % bwr
-    #     )
+    if fc < 0:
+        raise ValueError("Center frequency (fc=%.2f) must be >=0." % fc)
+    if bw <= 0:
+        raise ValueError("Fractional bandwidth (bw=%.2f) must be > 0." % bw)
+    if bwr >= 0:
+        raise ValueError(
+            "Reference level for bandwidth (bwr=%.2f) must " "be < 0 dB" % bwr
+        )
 
     # exp(-a t^2) <->  sqrt(pi/a) exp(-pi^2/a * f^2)  = g(f)
 
-    # ref = pow(10.0, bwr / 20.0)
-    # # fdel = fc*bw/2:  g(fdel) = ref --- solve this for a
-    # #
-    # # pi^2/a * fc^2 * bw^2 /4=-log(ref)
-    # a = -((cp.pi * fc * bw) ** 2) / (4.0 * cp.log(ref))
+    ref = pow(10.0, bwr / 20.0)
+    # fdel = fc*bw/2:  g(fdel) = ref --- solve this for a
+    #
+    # pi^2/a * fc^2 * bw^2 /4=-log(ref)
+    a = -((np.pi * fc * bw) ** 2) / (4.0 * np.log(ref))
 
-    # if isinstance(t, string_types):
-    #     print('ehy')
-    #     if t == "cutoff":  # compute cut_off point
-    #         #  Solve exp(-a tc**2) = tref  for tc
-    #         #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
-    #         if tpr >= 0:
-    #             raise ValueError(
-    #                 "Reference level for time cutoff must " "be < 0 dB"
-    #             )
-    #         tref = pow(10.0, tpr / 20.0)
-    #         return cp.sqrt(-cp.log(tref) / a)
-    #     else:
-    #         raise ValueError("If `t` is a string, it must be 'cutoff'")
+    if isinstance(t, string_types):
+        if t == "cutoff":  # compute cut_off point
+            #  Solve exp(-a tc**2) = tref  for tc
+            #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
+            if tpr >= 0:
+                raise ValueError(
+                    "Reference level for time cutoff must " "be < 0 dB"
+                )
+            tref = pow(10.0, tpr / 20.0)
+            return np.sqrt(-np.log(tref) / a)
+        else:
+            raise ValueError("If `t` is a string, it must be 'cutoff'")
 
-    # t = cp.asarray(t)
-    # yenv = cp.empty_like(t)
-    # yI = cp.empty_like(t)
-    # yQ = cp.empty_like(t)
+    t = cp.asarray(t)
 
-    # # _gausspulse_kernel(t, a, fc, cp.pi, yenv, yI, yQ)
-
-    # print('ehy')
-
-    # # yenv = cp.exp(-a * t * t)
-    # # yI = yenv * cp.cos(2 * cp.pi * fc * t)
-    # # yQ = yenv * cp.sin(2 * cp.pi * fc * t)
-    # if not retquad and not retenv:
-    #     return yI
-    # if not retquad and retenv:
-    #     return yI, yenv
-    # if retquad and not retenv:
-    #     return yI, yQ
-    # if retquad and retenv:
-    #     return yI, yQ, yenv
+    if not retquad and not retenv:
+        return _gausspulse_kernel_F_F(t, a, fc, cp.pi)
+    if not retquad and retenv:
+        return _gausspulse_kernel_F_T(t, a, fc, cp.pi)
+    if retquad and not retenv:
+        return _gausspulse_kernel_T_F(t, a, fc, cp.pi)
+    if retquad and retenv:
+        return _gausspulse_kernel_T_T(t, a, fc, cp.pi)
 
 
 def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -447,50 +447,6 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
             " or 'hyperbolic', but a value of %r was given." % method
         )
 
-    # Convert  phi to radians.
-    # phi *= cp.pi / 180
-    # return cp.cos(phase + phi)
-
-
-def _chirp_phase(t, f0, t1, f1, method="linear", vertex_zero=True):
-    """
-    Calculate the phase used by `chirp` to generate its output.
-
-    See `chirp` for a description of the arguments.
-
-    """
-    t = cp.asarray(t)
-    f0 = float(f0)
-    t1 = float(t1)
-    f1 = float(f1)
-
-    if method in ["linear", "lin", "li"]:
-        return _chirp_phase_lin_kernel(t, f0, t1, f1, cp.pi)
-
-    elif method in ["quadratic", "quad", "q"]:
-        return _chirp_phase_quad_kernel(t, f0, t1, f1, cp.pi, vertex_zero)
-
-    elif method in ["logarithmic", "log", "lo"]:
-        if f0 * f1 <= 0.0:
-            raise ValueError(
-                "For a logarithmic chirp, f0 and f1 must be "
-                "nonzero and have the same sign."
-            )
-        return _chirp_phase_log_kernel(t, f0, t1, f1, cp.pi)
-
-    elif method in ["hyperbolic", "hyp"]:
-        if f0 == 0 or f1 == 0:
-            raise ValueError(
-                "For a hyperbolic chirp, f0 and f1 must be " "nonzero."
-            )
-        return _chirp_phase_hyp_kernel(t, f0, t1, f1, cp.pi)
-
-    else:
-        raise ValueError(
-            "method must be 'linear', 'quadratic', 'logarithmic',"
-            " or 'hyperbolic', but a value of %r was given." % method
-        )
-
 
 def unit_impulse(shape, idx=None, dtype=float):
     """


### PR DESCRIPTION
This PR attempts optimize the waveform module

## Square
### This PR
```bash
---------- benchmark 'Square': 4 tests -----------4)
Name (time in us)                   Mean          
--------------------------------------------------
test_square_gpu[0.5-16384]       32.3753 (1.0)    
test_square_gpu[0.25-16384]      33.0561 (1.02)   
test_square_cpu[0.5-16384]      251.2782 (7.76)   
test_square_cpu[0.25-16384]     254.5398 (7.86)
--------------------------------------------------
```

### Branch 0.16
```bash
---------- benchmark 'Square': 4 tests -----------4)
Name (time in us)                   Mean          
--------------------------------------------------
test_square_cpu[0.25-16384]     257.9543 (1.0)    
test_square_cpu[0.5-16384]      260.2890 (1.01)   
test_square_gpu[0.25-16384]     466.7852 (1.81)   
test_square_gpu[0.5-16384]      474.1972 (1.84)   
--------------------------------------------------
```

## GaussPulse
### This PR
```bash
---------- benchmark 'GaussPulse': 4 tests -----------
Name (time in us)                       Mean          
------------------------------------------------------
test_gausspulse_gpu[0.75-16384]      27.5139 (1.0)    
test_gausspulse_gpu[5-16384]         28.1918 (1.02)   
test_gausspulse_cpu[0.75-16384]     394.4248 (14.34)  
test_gausspulse_cpu[5-16384]        450.1640 (16.36)  
------------------------------------------------------
```

### Branch 0.16
```bash
---------- benchmark 'GaussPulse': 4 tests -----------
Name (time in us)                       Mean          
------------------------------------------------------
test_gausspulse_gpu[5-16384]        109.8970 (1.0)    
test_gausspulse_gpu[0.75-16384]     110.6901 (1.01)   
test_gausspulse_cpu[0.75-16384]     394.6945 (3.59)   
test_gausspulse_cpu[5-16384]        454.8667 (4.14)   
------------------------------------------------------
```

## Chirp
### This PR
```bash
-------------- benchmark 'Chirp': 8 tests --------------
Name (time in us)                         Mean          
--------------------------------------------------------
test_chirp_gpu[quad-10-1-6-16384]      63.6777 (1.0)    
test_chirp_gpu[lin-10-1-6-16384]       63.7323 (1.00)   
test_chirp_gpu[hyp-10-1-6-16384]       66.1522 (1.04)   
test_chirp_gpu[log-10-1-6-16384]       73.1456 (1.15)   
test_chirp_cpu[lin-10-1-6-16384]      188.8952 (2.97)   
test_chirp_cpu[hyp-10-1-6-16384]      254.1944 (3.99)   
test_chirp_cpu[log-10-1-6-16384]      393.3425 (6.18)   
test_chirp_cpu[quad-10-1-6-16384]     415.5281 (6.53)   
--------------------------------------------------------
```

### Branch 0.16
```bash
-------------- benchmark 'Chirp': 8 tests --------------
Name (time in us)                         Mean          
--------------------------------------------------------
test_chirp_gpu[lin-10-1-6-16384]      112.1202 (1.0)    
test_chirp_gpu[hyp-10-1-6-16384]      117.7361 (1.05)   
test_chirp_gpu[quad-10-1-6-16384]     131.7041 (1.17)   
test_chirp_gpu[log-10-1-6-16384]      150.1537 (1.34)   
test_chirp_cpu[lin-10-1-6-16384]      181.4057 (1.62)   
test_chirp_cpu[hyp-10-1-6-16384]      246.7961 (2.20)   
test_chirp_cpu[log-10-1-6-16384]      386.3060 (3.45)   
test_chirp_cpu[quad-10-1-6-16384]     400.0489 (3.57)   
--------------------------------------------------------
```

## Unit Impulse
### This PR
```bash
---------- benchmark 'UnitImpulse': 2 tests ----------
Name (time in us)                       Mean          
------------------------------------------------------
test_unit_impulse_cpu[mid-16384]      7.1316 (1.0)    
test_unit_impulse_gpu[mid-16384]     23.3090 (3.27)   
-----------------------------------------------------
```

### Branch 0.16
```bash
---------- benchmark 'UnitImpulse': 2 tests ----------
Name (time in us)                       Mean          
------------------------------------------------------
test_unit_impulse_cpu[mid-16384]      7.6201 (1.0)    
test_unit_impulse_gpu[mid-16384]     76.5246 (10.04)  
------------------------------------------------------
```