### PR TITLE
Bypass Covariance Matrix Calculation if Supplied in MVDR Beamformer

### DIFF
--- a/python/cusignal/radartools/beamformers.py
+++ b/python/cusignal/radartools/beamformers.py
@@ -14,7 +14,7 @@
 import cupy as cp
 
 
-def mvdr(x, sv):
+def mvdr(x, sv, R=None):
     """
     Minimum variance distortionless response (MVDR) beamformer weights
 
@@ -25,6 +25,9 @@ def mvdr(x, sv):
 
     sv: ndarray
         Steering vector, assume 1D array with size [num_sensors, 1]
+
+    R : ndarray [Optional]
+        Optional covariance matrix to bypass calculation within MVDR beamformer
 
     Note: Unlike MATLAB where input matrix x is of size MxN where N represents
     the number of array elements, we assume row-major formatted data where each
@@ -37,7 +40,11 @@ def mvdr(x, sv):
     if x.shape[0] != sv.shape[0]:
         raise ValueError('Steering Vector and input data do not align')
 
-    R = cp.cov(x)
+    if R is None:
+        R = cp.cov(x)
+    else:
+        R = cp.asarray(R)
+
     R_inv = cp.linalg.inv(R)
     svh = cp.transpose(cp.conj(sv))
 

--- a/python/cusignal/radartools/beamformers.py
+++ b/python/cusignal/radartools/beamformers.py
@@ -14,20 +14,23 @@
 import cupy as cp
 
 
-def mvdr(x, sv, R=None):
+def mvdr(x, sv, calc_cov=True):
     """
     Minimum variance distortionless response (MVDR) beamformer weights
 
     Parameters
     ----------
     x : ndarray
-        Received signal, assume 2D array with size [num_sensors, num_samples]
+        Received signal or input covariance matrix, assume 2D array with
+        size [num_sensors, num_samples]
 
     sv: ndarray
         Steering vector, assume 1D array with size [num_sensors, 1]
 
-    R : ndarray [Optional]
-        Optional covariance matrix to bypass calculation within MVDR beamformer
+    calc_cov : bool
+        Determine whether to calculate covariance matrix. Simply put, calc_cov
+        defines whether x input is made of sensor/observation data or is
+        a precalculated covariance matrix
 
     Note: Unlike MATLAB where input matrix x is of size MxN where N represents
     the number of array elements, we assume row-major formatted data where each
@@ -40,10 +43,10 @@ def mvdr(x, sv, R=None):
     if x.shape[0] != sv.shape[0]:
         raise ValueError('Steering Vector and input data do not align')
 
-    if R is None:
+    if calc_cov:
         R = cp.cov(x)
     else:
-        R = cp.asarray(R)
+        R = cp.asarray(x)
 
     R_inv = cp.linalg.inv(R)
     svh = cp.transpose(cp.conj(sv))


### PR DESCRIPTION
Allow the option to pass in a covariance matrix, R, rather than computing it within the MVDR beamformer.