### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PR #248 - Fix channelizer bugs
 - PR #254 - Use CuPy v8 FFT cache plan
 - PR #259 - Fix notebook error handling in gpuCI
+- PR #263 - Remove precompile_kernels() from io_examples
 - PR #264 - Fix Build error w/ nvidia-smi
 
 # cuSignal 0.15.0 (26 Aug 2020)

--- a/notebooks/api_guide/io_examples.ipynb
+++ b/notebooks/api_guide/io_examples.ipynb
@@ -23,9 +23,7 @@
     "import json\n",
     "import numpy as np\n",
     "import cupy as cp\n",
-    "import cusignal\n",
-    "\n",
-    "cusignal.precompile_kernels()"
+    "import cusignal"
    ]
   },
   {


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.