### PR TITLE
Fix Radar API Docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -185,11 +185,6 @@ Radar/Phased Array
 Radar Tools
 ------------
 
-.. automodule:: cusignal.radartools.pulse_compression
-    :members:
-    :undoc-members:
-
-
-.. automodule:: cusignal.radartools.pulse_doppler
+.. automodule:: cusignal.radartools.radartools
     :members:
     :undoc-members:


### PR DESCRIPTION
Fix mistake in radar api docs where individual functions were treated as modules.