### PR TITLE
remove use_numba from notebooks - deprecated

### DIFF
--- a/notebooks/api_guide/convolution_examples.ipynb
+++ b/notebooks/api_guide/convolution_examples.ipynb
@@ -3,352 +3,300 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import cupy as cp\n",
     "import cusignal \n",
     "from scipy import signal\n",
     "import numpy as np"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Correlate"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "sig = np.random.rand(int(1e8))\n",
     "sig_noise = sig + np.random.randn(len(sig))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "ccorr = signal.correlate(sig_noise, np.ones(128), mode='same') / 1e6"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "4.02 s ± 22.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "ccorr = signal.correlate(sig_noise, np.ones(128), mode='same') / 1e6"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "sig = cp.random.rand(int(1e8))\n",
     "sig_noise = sig + cp.random.randn(len(sig))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "gcorr = cusignal.correlate(sig_noise, cp.ones(128), mode='same') / 1e6"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "72.5 ms ± 165 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "gcorr = cusignal.correlate(sig_noise, cp.ones(128), mode='same') / 1e6"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Convolve"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "sig = np.random.rand(int(1e8))\n",
     "win = signal.windows.hann(int(1e3))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cconv = signal.convolve(sig, win, mode='same') / np.sum(win)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "15.8 s ± 468 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cconv = signal.convolve(sig, win, mode='same') / np.sum(win)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "sig = cp.random.rand(int(1e8))\n",
     "win = cusignal.hann(int(1e3))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "gconv = cusignal.convolve(sig, win, mode='same') / cp.sum(win)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "72.7 ms ± 21.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "gconv = cusignal.convolve(sig, win, mode='same') / cp.sum(win)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Convolution using the FFT Method"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "csig = np.random.randn(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cautocorr = signal.fftconvolve(csig, csig[::-1], mode='full')"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "27.3 s ± 471 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cautocorr = signal.fftconvolve(csig, csig[::-1], mode='full')"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gsig = cp.random.randn(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "gautocorr = cusignal.fftconvolve(gsig, gsig[::-1], mode='full')"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "128 ms ± 77.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "gautocorr = cusignal.fftconvolve(gsig, gsig[::-1], mode='full')"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Perform 2-D Convolution and Correlation"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "csig = np.random.rand(int(1e4), int(1e4))\n",
     "filt = np.random.rand(5,5)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "grad = signal.convolve2d(csig, filt)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "8.4 s ± 10.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "grad = signal.convolve2d(csig, filt)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gsig = cp.random.rand(int(1e4), int(1e4))\n",
     "gfilt = cp.random.rand(5,5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/adamt/anaconda3/envs/cusignal/lib/python3.8/site-packages/cusignal-0.14.0a0+295.g617d0cb-py3.8.egg/cusignal/convolution/convolve.py:443: FutureWarning: Numba kernels will be removed in a later release\n",
-      "  out = _convolution_cuda._convolve2d(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "48.6 ms ± 2.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
    ],
