### PR TITLE
Fix labeler.yml GitHub Action [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,8 +10,8 @@ libcusignal:
   - cpp/**
 
 CMake:
-  - **/CMakeLists.txt
-  - **/cmake/**
+  - '**/CMakeLists.txt'
+  - '**/cmake/**'
   
 Java:
   - java/**
@@ -20,6 +20,6 @@ Ops:
   - .github/**
   - /ci/**
   - conda/**
-  - **/Dockerfile
-  - **/.dockerignore
+  - '**/Dockerfile'
+  - '**/.dockerignore'
   - docker/**


### PR DESCRIPTION
PR #299 added a new GitHub Action that had some invalid YAML. This PR fixes it.

According to the GitHub Action docs, any YAML values that start with `*` must be quoted to avoid problem ([src](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)).

