### PR TITLE
Perf Improvements for UPFIRDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# cuSignal 0.20.0 (Date TBD)
+# cuSignal 21.06.00 (Date TBD)
 
-Please see https://github.com/rapidsai/cusignal/releases/tag/v0.20.0a for the latest changes to this development branch.
+Please see https://github.com/rapidsai/cusignal/releases/tag/v21.06.00a for the latest changes to this development branch.
 
 # cuSignal 0.19.0 (21 Apr 2021)
 

--- a/cpp/src/filtering/_upfirdn.cu
+++ b/cpp/src/filtering/_upfirdn.cu
@@ -33,6 +33,14 @@ __device__ void _cupy_upfirdn1D( const T *__restrict__ inp,
     const int stride { static_cast<int>( blockDim.x * gridDim.x ) };
 
     for ( size_t tid = t; tid < outW; tid += stride ) {
+
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+        __builtin_assume( padded_len > 0 );
+        __builtin_assume( up > 0 );
+        __builtin_assume( down > 0 );
+        __builtin_assume( tid > 0 );
+#endif
+
         const int x_idx { static_cast<int>( ( tid * down ) / up ) % padded_len };
         int       h_idx { static_cast<int>( ( tid * down ) % up * h_per_phase ) };
         int       x_conv_idx { x_idx - h_per_phase + 1 };
@@ -44,10 +52,10 @@ __device__ void _cupy_upfirdn1D( const T *__restrict__ inp,
 
         T temp {};
 
-        for ( int x_c = x_conv_idx; x_c < ( x_idx + 1 ); x_c++ ) {
-            if ( x_c < x_shape_a && x_c >= 0 ) {
-                temp += inp[x_c] * h_trans_flip[h_idx];
-            }
+        int stop = ( x_shape_a < ( x_idx + 1 ) ) ? x_shape_a : ( x_idx + 1 );
+
+        for ( int x_c = x_conv_idx; x_c < stop; x_c++ ) {
+            temp += inp[x_c] * h_trans_flip[h_idx];
             h_idx += 1;
         }
         out[tid] = temp;
@@ -131,18 +139,30 @@ __device__ void _cupy_upfirdn2D( const T *__restrict__ inp,
     const int ty { static_cast<int>( blockIdx.x * blockDim.x + threadIdx.x ) };
     const int tx { static_cast<int>( blockIdx.y * blockDim.y + threadIdx.y ) };
 
-    const int stride_y { static_cast<int>( blockDim.x * gridDim.x ) }; 
+    const int stride_y { static_cast<int>( blockDim.x * gridDim.x ) };
     const int stride_x { static_cast<int>( blockDim.y * gridDim.y ) };
 
-    for (int x = tx; x < outH; x += stride_x) {
-        for (int y = ty; y < outW; y += stride_y) {
+    for ( int x = tx; x < outH; x += stride_x ) {
+        for ( int y = ty; y < outW; y += stride_y ) {
             int x_idx {};
             int h_idx {};
 
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+            __builtin_assume( padded_len > 0 );
+            __builtin_assume( up > 0 );
+            __builtin_assume( down > 0 );
+#endif
+
             if ( axis == 1 ) {
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+                __builtin_assume( x > 0 );
+#endif
                 x_idx = ( static_cast<int>( x * down ) / up ) % padded_len;
                 h_idx = ( x * down ) % up * h_per_phase;
             } else {
+#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
+                __builtin_assume( y > 0 );
+#endif
                 x_idx = ( static_cast<int>( y * down ) / up ) % padded_len;
                 h_idx = ( y * down ) % up * h_per_phase;
             }
@@ -155,13 +175,13 @@ __device__ void _cupy_upfirdn2D( const T *__restrict__ inp,
 
             T temp {};
 
-            for ( int x_c = x_conv_idx; x_c < ( x_idx + 1 ); x_c++ ) {
-                if ( x_c < x_shape_a && x_c >= 0 ) {
-                    if ( axis == 1 ) {
-                        temp += inp[y * inpH + x_c] * h_trans_flip[h_idx];
-                    } else {
-                        temp += inp[x_c * inpH + x] * h_trans_flip[h_idx];
-                    }
+            int stop = ( x_shape_a < ( x_idx + 1 ) ) ? x_shape_a : ( x_idx + 1 );
+
+            for ( int x_c = x_conv_idx; x_c < stop; x_c++ ) {
+                if ( axis == 1 ) {
+                    temp += inp[y * inpH + x_c] * h_trans_flip[h_idx];
+                } else {
+                    temp += inp[x_c * inpH + x] * h_trans_flip[h_idx];
                 }
                 h_idx += 1;
             }
@@ -171,33 +191,33 @@ __device__ void _cupy_upfirdn2D( const T *__restrict__ inp,
 }
 
 extern "C" __global__ void __launch_bounds__( 64 ) _cupy_upfirdn2D_float32( const float *__restrict__ inp,
-                                                                             const int inpH,
-                                                                             const float *__restrict__ h_trans_flip,
-                                                                             const int up,
-                                                                             const int down,
-                                                                             const int axis,
-                                                                             const int x_shape_a,
-                                                                             const int h_per_phase,
-                                                                             const int padded_len,
-                                                                             float *__restrict__ out,
-                                                                             const int outW,
-                                                                             const int outH ) {
+                                                                            const int inpH,
+                                                                            const float *__restrict__ h_trans_flip,
+                                                                            const int up,
+                                                                            const int down,
+                                                                            const int axis,
+                                                                            const int x_shape_a,
+                                                                            const int h_per_phase,
+                                                                            const int padded_len,
+                                                                            float *__restrict__ out,
+                                                                            const int outW,
+                                                                            const int outH ) {
     _cupy_upfirdn2D<float>(
         inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
 }
 
 extern "C" __global__ void __launch_bounds__( 64 ) _cupy_upfirdn2D_float64( const double *__restrict__ inp,
-                                                                             const int inpH,
-                                                                             const double *__restrict__ h_trans_flip,
-                                                                             const int up,
-                                                                             const int down,
-                                                                             const int axis,
-                                                                             const int x_shape_a,
-                                                                             const int h_per_phase,
-                                                                             const int padded_len,
-                                                                             double *__restrict__ out,
-                                                                             const int outW,
-                                                                             const int outH ) {
+                                                                            const int inpH,
+                                                                            const double *__restrict__ h_trans_flip,
+                                                                            const int up,
+                                                                            const int down,
+                                                                            const int axis,
+                                                                            const int x_shape_a,
+                                                                            const int h_per_phase,
+                                                                            const int padded_len,
+                                                                            double *__restrict__ out,
+                                                                            const int outW,
+                                                                            const int outH ) {
     _cupy_upfirdn2D<double>(
         inp, inpH, h_trans_flip, up, down, axis, x_shape_a, h_per_phase, padded_len, out, outW, outH );
 }

--- a/python/cusignal/filtering/_upfirdn_cuda.py
+++ b/python/cusignal/filtering/_upfirdn_cuda.py
@@ -170,7 +170,7 @@ class _UpFIRDn(object):
     def __init__(self, h, x_dtype, up, down):
         """Helper for resampling"""
 
-        if(str(type(h)) == "<class 'cupy._core.core.ndarray'>"):
+        if str(type(h)) == "<class 'cupy._core.core.ndarray'>":
             pp = cp
         else:
             pp = np

--- a/python/cusignal/filtering/filtering.py
+++ b/python/cusignal/filtering/filtering.py
@@ -142,10 +142,10 @@ def firfilter(b, x, axis=-1, zi=None):
     """
     b = cp.asarray(b)
     if b.ndim != 1:
-        raise ValueError('object of too small depth for desired array')
+        raise ValueError("object of too small depth for desired array")
 
     if x.ndim == 0:
-        raise ValueError('x must be at least 1-D')
+        raise ValueError("x must be at least 1-D")
 
     inputs = [b, x]
     if zi is not None:
@@ -153,7 +153,7 @@ def firfilter(b, x, axis=-1, zi=None):
         # singleton dims.
         zi = cp.asarray(zi)
         if zi.ndim != x.ndim:
-            raise ValueError('object of too small depth for desired array')
+            raise ValueError("object of too small depth for desired array")
         expected_shape = list(x.shape)
         expected_shape[axis] = b.shape[0] - 1
         expected_shape = tuple(expected_shape)
@@ -170,15 +170,15 @@ def firfilter(b, x, axis=-1, zi=None):
                 elif k != axis and zi.shape[k] == 1:
                     strides[k] = 0
                 else:
-                    raise ValueError('Unexpected shape for zi: expected '
-                                     '%s, found %s.' %
-                                     (expected_shape, zi.shape))
-            zi = cp.lib.stride_tricks.as_strided(zi, expected_shape,
-                                                 strides)
+                    raise ValueError(
+                        "Unexpected shape for zi: expected "
+                        "%s, found %s." % (expected_shape, zi.shape)
+                    )
+            zi = cp.lib.stride_tricks.as_strided(zi, expected_shape, strides)
         inputs.append(zi)
     dtype = cp.result_type(*inputs)
 
-    if dtype.char not in 'fdgFDGO':
+    if dtype.char not in "fdgFDGO":
         raise NotImplementedError("input type '%s' not supported" % dtype)
 
     b = cp.array(b, dtype=dtype)
@@ -363,10 +363,14 @@ def firfilter_zi(b):
 
 def _validate_pad(padtype, padlen, x, axis, ntaps):
     """Helper to validate padding for filtfilt"""
-    if padtype not in ['even', 'odd', 'constant', None]:
-        raise ValueError(("Unknown value '%s' given to padtype.  padtype "
-                          "must be 'even', 'odd', 'constant', or None.") %
-                         padtype)
+    if padtype not in ["even", "odd", "constant", None]:
+        raise ValueError(
+            (
+                "Unknown value '%s' given to padtype.  padtype "
+                "must be 'even', 'odd', 'constant', or None."
+            )
+            % padtype
+        )
 
     if padtype is None:
         padlen = 0
@@ -379,15 +383,17 @@ def _validate_pad(padtype, padlen, x, axis, ntaps):
 
     # x's 'axis' dimension must be bigger than edge.
     if x.shape[axis] <= edge:
-        raise ValueError("The length of the input vector x must be greater "
-                         "than padlen, which is %d." % edge)
+        raise ValueError(
+            "The length of the input vector x must be greater "
+            "than padlen, which is %d." % edge
+        )
 
     if padtype is not None and edge > 0:
         # Make an extension of length `edge` at each
         # end of the input array.
-        if padtype == 'even':
+        if padtype == "even":
             ext = _even_ext(x, edge, axis=axis)
-        elif padtype == 'odd':
+        elif padtype == "odd":
             ext = _odd_ext(x, edge, axis=axis)
         else:
             ext = _const_ext(x, edge, axis=axis)
@@ -396,8 +402,9 @@ def _validate_pad(padtype, padlen, x, axis, ntaps):
     return edge, ext
 
 
-def firfilter2(b, x, axis=-1, padtype='odd', padlen=None, method='pad',
-               irlen=None):
+def firfilter2(
+    b, x, axis=-1, padtype="odd", padlen=None, method="pad", irlen=None
+):
     """
     Apply a digital filter forward and backward to a signal.
     This function applies a linear digital filter twice, once forward and
@@ -502,8 +509,9 @@ def firfilter2(b, x, axis=-1, padtype='odd', padlen=None, method='pad',
     return cp.copy(y)
 
 
-def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
-             irlen=None):
+def filtfilt(
+    b, a, x, axis=-1, padtype="odd", padlen=None, method="pad", irlen=None
+):
     """
     Apply a digital filter forward and backward to a signal.
     This function applies a linear digital filter twice, once forward and
@@ -572,8 +580,15 @@ def filtfilt(b, a, x, axis=-1, padtype='odd', padlen=None, method='pad',
     """
     a = cp.atleast_1d(a)
     if len(a) == 1:
-        return firfilter2(b, x, axis=axis, padtype=padtype, padlen=padlen,
-                          method=method, irlen=irlen)
+        return firfilter2(
+            b,
+            x,
+            axis=axis,
+            padtype=padtype,
+            padlen=padlen,
+            method=method,
+            irlen=irlen,
+        )
     else:
         raise NotImplementedError("IIR support isn't supported yet")
 

--- a/python/cusignal/filtering/resample.py
+++ b/python/cusignal/filtering/resample.py
@@ -513,7 +513,6 @@ def upfirdn(
            [ 6.,  7.]])
     """
 
-    x = cp.asarray(x)
     ufd = _UpFIRDn(h, x.dtype, up, down)
     # This is equivalent to (but faster than) using cp.apply_along_axis
     return ufd.apply_filter(x, axis)


### PR DESCRIPTION
This PR improves performance by adding `__builtin_assume`, leave `h` on CPU, and more efficient data movement

## Results UPFIRDN

# OLD V100
```bash
------------ benchmark 'UpFirDn': 36 tests ------------
Name (time in us)                        Mean          
-------------------------------------------------------
test_upfirdn_gpu[0-9-7-1-16384]      315.4922 (1.0)    
test_upfirdn_gpu[0-2-7-1-16384]      316.1258 (1.00)   
test_upfirdn_gpu[0-2-3-1-16384]      316.1944 (1.00)   
test_upfirdn_gpu[-1-9-7-1-16384]     316.5337 (1.00)   
test_upfirdn_gpu[0-1-3-1-16384]      317.2807 (1.01)   
test_upfirdn_gpu[-1-9-3-1-16384]     317.4403 (1.01)   
test_upfirdn_gpu[0-1-7-1-16384]      318.3329 (1.01)   
test_upfirdn_gpu[0-9-3-1-16384]      318.9417 (1.01)   
test_upfirdn_gpu[0-1-7-2-256]        318.9686 (1.01)   
test_upfirdn_gpu[-1-9-3-2-256]       319.2423 (1.01)   
test_upfirdn_gpu[0-9-3-2-256]        319.3603 (1.01)   
test_upfirdn_gpu[-1-9-7-2-256]       319.3719 (1.01)   
test_upfirdn_gpu[0-9-7-2-256]        320.2904 (1.02)   
test_upfirdn_gpu[0-1-3-2-256]        321.2459 (1.02)   
test_upfirdn_gpu[0-2-7-2-256]        323.2091 (1.02)   
test_upfirdn_gpu[0-2-3-2-256]        323.8516 (1.03)   
test_upfirdn_gpu[-1-1-7-1-16384]     326.4069 (1.03)   
test_upfirdn_gpu[-1-2-7-1-16384]     326.9490 (1.04)   
test_upfirdn_gpu[-1-2-3-1-16384]     328.1549 (1.04)   
test_upfirdn_gpu[-1-1-3-1-16384]     329.2246 (1.04)   
test_upfirdn_gpu[-1-1-7-2-256]       331.7414 (1.05)   
test_upfirdn_gpu[-1-2-3-2-256]       332.3579 (1.05)   
test_upfirdn_gpu[-1-2-7-2-256]       332.7879 (1.05)   
test_upfirdn_gpu[-1-1-3-2-256]       335.2030 (1.06)   
test_upfirdn_gpu[0-2-2-1-16384]      342.3513 (1.09)   
test_upfirdn_gpu[0-9-2-1-16384]      343.5168 (1.09)   
test_upfirdn_gpu[-1-1-2-1-16384]     346.0149 (1.10)   
test_upfirdn_gpu[0-1-2-1-16384]      346.0737 (1.10)   
test_upfirdn_gpu[0-2-2-2-256]        347.2670 (1.10)   
test_upfirdn_gpu[0-9-2-2-256]        348.5359 (1.10)   
test_upfirdn_gpu[0-1-2-2-256]        351.3780 (1.11)   
test_upfirdn_gpu[-1-9-2-2-256]       355.5042 (1.13)   
test_upfirdn_gpu[-1-2-2-1-16384]     356.3156 (1.13)   
test_upfirdn_gpu[-1-9-2-1-16384]     359.0164 (1.14)   
test_upfirdn_gpu[-1-1-2-2-256]       359.5225 (1.14)   
test_upfirdn_gpu[-1-2-2-2-256]       363.7017 (1.15)   
-------------------------------------------------------
```
# NEW V100
```bash
------------ benchmark 'UpFirDn': 36 tests ------------
Name (time in us)                        Mean          
-------------------------------------------------------
test_upfirdn_gpu[0-2-3-1-16384]      143.3580 (1.0)    
test_upfirdn_gpu[0-1-3-1-16384]      143.4882 (1.00)   
test_upfirdn_gpu[-1-9-3-1-16384]     143.4895 (1.00)   
test_upfirdn_gpu[0-9-7-1-16384]      143.5652 (1.00)   
test_upfirdn_gpu[-1-2-3-1-16384]     143.6102 (1.00)   
test_upfirdn_gpu[-1-1-3-1-16384]     143.6836 (1.00)   
test_upfirdn_gpu[0-9-3-1-16384]      143.8562 (1.00)   
test_upfirdn_gpu[-1-1-7-1-16384]     143.9047 (1.00)   
test_upfirdn_gpu[-1-9-7-1-16384]     143.9970 (1.00)   
test_upfirdn_gpu[-1-2-7-1-16384]     144.2924 (1.01)   
test_upfirdn_gpu[0-1-2-1-16384]      145.0911 (1.01)   
test_upfirdn_gpu[0-2-7-1-16384]      145.1300 (1.01)   
test_upfirdn_gpu[-1-1-2-1-16384]     145.6404 (1.02)   
test_upfirdn_gpu[0-1-7-1-16384]      145.9676 (1.02)   
test_upfirdn_gpu[-1-2-2-1-16384]     146.2970 (1.02)   
test_upfirdn_gpu[-1-1-3-2-256]       146.3297 (1.02)   
test_upfirdn_gpu[0-2-2-1-16384]      146.4785 (1.02)   
test_upfirdn_gpu[-1-1-7-2-256]       147.0008 (1.03)   
test_upfirdn_gpu[-1-9-7-2-256]       147.0320 (1.03)   
test_upfirdn_gpu[-1-9-3-2-256]       147.3765 (1.03)   
test_upfirdn_gpu[0-9-2-1-16384]      147.5447 (1.03)   
test_upfirdn_gpu[0-1-3-2-256]        147.6369 (1.03)   
test_upfirdn_gpu[-1-2-3-2-256]       147.7050 (1.03)   
test_upfirdn_gpu[0-2-3-2-256]        147.8314 (1.03)   
test_upfirdn_gpu[0-1-7-2-256]        147.8698 (1.03)   
test_upfirdn_gpu[0-9-3-2-256]        147.8850 (1.03)   
test_upfirdn_gpu[0-9-7-2-256]        148.0991 (1.03)   
test_upfirdn_gpu[-1-9-2-1-16384]     148.4170 (1.04)   
test_upfirdn_gpu[-1-2-7-2-256]       149.2807 (1.04)   
test_upfirdn_gpu[0-1-2-2-256]        149.5813 (1.04)   
test_upfirdn_gpu[-1-1-2-2-256]       150.0676 (1.05)   
test_upfirdn_gpu[-1-9-2-2-256]       150.2809 (1.05)   
test_upfirdn_gpu[0-2-7-2-256]        150.5996 (1.05)   
test_upfirdn_gpu[0-9-2-2-256]        150.8771 (1.05)   
test_upfirdn_gpu[0-2-2-2-256]        151.4076 (1.06)   
test_upfirdn_gpu[-1-2-2-2-256]       151.6741 (1.06)   
-------------------------------------------------------
```

## Results RESAMPLE_POLY

# OLD V100
```bash
---------------- benchmark 'ResamplePoly': 8 tests -----------------
Name (time in ms)                                     Mean          
--------------------------------------------------------------------
test_resample_poly_gpu[window0-0-1-8-1-16384]       1.0500 (1.0)    
test_resample_poly_gpu[window0--1-1-8-1-16384]      1.0602 (1.01)   
test_resample_poly_gpu[window0--1-1-8-2-16384]      1.0861 (1.03)   
test_resample_poly_gpu[window0-0-1-8-2-16384]       1.1228 (1.07)   
test_resample_poly_gpu[window0--1-1-8-1-262144]     1.1264 (1.07)   
test_resample_poly_gpu[window0-0-1-8-1-262144]      1.1279 (1.07)   
test_resample_poly_gpu[window0--1-1-8-2-262144]     1.6999 (1.62)   
test_resample_poly_gpu[window0-0-1-8-2-262144]      2.4865 (2.37)   
--------------------------------------------------------------------
```
# NEW V100
NOTE: `True` is equivalent to old way with no parameter`
```bash
--------------------- benchmark 'ResamplePoly': 16 tests ---------------------
Name (time in us)                                               Mean          
------------------------------------------------------------------------------
test_resample_poly_gpu[False-window0--1-1-8-1-16384]        375.8534 (1.0)    
test_resample_poly_gpu[False-window0-0-1-8-1-16384]         377.2331 (1.00)   
test_resample_poly_gpu[False-window0--1-1-8-2-16384]        402.4394 (1.07)   
test_resample_poly_gpu[False-window0-0-1-8-2-16384]         428.6674 (1.14)   
test_resample_poly_gpu[False-window0-0-1-8-1-262144]        449.0409 (1.19)   
test_resample_poly_gpu[False-window0--1-1-8-1-262144]       451.0780 (1.20)   
test_resample_poly_gpu[True-window0-0-1-8-1-16384]          906.7175 (2.41)   
test_resample_poly_gpu[True-window0--1-1-8-1-16384]         914.1188 (2.43)   
test_resample_poly_gpu[True-window0-0-1-8-2-16384]          963.5410 (2.56)   
test_resample_poly_gpu[True-window0--1-1-8-2-16384]         965.9045 (2.57)   
test_resample_poly_gpu[True-window0-0-1-8-1-262144]         983.8116 (2.62)   
test_resample_poly_gpu[True-window0--1-1-8-1-262144]        984.4665 (2.62)   
test_resample_poly_gpu[False-window0--1-1-8-2-262144]     1,016.7856 (2.71)   
test_resample_poly_gpu[False-window0-0-1-8-2-262144]      1,385.3105 (3.69)   
test_resample_poly_gpu[True-window0--1-1-8-2-262144]      1,556.4297 (4.14)   
test_resample_poly_gpu[True-window0-0-1-8-2-262144]       1,917.0345 (5.10)   
------------------------------------------------------------------------------
```