### PR TITLE
Add 2D grid-stride loop to fix BUG 295

### DIFF
--- a/python/cusignal/filtering/_upfirdn_cuda.py
+++ b/python/cusignal/filtering/_upfirdn_cuda.py
@@ -16,7 +16,13 @@ import cupy as cp
 from math import ceil
 
 from ..utils._caches import _cupy_kernel_cache
-from ..utils.helper_tools import _print_atts, _get_function, _get_tpb_bpg
+from ..utils.helper_tools import (
+    _print_atts,
+    _get_function,
+    _get_tpb_bpg,
+    _get_max_gdx,
+    _get_max_gdy,
+)
 
 
 _SUPPORTED_TYPES = ["float32", "float64", "complex64", "complex128"]
@@ -199,10 +205,20 @@ class _UpFIRDn(object):
         h_per_phase = len(self._h_trans_flip) // self._up
         padded_len = x.shape[axis] + (len(self._h_trans_flip) // self._up) - 1
 
+        print(output_shape)
+
         if out.ndim > 1:
-            threadsperblock = (16, 16)
-            blockspergrid_x = ceil(out.shape[0] / threadsperblock[0])
-            blockspergrid_y = ceil(out.shape[1] / threadsperblock[1])
+            threadsperblock = (8, 8)
+            blocks = ceil(out.shape[0] / threadsperblock[0])
+            blockspergrid_x = (
+                blocks if blocks < _get_max_gdx() else _get_max_gdx()
+            )
+
+            blocks = ceil(out.shape[1] / threadsperblock[1])
+            blockspergrid_y = (
+                blocks if blocks < _get_max_gdy() else _get_max_gdy()
+            )
+
             blockspergrid = (blockspergrid_x, blockspergrid_y)
 
         else:
@@ -223,6 +239,8 @@ class _UpFIRDn(object):
             k_type = "upfirdn2D"
 
             _populate_kernel_cache(out.dtype, k_type)
+
+            print(out.dtype, blockspergrid, threadsperblock, k_type)
 
             kernel = _get_backend_kernel(
                 out.dtype,

--- a/python/cusignal/filtering/_upfirdn_cuda.py
+++ b/python/cusignal/filtering/_upfirdn_cuda.py
@@ -205,8 +205,6 @@ class _UpFIRDn(object):
         h_per_phase = len(self._h_trans_flip) // self._up
         padded_len = x.shape[axis] + (len(self._h_trans_flip) // self._up) - 1
 
-        print(output_shape)
-
         if out.ndim > 1:
             threadsperblock = (8, 8)
             blocks = ceil(out.shape[0] / threadsperblock[0])
@@ -239,8 +237,6 @@ class _UpFIRDn(object):
             k_type = "upfirdn2D"
 
             _populate_kernel_cache(out.dtype, k_type)
-
-            print(out.dtype, blockspergrid, threadsperblock, k_type)
 
             kernel = _get_backend_kernel(
                 out.dtype,

--- a/python/cusignal/filtering/resample.py
+++ b/python/cusignal/filtering/resample.py
@@ -390,8 +390,6 @@ def resample_poly(x, up, down, axis=0, window=("kaiser", 5.0), gpupath=True):
     else:
         pp = np
 
-    # print("window", window.size)
-
     if isinstance(window, (list, pp.ndarray)):
         window = pp.asarray(window)
         if window.ndim > 1:

--- a/python/cusignal/test/test_filtering.py
+++ b/python/cusignal/test/test_filtering.py
@@ -396,30 +396,35 @@ class TestFilter:
             array_equal(cp.asnumpy(output), key, atol=1e-4)
 
     @pytest.mark.benchmark(group="ResamplePoly")
-    @pytest.mark.parametrize("num_samps", [2 ** 14])
-    @pytest.mark.parametrize("up", [2, 3, 7])
-    @pytest.mark.parametrize("down", [1, 2, 9])
+    @pytest.mark.parametrize("dim, num_samps", [(1, 2 ** 14), (1, 2 ** 18), (2, 2 ** 14), (2, 2 ** 18)])
+    @pytest.mark.parametrize("up", [8])
+    @pytest.mark.parametrize("down", [1])
+    @pytest.mark.parametrize("axis", [-1, 0])
     @pytest.mark.parametrize("window", [("kaiser", 0.5)])
     class TestResamplePoly:
-        def cpu_version(self, sig, up, down, window):
-            return signal.resample_poly(sig, up, down, window=window)
+        def cpu_version(self, sig, up, down, axis, window):
+            return signal.resample_poly(sig, up, down, axis, window=window)
 
-        def gpu_version(self, sig, up, down, window):
+        def gpu_version(self, sig, up, down, axis, window):
             with cp.cuda.Stream.null:
-                out = cusignal.resample_poly(sig, up, down, window=window)
+                out = cusignal.resample_poly(sig, up, down, axis, window=window)
             cp.cuda.Stream.null.synchronize()
             return out
 
         @pytest.mark.cpu
         def test_resample_poly_cpu(
-            self, linspace_data_gen, benchmark, num_samps, up, down, window
+            self, linspace_data_gen, benchmark, dim, num_samps, up, down, axis, window
         ):
-            cpu_sig, _ = linspace_data_gen(0, 10, num_samps, endpoint=False)
+            if dim == 1:
+                cpu_sig, _ = linspace_data_gen(0, 10, num_samps, endpoint=False)
+            else:
+                cpu_sig = np.random.rand(dim, num_samps)
             benchmark(
                 self.cpu_version,
                 cpu_sig,
                 up,
                 down,
+                axis,
                 window,
             )
 
@@ -427,24 +432,31 @@ class TestFilter:
             self,
             linspace_data_gen,
             gpubenchmark,
+            dim,
             num_samps,
             up,
             down,
+            axis,
             window,
         ):
+            if dim == 1:
+                cpu_sig, gpu_sig = linspace_data_gen(
+                    0, 10, num_samps, endpoint=False
+                )
+            else:
+                cpu_sig = np.random.rand(dim, num_samps)
+                gpu_sig = cp.array(cpu_sig)
 
-            cpu_sig, gpu_sig = linspace_data_gen(
-                0, 10, num_samps, endpoint=False
-            )
             output = gpubenchmark(
                 self.gpu_version,
                 gpu_sig,
                 up,
                 down,
+                axis,
                 window,
             )
 
-            key = self.cpu_version(cpu_sig, up, down, window)
+            key = self.cpu_version(cpu_sig, up, down, axis, window)
             array_equal(output, key)
 
     @pytest.mark.benchmark(group="UpFirDn")

--- a/python/cusignal/test/test_filtering.py
+++ b/python/cusignal/test/test_filtering.py
@@ -396,7 +396,10 @@ class TestFilter:
             array_equal(cp.asnumpy(output), key, atol=1e-4)
 
     @pytest.mark.benchmark(group="ResamplePoly")
-    @pytest.mark.parametrize("dim, num_samps", [(1, 2 ** 14), (1, 2 ** 18), (2, 2 ** 14), (2, 2 ** 18)])
+    @pytest.mark.parametrize(
+        "dim, num_samps",
+        [(1, 2 ** 14), (1, 2 ** 18), (2, 2 ** 14), (2, 2 ** 18)],
+    )
     @pytest.mark.parametrize("up", [8])
     @pytest.mark.parametrize("down", [1])
     @pytest.mark.parametrize("axis", [-1, 0])
@@ -407,16 +410,28 @@ class TestFilter:
 
         def gpu_version(self, sig, up, down, axis, window):
             with cp.cuda.Stream.null:
-                out = cusignal.resample_poly(sig, up, down, axis, window=window)
+                out = cusignal.resample_poly(
+                    sig, up, down, axis, window=window
+                )
             cp.cuda.Stream.null.synchronize()
             return out
 
         @pytest.mark.cpu
         def test_resample_poly_cpu(
-            self, linspace_data_gen, benchmark, dim, num_samps, up, down, axis, window
+            self,
+            linspace_data_gen,
+            benchmark,
+            dim,
+            num_samps,
+            up,
+            down,
+            axis,
+            window,
         ):
             if dim == 1:
-                cpu_sig, _ = linspace_data_gen(0, 10, num_samps, endpoint=False)
+                cpu_sig, _ = linspace_data_gen(
+                    0, 10, num_samps, endpoint=False
+                )
             else:
                 cpu_sig = np.random.rand(dim, num_samps)
             benchmark(

--- a/python/cusignal/utils/helper_tools.py
+++ b/python/cusignal/utils/helper_tools.py
@@ -38,6 +38,20 @@ def _get_max_tpb():
     return device_id.attributes["MaxThreadsPerBlock"]
 
 
+def _get_max_gdx():
+
+    device_id = cp.cuda.Device()
+
+    return device_id.attributes["MaxGridDimX"]
+
+
+def _get_max_gdy():
+
+    device_id = cp.cuda.Device()
+
+    return device_id.attributes["MaxGridDimY"]
+
+
 def _get_tpb_bpg():
 
     numSM = _get_numSM()


### PR DESCRIPTION
closes bug #295 

This code adds 2d grid stride looping to _cupy_upfirdn2D. This fixes the bug by removing the hardware cap on grid size in the y direction.