### PR TITLE
Remove pytorch from cusignal CI/CD

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -85,9 +85,6 @@ cd $WORKSPACE/python
 
 pytest --cache-clear --junitxml=${WORKSPACE}/junit-cusignal.xml -v -s -m "not cpu"
 
-conda remove -y --force blas nomkl rapids-build-env rapids-notebook-env
-gpuci_conda_retry install -y -c pytorch "pytorch>=1.4"
-
 ${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log
 python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
 


### PR DESCRIPTION
Fix errors when running CI/CD on cuSignal PRs with PyTorch and CTK 11.2 and 11.0.

cc @ajschmidt8 @jakirkham 