### PR TITLE
mvdr perf optimizations and addition of elementwise divide kernel

### DIFF
--- a/python/cusignal/radartools/beamformers.py
+++ b/python/cusignal/radartools/beamformers.py
@@ -14,15 +14,6 @@
 import cupy as cp
 
 
-_elementwise_divide = cp.ElementwiseKernel(
-    'T wB, T wA',
-    'T w',
-    'w = wB / wA',
-    '_elementwise_divide',
-    options=("-std=c++11",)
-)
-
-
 def mvdr(x, sv):
     """
     Minimum variance distortionless response (MVDR) beamformer weights
@@ -53,6 +44,6 @@ def mvdr(x, sv):
     wB = cp.matmul(R_inv, sv)
     # wA is a 1x1 scalar
     wA = cp.matmul(svh, wB)
-    w = _elementwise_divide(wB, wA)
+    w = _wB / wA
 
     return w

--- a/python/cusignal/radartools/beamformers.py
+++ b/python/cusignal/radartools/beamformers.py
@@ -14,6 +14,14 @@
 import cupy as cp
 
 
+_elementwise_divide = cp.ElementwiseKernel(
+    'T wB, T wA',
+    'T w',
+    'w = wB / wA',
+    '_elementwise_divide',
+    options=("-std=c++11",)
+)
+
 def mvdr(x, sv):
     """
     Minimum variance distortionless response (MVDR) beamformer weights
@@ -42,7 +50,8 @@ def mvdr(x, sv):
     svh = cp.transpose(cp.conj(sv))
 
     wB = cp.matmul(R_inv, sv)
+    # wA is a 1x1 scalar
     wA = cp.matmul(svh, wB)
-    w = cp.matmul(wB, cp.linalg.inv(wA))
+    w = _elementwise_divide(wB, wA)
 
     return w

--- a/python/cusignal/radartools/beamformers.py
+++ b/python/cusignal/radartools/beamformers.py
@@ -22,6 +22,7 @@ _elementwise_divide = cp.ElementwiseKernel(
     options=("-std=c++11",)
 )
 
+
 def mvdr(x, sv):
     """
     Minimum variance distortionless response (MVDR) beamformer weights

--- a/python/cusignal/radartools/beamformers.py
+++ b/python/cusignal/radartools/beamformers.py
@@ -44,6 +44,6 @@ def mvdr(x, sv):
     wB = cp.matmul(R_inv, sv)
     # wA is a 1x1 scalar
     wA = cp.matmul(svh, wB)
-    w = _wB / wA
+    w = wB / wA
 
     return w


### PR DESCRIPTION
Previous version of mvdr beamformer failed to account for the fact that the `wA` denominator result is a scalar. Removing inverse and additional matmul in addition to adding elementwise kernel