### PR TITLE
Remove six dependency

### DIFF
--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -14,7 +14,6 @@
 import cupy as cp
 import numpy as np
 
-from six import string_types
 
 
 _square_kernel = cp.ElementwiseKernel(
@@ -234,18 +233,17 @@ def gausspulse(
     # pi^2/a * fc^2 * bw^2 /4=-log(ref)
     a = -((np.pi * fc * bw) ** 2) / (4.0 * np.log(ref))
 
-    if isinstance(t, string_types):
-        if t == "cutoff":  # compute cut_off point
-            #  Solve exp(-a tc**2) = tref  for tc
-            #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
-            if tpr >= 0:
-                raise ValueError(
-                    "Reference level for time cutoff must " "be < 0 dB"
-                )
-            tref = pow(10.0, tpr / 20.0)
-            return np.sqrt(-np.log(tref) / a)
-        else:
-            raise ValueError("If `t` is a string, it must be 'cutoff'")
+    if t == "cutoff":  # compute cut_off point
+        #  Solve exp(-a tc**2) = tref  for tc
+        #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
+        if tpr >= 0:
+            raise ValueError(
+                "Reference level for time cutoff must " "be < 0 dB"
+            )
+        tref = pow(10.0, tpr / 20.0)
+        return np.sqrt(-np.log(tref) / a)
+    else:
+        raise ValueError("If `t` is a string, it must be 'cutoff'")
 
     t = cp.asarray(t)
 

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -15,7 +15,6 @@ import cupy as cp
 import numpy as np
 
 
-
 _square_kernel = cp.ElementwiseKernel(
     "T t, T w",
     "float64 y",

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -232,7 +232,7 @@ def gausspulse(
     # pi^2/a * fc^2 * bw^2 /4=-log(ref)
     a = -((np.pi * fc * bw) ** 2) / (4.0 * np.log(ref))
 
-    try:
+    if isinstance(t, str):
         if t == "cutoff":  # compute cut_off point
             #  Solve exp(-a tc**2) = tref  for tc
             #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
@@ -242,8 +242,8 @@ def gausspulse(
                 )
             tref = pow(10.0, tpr / 20.0)
             return np.sqrt(-np.log(tref) / a)
-    except ValueError:
-        print("If `t` is a string, it must be 'cutoff'")
+        else:
+            raise ValueError("If `t` is a string, it must be 'cutoff'")
 
     t = cp.asarray(t)
 

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -232,17 +232,18 @@ def gausspulse(
     # pi^2/a * fc^2 * bw^2 /4=-log(ref)
     a = -((np.pi * fc * bw) ** 2) / (4.0 * np.log(ref))
 
-    if t == "cutoff":  # compute cut_off point
-        #  Solve exp(-a tc**2) = tref  for tc
-        #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
-        if tpr >= 0:
-            raise ValueError(
-                "Reference level for time cutoff must " "be < 0 dB"
-            )
-        tref = pow(10.0, tpr / 20.0)
-        return np.sqrt(-np.log(tref) / a)
-    else:
-        raise ValueError("If `t` is a string, it must be 'cutoff'")
+    try:
+        if t == "cutoff":  # compute cut_off point
+            #  Solve exp(-a tc**2) = tref  for tc
+            #   tc = sqrt(-log(tref) / a) where tref = 10^(tpr/20)
+            if tpr >= 0:
+                raise ValueError(
+                    "Reference level for time cutoff must " "be < 0 dB"
+                )
+            tref = pow(10.0, tpr / 20.0)
+            return np.sqrt(-np.log(tref) / a)
+    except ValueError:
+        print("If `t` is a string, it must be 'cutoff'")
 
     t = cp.asarray(t)
 


### PR DESCRIPTION
Remove dependency on six in `waveforms.py` - no longer needed as we are only supporting Python 3 and above.
