### PR TITLE
Increment Max CuPy Version in CI

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=8.0.0,<9.0.0a0
+    - cupy>=8.0.0,<9.1.0a0
 
 test:
   requires:


### PR DESCRIPTION
Allow for CuPy 9.0 when available on conda channels.