### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
+# 0.18.0
 
-# cuSignal 0.18.0 (Date TBD)
-
-## New Features
-
-## Improvements
-- PR #296 - Increment cuSignal versions in README
-- PR #297 - Clarify GPU timing in E2E Jupyter example
-
-## Bug Fixes
-
+Please see https://github.com/rapidsai/cusignal/releases/tag/branch-0.18-latest for the latest changes to this development branch.
 
 # cuSignal 0.17.0 (10 Dec 2020)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -177,3 +177,19 @@ Writer
 .. automodule:: cusignal.io.writer
     :members:
     :undoc-members:
+
+
+Radar/Phased Array
+============
+
+Radar Tools
+------------
+
+.. automodule:: cusignal.radartools.pulse_compression
+    :members:
+    :undoc-members:
+
+
+.. automodule:: cusignal.radartools.pulse_doppler
+    :members:
+    :undoc-members:


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.