### PR TITLE
Fix bug in bin_reader that ignored dtype

### DIFF
--- a/python/cusignal/io/reader.py
+++ b/python/cusignal/io/reader.py
@@ -76,7 +76,8 @@ def read_bin(file, buffer=None, dtype=cp.uint8, num_samples=None, offset=0):
     # offset is measured in bytes
     offset *= cp.dtype(dtype).itemsize
 
-    fp = np.memmap(file, mode="r", offset=offset, shape=num_samples)
+    fp = np.memmap(file, mode="r", offset=offset, shape=num_samples,
+                   dtype=dtype)
 
     if buffer is not None:
         out = cp.empty(buffer.shape, buffer.dtype)


### PR DESCRIPTION
cuSignal's binary reader would ignore specified dtype, causing an error in parsing a stored binary file. The following code example now produces output `y` that matches input `x`.

```python
import cupy as cp
import cusignal
x = cp.arange(1000,dtype=cp.float32)
cusignal.write_bin('bintest',x)
y = cusignal.read_bin('bintest',dtype=cp.float32)
```