### PR TITLE
Fix bug in casting array to cupy

### DIFF
--- a/python/cusignal/convolution/_convolution_cuda.py
+++ b/python/cusignal/convolution/_convolution_cuda.py
@@ -237,8 +237,8 @@ def _convolve_gpu(
     swapped_inputs,
 ):
 
-    d_inp = cp.array(inp)
-    d_kernel = cp.array(ker)
+    d_inp = cp.asarray(inp)
+    d_kernel = cp.asarray(ker)
 
     threadsperblock, blockspergrid = _get_tpb_bpg()
 
@@ -352,8 +352,8 @@ def _convolve2d_gpu(
     outW = out.shape[1]
     outH = out.shape[0]
 
-    d_inp = cp.array(inp)
-    d_kernel = cp.array(ker)
+    d_inp = cp.asarray(inp)
+    d_kernel = cp.asarray(ker)
 
     threadsperblock = (16, 16)
     blockspergrid = (
@@ -519,8 +519,8 @@ def _convolve1d2o_gpu(
     mode,
 ):
 
-    d_inp = cp.array(inp)
-    d_kernel = cp.array(ker)
+    d_inp = cp.asarray(inp)
+    d_kernel = cp.asarray(ker)
 
     threadsperblock, blockspergrid = _get_tpb_bpg()
 
@@ -582,8 +582,8 @@ def _convolve1d3o_gpu(
     mode,
 ):
 
-    d_inp = cp.array(inp)
-    d_kernel = cp.array(ker)
+    d_inp = cp.asarray(inp)
+    d_kernel = cp.asarray(ker)
 
     threadsperblock, blockspergrid = _get_tpb_bpg()
 


### PR DESCRIPTION
Bug fix when looking at A100 optimization of `cusignal.convolve.`

Changed `cupy.array` to `cupy.asarray`.

Prior to PR:
```python
import cusignal
import cupy as cp

sig = cp.random.randn(16384000, dtype=cp.float32)
win = cp.random.randn(128, dtype=cp.float32)

%%timeit
cusignal.convolve(sig, win, mode='same', method='direct')
```
Runs in 1.22 ms on A100

After PR, the same code finishes in 1.12ms on A100