### PR TITLE
Update environment variable used to determine `cuda_version`

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '10.1').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '10.1').split('.')[:2]) %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This PR updates the environment variable thats used to determine the `cuda_version` varaible in our conda recipes.

The `CUDA` environment variable is explicitly set by the Ops team in our Jenkins jobs, whereas `CUDA_VERSION` comes from the `nvidia/cuda` Docker images that we base our images from.