-   "source": [
-    "%%timeit\n",
-    "ggrad = cusignal.convolve2d(gsig, gfilt, use_numba=True)"
-   ]
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "ggrad = cusignal.convolve2d(gsig, gfilt)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "24.6 ms ± 30.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "ggrad = cusignal.convolve2d(gsig, gfilt, use_numba=False)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "grad = signal.correlate2d(csig, filt)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "8.44 s ± 26.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "grad = signal.correlate2d(csig, filt)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/adamt/anaconda3/envs/cusignal/lib/python3.8/site-packages/cusignal-0.14.0a0+295.g617d0cb-py3.8.egg/cusignal/convolution/correlate.py:277: FutureWarning: Numba kernels will be removed in a later release\n",
-      "  out = _convolution_cuda._convolve2d(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "49 ms ± 2.32 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%timeit\n",
-    "ggrad = cusignal.correlate2d(gsig, gfilt, use_numba=True)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "ggrad = cusignal.correlate2d(gsig, gfilt)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "24.6 ms ± 6.66 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "ggrad = cusignal.correlate2d(gsig, gfilt, use_numba=False)"
-   ]
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/notebooks/api_guide/filtering_examples.ipynb
+++ b/notebooks/api_guide/filtering_examples.ipynb
@@ -3,88 +3,86 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import cupy as cp\n",
     "import cusignal \n",
     "from scipy import signal\n",
     "import numpy as np"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Decimate"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "csig = np.random.rand(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cdecimate = signal.decimate(csig, 3, ftype='fir')"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "2.12 s ± 998 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cdecimate = signal.decimate(csig, 3, ftype='fir')"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gsig = cp.random.rand(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "gdecimate = cusignal.decimate(gsig, 3)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "15.9 ms ± 12.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "gdecimate = cusignal.decimate(gsig, 3)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Resample"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "start = 0\n",
     "stop = 10\n",
@@ -93,66 +91,66 @@
     "\n",
     "cx = np.linspace(start, stop, num, endpoint=False) \n",
     "cy = np.cos(-cx**2/6.0)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cf = signal.resample(cy, resample_num, window=('kaiser', 0.5))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "13.9 s ± 65.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cf = signal.resample(cy, resample_num, window=('kaiser', 0.5))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gx = cp.linspace(start, stop, num, endpoint=False)\n",
     "gy = cp.cos(-gx**2/6.0)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "gf = cusignal.resample(gy, resample_num, window=('kaiser',0.5))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "72.2 ms ± 2.86 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "gf = cusignal.resample(gy, resample_num, window=('kaiser',0.5))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Resample Poly"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "start = 0\n",
     "stop = 10\n",
@@ -162,262 +160,238 @@
     "\n",
     "cx = np.linspace(start, stop, num, endpoint=False) \n",
     "cy = np.cos(-cx**2/6.0)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cf = signal.resample_poly(cy, resample_up, resample_down, window=('kaiser', 0.5))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "2.39 s ± 11.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cf = signal.resample_poly(cy, resample_up, resample_down, window=('kaiser', 0.5))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gx = cp.linspace(start, stop, num, endpoint=False)\n",
     "gy = cp.cos(-gx**2/6.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/adamt/anaconda3/envs/cusignal/lib/python3.8/site-packages/cusignal-0.14.0a0+295.g617d0cb-py3.8.egg/cusignal/filtering/resample.py:448: FutureWarning: Numba kernels will be removed in a later release\n",
-      "  y = upfirdn(h, x, up, down, axis=axis, use_numba=use_numba)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "34.7 ms ± 1.34 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
    ],
-   "source": [
-    "%%timeit\n",
-    "cf = cusignal.resample_poly(gy, resample_up, resample_down, window=('kaiser', 0.5), use_numba=True)"
-   ]
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cf = cusignal.resample_poly(gy, resample_up, resample_down, window=('kaiser', 0.5))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "17.4 ms ± 9.88 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cf = cusignal.resample_poly(gy, resample_up, resample_down, window=('kaiser', 0.5), use_numba=False)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Wiener Filter on N-Dimensional Array"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "csig = np.random.rand(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "cfilt = signal.wiener(csig)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "3.58 s ± 15.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "cfilt = signal.wiener(csig)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gsig = cp.random.randn(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "gfilt = cusignal.wiener(gsig)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "255 ms ± 42.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "gfilt = cusignal.wiener(gsig)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Perform 1-D Hilbert Transform"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "csig = np.random.rand((int(1e8)))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "chtrans = signal.hilbert(csig)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "11.8 s ± 412 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "chtrans = signal.hilbert(csig)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gsig = cp.random.rand(int(1e8))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "ghtrans = cusignal.hilbert(gsig)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "71.4 ms ± 1.37 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "ghtrans = cusignal.hilbert(gsig)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Perform 2-D Hilbert Transform"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "csig = np.random.rand(int(1e4), int(1e4))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "chtrans2d = signal.hilbert2(csig)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "6.31 s ± 47.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "chtrans2d = signal.hilbert2(csig)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "gsig = cp.random.rand(int(1e4), int(1e4))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
+   "source": [
+    "%%timeit\n",
+    "ghtrans2d = cusignal.hilbert2(gsig)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "85.2 ms ± 2.28 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
-   "source": [
-    "%%timeit\n",
-    "ghtrans2d = cusignal.hilbert2(gsig)"
-   ]
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
Remove deprecated `use_numba` flag in cusignal that appeared in notebook API guide and was causing testing errors.