### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
-# cuSignal 0.19.0 (Date TBD)
+# cuSignal 0.19.0 (21 Apr 2021)
 
-Please see https://github.com/rapidsai/cusignal/releases/tag/v0.19.0a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- Fix bug in casting array to cupy ([#340](https://github.com/rapidsai/cusignal/pull/340)) [@awthomp](https://github.com/awthomp)
+
+## 🚀 New Features
+
+- Add morlet2 ([#336](https://github.com/rapidsai/cusignal/pull/336)) [@mnicely](https://github.com/mnicely)
+- Increment Max CuPy Version in CI ([#328](https://github.com/rapidsai/cusignal/pull/328)) [@awthomp](https://github.com/awthomp)
+
+## 🛠️ Improvements
+
+- Add cusignal source dockerfile ([#343](https://github.com/rapidsai/cusignal/pull/343)) [@awthomp](https://github.com/awthomp)
+- Update min scipy and cupy versions ([#339](https://github.com/rapidsai/cusignal/pull/339)) [@awthomp](https://github.com/awthomp)
+- Add Taylor window ([#338](https://github.com/rapidsai/cusignal/pull/338)) [@mnicely](https://github.com/mnicely)
+- Skip online signal processing tools testing ([#337](https://github.com/rapidsai/cusignal/pull/337)) [@awthomp](https://github.com/awthomp)
+- Add 2D grid-stride loop to fix BUG 295 ([#335](https://github.com/rapidsai/cusignal/pull/335)) [@mnicely](https://github.com/mnicely)
+- Update Changelog Link ([#334](https://github.com/rapidsai/cusignal/pull/334)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Fix bug in bin_reader that ignored dtype ([#333](https://github.com/rapidsai/cusignal/pull/333)) [@awthomp](https://github.com/awthomp)
+- Remove six dependency ([#332](https://github.com/rapidsai/cusignal/pull/332)) [@awthomp](https://github.com/awthomp)
+- Prepare Changelog for Automation ([#331](https://github.com/rapidsai/cusignal/pull/331)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update 0.18 changelog entry ([#330](https://github.com/rapidsai/cusignal/pull/330)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Fix merge conflicts in #315 ([#316](https://github.com/rapidsai/cusignal/pull/316)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 # cuSignal 0.18.0 (24 Feb 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.