### PR TITLE
Speedup build for multi-arch compile

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -183,6 +183,12 @@ else
     RETURN_ALL
 fi
 
+if [ "$NVCC_MAJOR" -ge 11 ] && [ "$NVCC_MINOR" -ge 2 ] ; then
+    THREADS="-t 0"
+else
+    THREADS=
+fi
+
 # Must check GCC for Centos OS
 if [ "$GCC_V" -lt 7 ] || [ "$NVCC_MAJOR" -lt 11 ]; then
     FLAGS="-std=c++11"
@@ -201,30 +207,30 @@ fi
 echo "Building Convolution kernels..."
 FOLDER="convolution"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Filtering kernels..."
 FOLDER="filtering"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/ &
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/ &
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building IO kernels..."
 FOLDER="io"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/ &
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Peak Finding kernels..."
 FOLDER="peak_finding"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Spectral kernels..."
 FOLDER="spectral_analysis"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/ &
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/ &
 
 wait
 

--- a/build.sh
+++ b/build.sh
@@ -183,6 +183,12 @@ else
     RETURN_ALL
 fi
 
+if [ "$NVCC_MAJOR" -ge 11 ] && [ "$NVCC_MINOR" -ge 2 ] ; then
+    THREADS="-t 0"
+else
+    THREADS=
+fi
+
 # Must check GCC for Centos OS
 if [ "$GCC_V" -lt 7 ] || [ "$NVCC_MAJOR" -lt 11 ]; then
     FLAGS="-std=c++11"
@@ -201,38 +207,38 @@ fi
 echo "Building Convolution kernels..."
 FOLDER="convolution"
 mkdir -p ${FAT}/${FOLDER}/
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Filtering kernels..."
 FOLDER="filtering"
 mkdir -p ${FAT}/${FOLDER}/
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/ &
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/ &
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building IO kernels..."
 FOLDER="io"
 mkdir -p ${FAT}/${FOLDER}/
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/ &
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Peak Finding kernels..."
 FOLDER="peak_finding"
 mkdir -p ${FAT}/${FOLDER}/
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Spectral kernels..."
 FOLDER="spectral_analysis"
 mkdir -p ${FAT}/${FOLDER}/
-echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/"
-nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/ &
 
 wait
 

--- a/build.sh
+++ b/build.sh
@@ -183,12 +183,6 @@ else
     RETURN_ALL
 fi
 
-if [ "$NVCC_MAJOR" -ge 11 ] && [ "$NVCC_MINOR" -ge 2 ] ; then
-    THREADS="-t 0"
-else
-    THREADS=
-fi
-
 # Must check GCC for Centos OS
 if [ "$GCC_V" -lt 7 ] || [ "$NVCC_MAJOR" -lt 11 ]; then
     FLAGS="-std=c++11"
@@ -207,30 +201,38 @@ fi
 echo "Building Convolution kernels..."
 FOLDER="convolution"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_convolution.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Filtering kernels..."
 FOLDER="filtering"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/ &
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/ &
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_upfirdn.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_sosfilt.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_channelizer.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building IO kernels..."
 FOLDER="io"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/ &
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_reader.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_writer.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Peak Finding kernels..."
 FOLDER="peak_finding"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_peak_finding.cu -odir ${FAT}/${FOLDER}/ &
 
 echo "Building Spectral kernels..."
 FOLDER="spectral_analysis"
 mkdir -p ${FAT}/${FOLDER}/
-nvcc --fatbin ${THREADS} ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/ &
+echo "nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/"
+nvcc --fatbin ${FLAGS} ${GPU_ARCH} ${SRC}/${FOLDER}/_spectral.cu -odir ${FAT}/${FOLDER}/ &
 
 wait
 


### PR DESCRIPTION
The PR adds `--threads` compile feature when CTK version 11.2 or greater are detected during build.

The benefit is only seen will all CCs (e.g., sm_50, sm_60, sm_70, sm_80) are built. 

Performance example, on DGXA100

```bash
./build --allgpuarch
```

CTK 11.1
```bash
real    0m20.578s
user    0m55.533s
sys     0m5.241s
```

CTK 11.2
```bash
real    0m6.506s
user    1m10.992s
sys     0m12.081s
```