### PR TITLE
Add sw dependencies for pip packaging

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -63,9 +63,15 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 gpuci_logger "Build conda pkg for cuSignal"
 gpuci_conda_retry build conda/recipes/cusignal --python=${PYTHON}
 
+rm -rf dist/
+python setup.py sdist bdist_wheel
+
 ################################################################################
 # UPLOAD - Conda packages
 ################################################################################
 
 gpuci_logger "Upload conda pkgs for cuSignal"
 source ci/cpu/upload.sh
+
+gpuci_logger "Upload pypi pkgs for cuSignal"
+source ci/cpu/upload-pypi.sh

--- a/ci/cpu/upload-pypi.sh
+++ b/ci/cpu/upload-pypi.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+
+if [ ${BUILD_MODE} != "branch" ]; then
+  echo "Skipping upload"
+  return 0
+fi
+
+if [ -z "$TWINE_PASSWORD" ]; then
+    echo "TWINE_PASSWORD not set"
+    return 0
+fi
+
+echo "Upload pypi"
+twine upload --skip-existing -u ${TWINE_USERNAME:-rapidsai} dist/*

--- a/python/cusignal/__init__.py
+++ b/python/cusignal/__init__.py
@@ -11,6 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+_is_cupy_available = False
+
+try:
+    import cupy
+    _is_cupy_available = True
+except ImportError:
+    pass
+
 from cusignal.acoustics.cepstrum import (
     real_cepstrum,
     complex_cepstrum,

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -23,6 +23,9 @@ versionfile_build = cusignal/_version.py
 tag_prefix = v
 parentdir_prefix = cusignal-
 
+[bdist_wheel]
+universal = 0
+
 [flake8]
 exclude = __init__.py
 ignore =

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,22 +11,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import versioneer
 from setuptools import setup, find_packages
+import sys
+from os.path import dirname, join
 
 
-INSTALL_REQUIRES = ["numba"]
+SETUP_REQUIRES = ['setuptools >= 24.2.0']
+SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
 
-setup(
+
+def read(*names, **kwargs):
+    with io.open(
+        join(dirname(__file__), *names),
+        encoding=kwargs.get('encoding', 'utf8')
+    ) as fh:
+        return fh.read()
+
+
+opts = dict(
     name='cusignal',
     version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    license="Apache 2.0",
     description="cuSignal - GPU Signal Processing",
     url="https://github.com/rapidsai/cusignal",
     author="NVIDIA Corporation",
-    license="Apache 2.0",
     packages=find_packages(include=["cusignal", "cusignal.*"]),
-    cmdclass=versioneer.get_cmdclass(),
-    install_requires=INSTALL_REQUIRES,
+    package_data={"": ["*.fatbin"]},
+    include_package_data=True,
     zip_safe=False,
-    package_data={"": ["*.fatbin"]}
+    project_urls={
+        'Documentation': 'https://docs.rapids.ai/api/cusignal/stable/',
+        'Issue Tracker': 'https://github.com/rapidsai/cusignal/issues',
+    },
+    python_requires='>=3.6',
+    platforms=['manylinux2014_x86_64'],
+    setup_requires=SETUP_REQUIRES,
+    install_requires=[
+        'numpy', 'numba', 'scipy',
+    ],
 )
+
+if __name__ == '__main__':
+    setup(**opts)


### PR DESCRIPTION
Matching cucim pip packaging. Requiring cupy to be installed prior to pip installing cusignal.