### PR TITLE
[REVIEW] Add Pulse-Doppler Processing to radartools

### DIFF
--- a/notebooks/api_guide/radar_examples.ipynb
+++ b/notebooks/api_guide/radar_examples.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/api_guide/radar_examples.ipynb
+++ b/notebooks/api_guide/radar_examples.ipynb
@@ -1,6 +1,74 @@
 {
- "cells": [],
- "metadata": {},
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cusignal\n",
+    "import cupy as cp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pulse Compression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_pulses = 128\n",
+    "num_samples_per_pulse = 9000\n",
+    "template_length = 1000\n",
+    "\n",
+    "x = cp.random.randn(num_pulses, num_samples_per_pulse) + 1j*cp.random.randn(num_pulses, num_samples_per_pulse)\n",
+    "template = cp.random.randn(template_length) + 1j*cp.random.randn(template_length)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "803 µs ± 210 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "pc_out = cusignal.pulse_compression(x, template, normalize=True, window='hamming')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -119,6 +119,7 @@ from cusignal.io.writer import (
 )
 from cusignal.radartools.radartools import (
     pulse_compression,
+    pulse_doppler,
 )
 
 # Versioneer

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -117,6 +117,9 @@ from cusignal.io.writer import (
     pack_bin,
     write_sigmf,
 )
+from cusignal.radartools.radartools import (
+    pulse_compression,
+)
 
 # Versioneer
 from ._version import get_versions

--- a/python/cusignal/radartools/__init__.py
+++ b/python/cusignal/radartools/__init__.py
@@ -12,5 +12,6 @@
 # limitations under the License.
 
 from cusignal.radartools.radartools import (
-    pulse_compression
+    pulse_compression,
+    pulse_doppler,
 )

--- a/python/cusignal/radartools/__init__.py
+++ b/python/cusignal/radartools/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cusignal.radartools.radartools import (
+    pulse_compression
+)

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -57,7 +57,7 @@ def pulse_compression(x, template, normalize=False, window=None):
         template = cp.multiply(template, W)
 
     if normalize is True:
-        template = cp.linalg.norm(template)
+        template = cp.divide(template, cp.linalg.norm(template))
 
     fft_x = cp.fft.fft(x)
     fft_template = cp.conj(cp.tile(cp.fft.fft(template, samples_per_pulse),

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -62,4 +62,4 @@ def pulse_compression(x, template, normalize=False, window=None):
     fft_template = cp.conj(cp.tile(cp.fft.fft(template, samples_per_pulse), (num_pulses, 1)))
     compressedIQ = cp.fft.ifft(cp.multiply(fft_x, fft_template))
 
-    return compressedIQ    
+    return compressedIQ

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -17,8 +17,9 @@ from ..windows.windows import get_window
 
 def pulse_compression(x, template, normalize=False, window=None):
     """
-    Pulse Compression is used to increase the range resolution and SNR by performing
-    matched filtering of the transmitted pulse (template) with the received signal (x)
+    Pulse Compression is used to increase the range resolution and SNR
+    by performing matched filtering of the transmitted pulse (template)
+    with the received signal (x)
 
     Parameters
     ----------
@@ -52,14 +53,15 @@ def pulse_compression(x, template, normalize=False, window=None):
             W = window
         else:
             W = get_window(window, Nx, False)
-        
+
         template = cp.multiply(template, W)
-        
+
     if normalize is True:
         template = cp.linalg.norm(template)
-    
+
     fft_x = cp.fft.fft(x)
-    fft_template = cp.conj(cp.tile(cp.fft.fft(template, samples_per_pulse), (num_pulses, 1)))
+    fft_template = cp.conj(cp.tile(cp.fft.fft(template, samples_per_pulse),
+                                   (num_pulses, 1)))
     compressedIQ = cp.fft.ifft(cp.multiply(fft_x, fft_template))
 
     return compressedIQ

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cupy as cp
+from ..windows.windows import get_window
+
+
+def pulse_compression(x, template, normalize=False, window=None):
+    """
+    Pulse Compression is used to increase the range resolution and SNR by performing
+    matched filtering of the transmitted pulse (template) with the received signal (x)
+
+    Parameters
+    ----------
+    x : ndarray
+        Received signal, assume 2D array with [num_pulses, sample_per_pulse]
+
+    template : ndarray
+        Transmitted signal, assume 1D array
+
+    normalize : bool
+        Normalize transmitted signal
+
+     window : array_like, callable, string, float, or tuple, optional
+        Specifies the window applied to the signal in the Fourier
+        domain.
+
+    Returns
+    -------
+    compressedIQ : ndarray
+        Pulse compressed output
+    """
+    [num_pulses, samples_per_pulse] = x.shape
+
+    if window is not None:
+        Nx = len(template)
+        if callable(window):
+            W = window(cp.fft.fftfreq(Nx))
+        elif isinstance(window, cp.ndarray):
+            if window.shape != (Nx,):
+                raise ValueError("window must have the same length as data")
+            W = window
+        else:
+            W = get_window(window, Nx, False)
+        
+        template = cp.multiply(template, W)
+        
+    if normalize is True:
+        template = cp.linalg.norm(template)
+    
+    fft_x = cp.fft.fft(x)
+    fft_template = cp.conj(cp.tile(cp.fft.fft(template, samples_per_pulse), (num_pulses, 1)))
+    compressedIQ = cp.fft.ifft(cp.multiply(fft_x, fft_template))
+
+    return compressedIQ    


### PR DESCRIPTION
**This PR should be merged after https://github.com/rapidsai/cusignal/pull/300**

Expanding on phased array processing tools, the pulse doppler processing function transforms a data-matrix that's slow-time (pulses) by fast time (range) to doppler by fast time (range). Pulse doppler processing helps remove background clutter and to detect phase shifts. 

In a row-major view (default for cuSignal), this consists of taking the FFT along the slow-time (pulse) dimension. In this case, we perform 1D FFTs along each column of the input data matrix.