### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuSignal 0.16.0 (Date TBD)
+# cuSignal 0.16.0 (21 Oct 2020)
 
 ## New Features
 - PR #185 - Add function to translate PyCUDA gpuarray to CuPy ndarray


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.