### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - PR #248 - Fix channelizer bugs
 - PR #254 - Use CuPy v8 FFT cache plan
 - PR #259 - Fix notebook error handling in gpuCI
-
+- PR #264 - Fix Build error w/ nvidia-smi
 
 # cuSignal 0.15.0 (26 Aug 2020)
 

--- a/build.sh
+++ b/build.sh
@@ -127,7 +127,7 @@ if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
     if [ -z "${DEVICES}" ]
     then
         # If DEVICES is empty, retrieve all attached NVIDIA GPU
-        NUMGPU=`nvidia-smi -L | wc -l`
+        NUMGPU=`lspci | grep VGA | grep NVIDIA | wc -l`
         for (( i=0; i<${NUMGPU}; i++ ))
         do
             GET_CC ${i}


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.