### PR TITLE
Add Ambiguity Function (ambgfun)

### DIFF
--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -129,6 +129,7 @@ from cusignal.io.writer import (
 from cusignal.radartools.radartools import (
     pulse_compression,
     pulse_doppler,
+    ambgfun,
 )
 
 # Versioneer

--- a/python/cusignal/radartools/__init__.py
+++ b/python/cusignal/radartools/__init__.py
@@ -14,4 +14,5 @@
 from cusignal.radartools.radartools import (
     pulse_compression,
     pulse_doppler,
+    ambgfun,
 )

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -188,14 +188,17 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
         ynorm = y / cp.linalg.norm(y)
 
     len_seq = len(xnorm) + len(ynorm)
-    nfreq = 2**ceil(log2(abs(len_seq - 1)))
+    nfreq = 2**ceil(log2(len_seq - 1))
 
+    # Consider for deletion as we add different cut values
+    """
     if len(xnorm) < len(ynorm):
         len_diff = len(ynorm) - len(xnorm)
         ynorm = cp.concatenate(ynorm, cp.zeros(len_diff))
     elif len(xnorm) > len(ynorm):
         len_diff = len(xnorm) - len(ynorm)
         xnorm = cp.concatenate(xnorm, cp.zeros(len_diff))
+    """
 
     xlen = len(xnorm)
 

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -189,10 +189,13 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
     amfun : ndarray
         Normalized magnitude of the ambiguity function
     """
-    if 'complex' not in x.dtype.name:
-        x = cp.asarray(x, dtype=cp.complex)
+    if 'float64' in x.dtype.name:
+        x = cp.asarray(x, dtype=cp.complex128)
+    elif 'float32' in x.dtype.name:
+        x = cp.asarray(x, dtype=cp.complex64)
     else:
         x = cp.asarray(x)
+
     xnorm = x / cp.linalg.norm(x)
     if y is None:
         y = x

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -159,6 +159,7 @@ _new_ynorm_kernel = cp.ElementwiseKernel(
     options=("-std=c++11",),
 )
 
+
 def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
     """
     Calculates the normalized ambiguity function for the vector x
@@ -217,7 +218,7 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
     if cut == '2d':
         new_ynorm = cp.empty((len_seq - 1, xlen), dtype=xnorm.dtype)
-        _new_ynorm_kernel(xlen, xnorm, ynorm,  new_ynorm)
+        _new_ynorm_kernel(xlen, xnorm, ynorm, new_ynorm)
 
         amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(new_ynorm, nfreq, axis=1), axes=1))

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -210,6 +210,7 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
         amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(new_ynorm, nfreq, axis=1), axes=1))
+
     elif cut == 'delay':
         Fd = cp.arange(-fs / 2, fs / 2, fs / nfreq)
         fftx = cp.fft.fft(xnorm, nfreq) * \
@@ -221,5 +222,17 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
         amf = nfreq * cp.abs(cp.fft.ifftshift(
             cp.fft.ifft(ynorm_pad * cp.conj(xshift), nfreq)))
+
+    elif cut == 'doppler':
+        t = cp.arange(0, xlen) / fs
+        ffty = cp.fft.fft(ynorm, len_seq - 1)
+        fftx = cp.fft.fft(xnorm * cp.exp(1j * 2 * cp.pi * cutValue * t),
+                          len_seq - 1)
+
+        amf = cp.abs(cp.fft.fftshift(cp.fft.ifft(ffty * cp.conj(fftx))))
+
+    else:
+        raise ValueError('2d, delay, and doppler are the only\
+            cut values allowed')
 
     return amf

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -124,23 +124,6 @@ def pulse_doppler(x, window=None, nfft=None):
     return pd_dataMatrix
 
 
-# v
-#  [[0.         0.         0.         0.        ]
-#  [0.         0.         0.         0.        ]
-#  [0.         0.         0.         0.        ]
-#  [0.66253751 0.66253751 0.66253751 0.66253751]
-#  [0.32884939 0.32884939 0.32884939 0.32884939]
-#  [0.18639329 0.18639329 0.18639329 0.18639329]
-#  [0.64665267 0.64665267 0.64665267 0.64665267]]
-# v_shift
-#  [[0.         0.         0.         0.66253751]
-#  [0.         0.         0.66253751 0.32884939]
-#  [0.         0.66253751 0.32884939 0.18639329]
-#  [0.66253751 0.32884939 0.18639329 0.64665267]
-#  [0.32884939 0.18639329 0.64665267 0.        ]
-#  [0.18639329 0.64665267 0.         0.        ]
-#  [0.64665267 0.         0.         0.        ]]
-
 _new_ynorm_kernel = cp.ElementwiseKernel(
     "int32 xlen, raw T xnorm, raw T ynorm",
     "T out",
@@ -218,7 +201,7 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
     if cut == '2d':
         new_ynorm = cp.empty((len_seq - 1, xlen), dtype=xnorm.dtype)
-        _new_ynorm_kernel(xlen, xnorm, ynorm, new_ynorm)
+        _new_ynorm_kernel(xlen, xnorm, ynorm, anew_ynorm)
 
         amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(new_ynorm, nfreq, axis=1), axes=1))

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -148,7 +148,7 @@ _new_ynorm_kernel = cp.ElementwiseKernel(
     int row = i / xlen;
     int col = i % xlen;
     int x_col = col - ( xlen - 1 ) + row;
-    
+
     if ( ( x_col >= 0 ) && ( x_col < xlen ) ) {
         //out = ynorm[col] * thrust::conj( xnorm[x_col] );
         out = ynorm[col] * xnorm[x_col].real();
@@ -202,10 +202,9 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
     if cut == '2d':
         new_ynorm = cp.empty((len_seq - 1, xlen), dtype=xnorm.dtype)
-        _new_ynorm_kernel(xlen, xnorm, ynorm,  new_ynorm)        
-  
+        _new_ynorm_kernel(xlen, xnorm, ynorm,  new_ynorm)
+
         amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(new_ynorm, nfreq, axis=1), axes=1))
