### PR TITLE
Fix Forward-Merge Conflicts [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Please see https://github.com/rapidsai/cusignal/releases/tag/v21.10.00a for the latest changes to this development branch.
 
-# cuSignal 21.08.00 (Date TBD)
+# cuSignal 21.08.00 (4 Aug 2021)
 
 ## 🐛 Bug Fixes
 


### PR DESCRIPTION
This PR fixes the merge conflicts in `CHANGELOG.md` for the latest forward-merger PR.
