### PR TITLE
[REVIEW] Remove precompile_kernels from io_examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PR #248 - Fix channelizer bugs
 - PR #254 - Use CuPy v8 FFT cache plan
 - PR #259 - Fix notebook error handling in gpuCI
+- PR #263 - Remove precompile_kernels() from io_examples
 
 
 # cuSignal 0.15.0 (26 Aug 2020)

--- a/notebooks/api_guide/io_examples.ipynb
+++ b/notebooks/api_guide/io_examples.ipynb
@@ -23,9 +23,7 @@
     "import json\n",
     "import numpy as np\n",
     "import cupy as cp\n",
-    "import cusignal\n",
-    "\n",
-    "cusignal.precompile_kernels()"
+    "import cusignal"
    ]
   },
   {


### PR DESCRIPTION
`precompile_kernels` has been deprecated in cuSignal.