### PR TITLE
Bump cuSignal Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #296 - Increment cuSignal versions in README
 
 ## Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This code executes on an NVIDIA V100 in 637 ms.
 ## Documentation
 The complete cuSignal API documentation including a complete list of functionality and examples can be found for both the Stable and Nightly (Experimental) releases.
 
-[cuSignal 0.16 API](https://docs.rapids.ai/api/cusignal/stable/) | [cuSignal 0.17 Nightly](https://docs.rapids.ai/api/cusignal/nightly/)
+[cuSignal 0.17 API](https://docs.rapids.ai/api/cusignal/stable/) | [cuSignal 0.18 Nightly](https://docs.rapids.ai/api/cusignal/nightly/)
 
 ### Installation
 cuSignal has been tested on and supports all modern GPUs - from Maxwell to Ampere. While Anaconda is the preferred installation mechanism for cuSignal, developers and Jetson users should follow the source build instructions below. As of cuSignal 0.16, there isn't a cuSignal conda package for aarch64.
@@ -120,36 +120,36 @@ cuSignal has been tested on and supports all modern GPUs - from Maxwell to Amper
 ### Conda, Linux OS
 cuSignal can be installed with conda ([Miniconda](https://docs.conda.io/en/latest/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/distribution/)) from the `rapidsai` channel. If you're using a Jetson GPU, please follow the build instructions [below](https://github.com/rapidsai/cusignal#conda---jetson-nano-tk1-tx2-xavier-linux-os)
 
-For `cusignal version == 0.16`:
+For `cusignal version == 0.17`:
 
 ```
 For CUDA 10.1.2
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cusignal=0.16 python=3.7 cudatoolkit=10.1
+    cusignal=0.17 python=3.8 cudatoolkit=10.1
 
 # or, for CUDA 10.2
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cusignal=0.16 python=3.7 cudatoolkit=10.2
+    cusignal=0.17 python=3.8 cudatoolkit=10.2
 
 # or, for CUDA 11.0
 conda install -c rapidsai -c nvidia -c numba -c conda-forge \
-    cusignal=0.16 python=3.7 cudatoolkit=11.0
+    cusignal=0.17 python=3.8 cudatoolkit=11.0
 ```
 
-For the nightly verison of `cusignal`, currently 0.17a:
+For the nightly verison of `cusignal`, currently 0.18a:
 
 ```
 # For CUDA 10.1.2
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cusignal python=3.7 cudatoolkit=10.1.2
+    cusignal python=3.8 cudatoolkit=10.1.2
 
 # or, for CUDA 10.2
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cusignal python=3.7 cudatoolkit=10.2
+    cusignal python=3.8 cudatoolkit=10.2
 
 # or, for CUDA 11.0
 conda install -c rapidsai-nightly -c nvidia -c numba -c conda-forge \
-    cusignal python=3.7 cudatoolkit=11.0
+    cusignal python=3.8 cudatoolkit=11.0
 ```
 
 cuSignal has been tested and confirmed to work with Python 3.6, 3.7, and 3.8.


### PR DESCRIPTION
Bump Python 3.7 to 3.8 and cuSignal 0.16 to 0.17.