-
 
     return amf

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -173,6 +173,8 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
     amfun : ndarray
         Normalized magnitude of the ambiguity function
     """
+    cut = cut.lower()
+
     if 'float64' in x.dtype.name:
         x = cp.asarray(x, dtype=cp.complex128)
     elif 'float32' in x.dtype.name:
@@ -208,5 +210,16 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
         amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(new_ynorm, nfreq, axis=1), axes=1))
+    elif cut == 'delay':
+        Fd = cp.arange(-fs / 2, fs / 2, fs / nfreq)
+        fftx = cp.fft.fft(xnorm, nfreq) * \
+            cp.exp(1j * 2 * cp.pi * Fd * cutValue)
+        xshift = cp.fft.ifft(fftx)
+
+        ynorm_pad = cp.zeros(nfreq)
+        ynorm_pad[:ynorm.shape[0]] = ynorm
+
+        amf = nfreq * cp.abs(cp.fft.ifftshift(
+            cp.fft.ifft(ynorm_pad * cp.conj(xshift), nfreq)))
 
     return amf

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -145,12 +145,12 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
         Normalized magnitude of the ambiguity function
     """
     x = cp.asarray(x)
-    xnorm = x/cp.linalg.norm(x)
+    xnorm = x / cp.linalg.norm(x)
     if y is None:
         y = x
         ynorm = xnorm
     else:
-        ynorm = y/cp.linalg.norm(y)
+        ynorm = y / cp.linalg.norm(y)
 
     len_seq = len(xnorm) + len(ynorm)
     nfreq = 2**ceil(log2(abs(len_seq - 1)))
@@ -172,7 +172,7 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
         for col in range(v.shape[1]):
             v_shift[:, col] = cp.roll(v[:, col], -col, axis=0)
         ynorm = cp.tile(ynorm, (len_seq - 1, 1))
-        amf = nfreq*cp.abs(cp.fft.fftshift(
+        amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(ynorm * cp.conj(v_shift), nfreq, axis=1), axes=1))
 
     return amf

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -201,7 +201,7 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
 
     if cut == '2d':
         new_ynorm = cp.empty((len_seq - 1, xlen), dtype=xnorm.dtype)
-        _new_ynorm_kernel(xlen, xnorm, ynorm, anew_ynorm)
+        _new_ynorm_kernel(xlen, xnorm, ynorm, new_ynorm)
 
         amf = nfreq * cp.abs(cp.fft.fftshift(
             cp.fft.ifft(new_ynorm, nfreq, axis=1), axes=1))

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -174,12 +174,25 @@ def ambgfun(x, fs, prf, y=None, cut='2d', cutValue=0):
     prf: int, float
         Pulse repetition frequency in Hz
 
+    y : ndarray
+        Second input pulse waveform. If not given, y = x
+
+    cut : string
+        Direction of one-dimensional cut through ambiguity function
+
+    cutValue : int, float
+        Time delay or doppler shift at which one-dimensional cut
+        through ambiguity function is taken
+
     Returns
     -------
     amfun : ndarray
         Normalized magnitude of the ambiguity function
     """
-    x = cp.asarray(x)
+    if 'complex' not in x.dtype.name:
+        x = cp.asarray(x, dtype=cp.complex)
+    else:
+        x = cp.asarray(x)
     xnorm = x / cp.linalg.norm(x)
     if y is None:
         y = x

--- a/python/cusignal/radartools/radartools.py
+++ b/python/cusignal/radartools/radartools.py
@@ -150,8 +150,7 @@ _new_ynorm_kernel = cp.ElementwiseKernel(
     int x_col = col - ( xlen - 1 ) + row;
 
     if ( ( x_col >= 0 ) && ( x_col < xlen ) ) {
-        //out = ynorm[col] * thrust::conj( xnorm[x_col] );
-        out = ynorm[col] * xnorm[x_col].real();
+        out = ynorm[col] * thrust::conj( xnorm[x_col] );
     } else {
         out = T(0,0);
     }


### PR DESCRIPTION
Initial commit with seemingly correct logic for normalized ambiguity function for input signal `x`. Haven't worked cross correlation and only taking 1D cut through the AF.

Updates:
* Implemented `doppler` and `delay` techniques in addition to existing default `2d`.
* @mnicely optimized `2d`
* Need to look at areas for perf improvement w/ `doppler` and `delay`
* Need to write unit tests (pure python) and benchmarks