### PR TITLE
[REVIEW] [ENH] Increment CuPy Version in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #292 - Increment CuPy Version
 
 ## Bug Fixes
 

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=8.0.0,<9.0.0a0
+    - cupy>=8.0.0,<9.1.0a0
 
 test:
   requires:


### PR DESCRIPTION
Supports @luigifcruz and his PR located here: https://github.com/rapidsai/cusignal/pull/287

@ajschmidt8 -- Is this a safe cupy version to cap?