### PR TITLE
Allow CuPy 10

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=8.3.0,<10.0.0a0
+    - cupy>=8.3.0,<11.0.0a0
 
 test:
   requires:


### PR DESCRIPTION
Relaxes version constraints to allow CuPy 10.

xref: https://github.com/rapidsai/integration/pull/413