### PR TITLE
[skip-ci] Add `-y` flag to conda install in E2E_Example Notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #272 Fix bug in gausspulse
 - PR #275 Improve gpuCI Scripts
 - PR #281 Fix erroneous path in CI scripts
+- PR #286 Update conda install command in notebook
 
 # cuSignal 0.16.0 (21 Oct 2020)
 

--- a/notebooks/E2E_Example.ipynb
+++ b/notebooks/E2E_Example.ipynb
@@ -316,7 +316,7 @@
     "# Alternatively, the docker image can be run with the following variable:\n",
     "#     docker run -e EXTRA_CONDA_PACKAGES=\"-c pytorch pytorch\"...\n",
     "\n",
-    "#!conda install -c pytorch pytorch"
+    "#!conda install -y -c pytorch pytorch"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the `conda install` command to include the `-y` flag in order to install PyTorch without requiring user input.