### PR TITLE
Add Taylor window

### DIFF
--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -71,6 +71,7 @@ from cusignal.windows.windows import (
     chebwin,
     cosine,
     exponential,
+    taylor,
     get_window,
 )
 from cusignal.spectral_analysis.spectral import (

--- a/python/cusignal/windows/__init__.py
+++ b/python/cusignal/windows/__init__.py
@@ -33,5 +33,6 @@ from cusignal.windows.windows import (
     chebwin,
     cosine,
     exponential,
+    taylor,
     get_window,
 )

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1827,6 +1827,132 @@ def exponential(M, center=None, tau=1.0, sym=True):
     return _truncate(w, needs_trunc)
 
 
+_taylor_kernel = cp.ElementwiseKernel(
+    "int64 nbar, raw float64 Fm, bool norm",
+    "float64 out",
+    """
+    double temp { mod_pi * ( i - _ind.size() / 2.0 + 0.5 ) };
+    double dot {};
+
+    for ( int k = 1; k < nbar; k++ ) {
+        dot += Fm[k-1] * cos( temp * k );
+    }
+    out = 1.0 + 2.0 * dot;
+
+    double scale { 1.0 };
+    if (norm == 1) {
+        dot = 0;
+        temp = mod_pi * ( ( ( _ind.size() - 1.0 ) / 2.0 )
+            - _ind.size() / 2.0 + 0.5 );
+        for ( int k = 1; k < nbar; k++ ) {
+            dot += Fm[k-1] * cos( temp * k );
+        }
+        scale = 1.0 / ( 1.0 + 2.0 * dot );
+    }
+
+    out *= scale;
+    """,
+    "_taylor_kernel",
+    options=("-std=c++11",),
+    loop_prep="const double mod_pi { 2.0 * M_PI / _ind.size() }",
+)
+
+
+def taylor(M, nbar=4, sll=30, norm=True, sym=True):
+    """
+    Return a Taylor window.
+    The Taylor window taper function approximates the Dolph-Chebyshev window's
+    constant sidelobe level for a parameterized number of near-in sidelobes,
+    but then allows a taper beyond [2]_.
+    The SAR (synthetic aperature radar) community commonly uses Taylor
+    weighting for image formation processing because it provides strong,
+    selectable sidelobe suppression with minimum broadening of the
+    mainlobe [1]_.
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero or less, an
+        empty array is returned.
+    nbar : int, optional
+        Number of nearly constant level sidelobes adjacent to the mainlobe.
+    sll : float, optional
+        Desired suppression of sidelobe level in decibels (dB) relative to the
+        DC gain of the mainlobe. This should be a positive number.
+    norm : bool, optional
+        When True (default), divides the window by the largest (middle) value
+        for odd-length windows or the value that would occur between the two
+        repeated middle values for even-length windows such that all values
+        are less than or equal to 1. When False the DC gain will remain at 1
+        (0 dB) and the sidelobes will be `sll` dB down.
+    sym : bool, optional
+        When True (default), generates a symmetric window, for use in filter
+        design.
+        When False, generates a periodic window, for use in spectral analysis.
+    Returns
+    -------
+    out : array
+        The window. When `norm` is True (default), the maximum value is
+        normalized to 1 (though the value 1 does not appear if `M` is
+        even and `sym` is True).
+    See Also
+    --------
+    chebwin, kaiser, bartlett, blackman, hamming, hanning
+    References
+    ----------
+    .. [1] W. Carrara, R. Goodman, and R. Majewski, "Spotlight Synthetic
+           Aperture Radar: Signal Processing Algorithms" Pages 512-513,
+           July 1995.
+    .. [2] Armin Doerry, "Catalog of Window Taper Functions for
+           Sidelobe Control", 2017.
+           https://www.researchgate.net/profile/Armin_Doerry/publication/316281181_Catalog_of_Window_Taper_Functions_for_Sidelobe_Control/links/58f92cb2a6fdccb121c9d54d/Catalog-of-Window-Taper-Functions-for-Sidelobe-Control.pdf
+    Examples
+    --------
+    Plot the window and its frequency response:
+    >>> from scipy import signal
+    >>> from scipy.fft import fft, fftshift
+    >>> import matplotlib.pyplot as plt
+    >>> window = signal.windows.taylor(51, nbar=20, sll=100, norm=False)
+    >>> plt.plot(window)
+    >>> plt.title("Taylor window (100 dB)")
+    >>> plt.ylabel("Amplitude")
+    >>> plt.xlabel("Sample")
+    >>> plt.figure()
+    >>> A = fft(window, 2048) / (len(window)/2.0)
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = 20 * np.log10(np.abs(fftshift(A / abs(A).max())))
+    >>> plt.plot(freq, response)
+    >>> plt.axis([-0.5, 0.5, -120, 0])
+    >>> plt.title("Frequency response of the Taylor window (100 dB)")
+    >>> plt.ylabel("Normalized magnitude [dB]")
+    >>> plt.xlabel("Normalized frequency [cycles per sample]")
+    """  # noqa: E501
+    if _len_guards(M):
+        return np.ones(M)
+    M, needs_trunc = _extend(M, sym)
+
+    # Original text uses a negative sidelobe level parameter and then negates
+    # it in the calculation of B. To keep consistent with other methods we
+    # assume the sidelobe level parameter to be positive.
+    B = 10**(sll / 20)
+    A = np.arccosh(B) / np.pi
+    s2 = nbar**2 / (A**2 + (nbar - 0.5)**2)
+    ma = np.arange(1, nbar)
+
+    Fm = np.empty(nbar-1)
+    signs = np.empty_like(ma)
+    signs[::2] = 1
+    signs[1::2] = -1
+    m2 = ma*ma
+    for mi, _ in enumerate(ma):
+        numer = signs[mi] * np.prod(1 - m2[mi]/s2/(A**2 + (ma - 0.5)**2))
+        denom = 2 * np.prod(1 - m2[mi]/m2[:mi]) * np.prod(1 - m2[mi]/m2[mi+1:])
+        Fm[mi] = numer / denom
+
+    w = _taylor_kernel(nbar, cp.asarray(Fm), norm, size=M)
+
+    return _truncate(w, needs_trunc)
+
+
 def _fftautocorr(x):
     """Compute the autocorrelation of a real array and crop the result."""
     N = x.shape[-1]

--- a/python/cusignal/windows/windows.py
+++ b/python/cusignal/windows/windows.py
@@ -1933,19 +1933,25 @@ def taylor(M, nbar=4, sll=30, norm=True, sym=True):
     # Original text uses a negative sidelobe level parameter and then negates
     # it in the calculation of B. To keep consistent with other methods we
     # assume the sidelobe level parameter to be positive.
-    B = 10**(sll / 20)
+    B = 10 ** (sll / 20)
     A = np.arccosh(B) / np.pi
-    s2 = nbar**2 / (A**2 + (nbar - 0.5)**2)
+    s2 = nbar ** 2 / (A ** 2 + (nbar - 0.5) ** 2)
     ma = np.arange(1, nbar)
 
-    Fm = np.empty(nbar-1)
+    Fm = np.empty(nbar - 1)
     signs = np.empty_like(ma)
     signs[::2] = 1
     signs[1::2] = -1
-    m2 = ma*ma
+    m2 = ma * ma
     for mi, _ in enumerate(ma):
-        numer = signs[mi] * np.prod(1 - m2[mi]/s2/(A**2 + (ma - 0.5)**2))
-        denom = 2 * np.prod(1 - m2[mi]/m2[:mi]) * np.prod(1 - m2[mi]/m2[mi+1:])
+        numer = signs[mi] * np.prod(
+            1 - m2[mi] / s2 / (A ** 2 + (ma - 0.5) ** 2)
+        )
+        denom = (
+            2
+            * np.prod(1 - m2[mi] / m2[:mi])
+            * np.prod(1 - m2[mi] / m2[mi + 1 :])
+        )
         Fm[mi] = numer / denom
 
     w = _taylor_kernel(nbar, cp.asarray(Fm), norm, size=M)


### PR DESCRIPTION
Taylor Windows was added to SciPy Signal in 1.6.x

This PR adds it to cuSignal.

Results on Titan RTX
```bash
-------------- benchmark 'Taylor': 8 tests ---------------
Name (time in us)                           Mean          
----------------------------------------------------------
test_taylor_gpu[False-20-32768]         567.8799 (1.0)    
test_taylor_gpu[True-20-32768]          694.2484 (1.22)   
test_taylor_gpu[False-100-32768]      2,703.1287 (4.76)   
test_taylor_gpu[True-100-32768]       3,139.7567 (5.53)   
test_taylor_cpu[False-20-32768]       6,314.9267 (11.12)  
test_taylor_cpu[True-20-32768]        7,083.8202 (12.47)  
test_taylor_cpu[True-100-32768]      37,077.0545 (65.29)  
test_taylor_cpu[False-100-32768]     37,368.7508 (65.80)  
----------------------------------------------------------
```
