### PR TITLE
adding complex parameter to chirp and additional tests

### DIFF
--- a/python/cusignal/test/test_waveforms.py
+++ b/python/cusignal/test/test_waveforms.py
@@ -114,9 +114,7 @@ class TestWaveforms:
             array_equal(output, key)
 
     @pytest.mark.benchmark(group="Chirp")
-    @pytest.mark.parametrize(
-        "dtype", [np.float32, np.float64, np.complex64, np.complex128]
-    )
+    @pytest.mark.parametrize("dtype", ["real", "complex"])
     @pytest.mark.parametrize("num_samps", [2 ** 14])
     @pytest.mark.parametrize("f0", [6])
     @pytest.mark.parametrize("t1", [1])
@@ -125,7 +123,7 @@ class TestWaveforms:
     class TestChirp:
         def cpu_version(self, sig, f0, t1, f1, method, dtype):
             if method in ["linear", "lin", "li"]:
-                if np.issubclass_(dtype, (np.float32, np.float64)):
+                if dtype == "real":
                     return signal.chirp(sig, f0, t1, f1, method)
                 else:
                     beta = (f1 - f0) / t1

--- a/python/cusignal/test/test_waveforms.py
+++ b/python/cusignal/test/test_waveforms.py
@@ -41,9 +41,7 @@ class TestWaveforms:
             cpu_sig, _ = time_data_gen(0, 10, num_samps)
             benchmark(self.cpu_version, cpu_sig, w)
 
-        def test_sawtooth_gpu(
-            self, time_data_gen, gpubenchmark, num_samps, w
-        ):
+        def test_sawtooth_gpu(self, time_data_gen, gpubenchmark, num_samps, w):
 
             cpu_sig, gpu_sig = time_data_gen(0, 10, num_samps)
             output = gpubenchmark(self.gpu_version, gpu_sig, w)
@@ -65,9 +63,7 @@ class TestWaveforms:
             return out
 
         @pytest.mark.cpu
-        def test_square_cpu(
-            self, time_data_gen, benchmark, num_samps, duty
-        ):
+        def test_square_cpu(self, time_data_gen, benchmark, num_samps, duty):
             cpu_sig, _ = time_data_gen(0, 10, num_samps)
             benchmark(self.cpu_version, cpu_sig, duty)
 
@@ -88,9 +84,7 @@ class TestWaveforms:
     @pytest.mark.parametrize("retenv", [True, False])
     class TestGaussPulse:
         def cpu_version(self, sig, fc, retquad, retenv):
-            return signal.gausspulse(
-                sig, fc, retquad=retquad, retenv=retenv
-            )
+            return signal.gausspulse(sig, fc, retquad=retquad, retenv=retenv)
 
         def gpu_version(self, sig, fc, retquad, retenv):
             with cp.cuda.Stream.null:
@@ -108,13 +102,7 @@ class TestWaveforms:
             benchmark(self.cpu_version, cpu_sig, fc, retquad, retenv)
 
         def test_gausspulse_gpu(
-            self,
-            time_data_gen,
-            gpubenchmark,
-            num_samps,
-            fc,
-            retquad,
-            retenv,
+            self, time_data_gen, gpubenchmark, num_samps, fc, retquad, retenv
         ):
 
             cpu_sig, gpu_sig = time_data_gen(0, 10, num_samps)
@@ -127,13 +115,7 @@ class TestWaveforms:
 
     @pytest.mark.benchmark(group="Chirp")
     @pytest.mark.parametrize(
-        "dtype",
-        [
-            np.float32,
-            np.float64,
-            np.complex64,
-            np.complex128,
-        ],
+        "dtype", [np.float32, np.float64, np.complex64, np.complex128]
     )
     @pytest.mark.parametrize("num_samps", [2 ** 14])
     @pytest.mark.parametrize("f0", [6])
@@ -148,7 +130,7 @@ class TestWaveforms:
                 else:
                     beta = (f1 - f0) / t1
                     phase = 2 * np.pi * (f0 * sig + 0.5 * beta * sig * sig)
-                    return np.cos(phase) - 1j*np.cos(phase + np.pi/2)
+                    return np.cos(phase) - 1j * np.cos(phase + np.pi / 2)
             else:
                 return signal.chirp(sig, f0, t1, f1, method)
 

--- a/python/cusignal/test/test_waveforms.py
+++ b/python/cusignal/test/test_waveforms.py
@@ -130,16 +130,16 @@ class TestWaveforms:
         "dtype",
         [
             pytest.param(
-                cp.float32,
+                np.float32,
                 marks=pytest.mark.xfail(reason="no scipy equivalent"),
             ),
-            cp.float64,
+            np.float64,
             pytest.param(
-                cp.complex64,
+                np.complex64,
                 marks=pytest.mark.xfail(reason="no scipy equivalent"),
             ),
             pytest.param(
-                cp.complex128,
+                np.complex128,
                 marks=pytest.mark.xfail(reason="no scipy equivalent"),
             ),
         ],

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -407,7 +407,7 @@ _chirp_phase_hyp_kernel = cp.ElementwiseKernel(
 
 
 def chirp(
-    t, f0, t1, f1, method="linear", phi=0, vertex_zero=True, type=cp.float64
+    t, f0, t1, f1, method="linear", phi=0, vertex_zero=True, type="real"
 ):
     """Frequency-swept cosine generator.
 
@@ -435,6 +435,8 @@ def chirp(
         This parameter is only used when `method` is 'quadratic'.
         It determines whether the vertex of the parabola that is the graph
         of the frequency is at t=0 or t=t1.
+    type : {'real', 'complex'}, optional
+        Specify output chirp type, only applicable when `method` is 'linear'.
 
     Returns
     -------
@@ -490,10 +492,12 @@ def chirp(
     phi *= np.pi / 180
 
     if method in ["linear", "lin", "li"]:
-        if np.issubclass_(type, (np.float32, np.float64)):
+        if type == "real":
             return _chirp_phase_lin_kernel_real(t, f0, t1, f1, phi)
-        elif np.issubclass_(type, (np.complex64, np.complex128)):
-            phase = cp.empty(t.shape, dtype=type)
+        elif type == "complex":
+            phase = cp.empty(t.shape, dtype=cp.complex64)
+            if np.issubclass_(t.dtype, (np.float64)):
+                phase = cp.empty(t.shape, dtype=cp.complex128)
             _chirp_phase_lin_kernel_cplx(t, f0, t1, f1, phi, phase)
             return phase
         else:

--- a/python/cusignal/waveforms/waveforms.py
+++ b/python/cusignal/waveforms/waveforms.py
@@ -479,6 +479,7 @@ def chirp(
     >>> plt.show()
     """
 
+    t = cp.asarray(t)
     phase = cp.empty(t.shape, dtype=dtype)
 
     phi *= np.pi / 180


### PR DESCRIPTION
This PR add parity with MATLAB chirp, specifically complex output.

Adding the following parameter (`dtype=cp.float64`)
Example input (`w = cusignal.chirp(t, cf-100, t[-1], cf+100, dtype=cp.complex128)`)

Perf on original
```bash
test/test_waveforms.py ........                                                                                                                                                                                                                                                               [100%]


-------------- benchmark 'Chirp': 8 tests --------------
Name (time in us)                         Mean          
--------------------------------------------------------
test_chirp_gpu[quad-10-1-6-16384]      61.1752 (1.0)    
test_chirp_gpu[lin-10-1-6-16384]       61.2585 (1.00)   
test_chirp_gpu[hyp-10-1-6-16384]       63.2589 (1.03)   
test_chirp_gpu[log-10-1-6-16384]       70.5225 (1.15)   
test_chirp_cpu[lin-10-1-6-16384]      179.8704 (2.94)   
test_chirp_cpu[hyp-10-1-6-16384]      234.5341 (3.83)   
test_chirp_cpu[log-10-1-6-16384]      394.2949 (6.45)   
test_chirp_cpu[quad-10-1-6-16384]     403.2681 (6.59)   
--------------------------------------------------------

```

Perf on new 
**Notice:**
- float64 is about 4x faster... There was a bug in test suite causing memory copy
```bash
----------------- benchmark 'Chirp': 16 tests ------------------
Name (time in us)                                 Mean          
----------------------------------------------------------------
test_chirp_gpu[lin-10-1-6-16384-real]          17.7974 (1.0)    
test_chirp_gpu[quad-10-1-6-16384-complex]      18.9554 (1.07)   
test_chirp_gpu[quad-10-1-6-16384-real]         19.1889 (1.08)   
test_chirp_gpu[hyp-10-1-6-16384-real]          19.7320 (1.11)   
test_chirp_gpu[hyp-10-1-6-16384-complex]       19.7500 (1.11)   
test_chirp_gpu[lin-10-1-6-16384-complex]       22.5316 (1.27)   
test_chirp_gpu[log-10-1-6-16384-complex]       26.4949 (1.49)   
test_chirp_gpu[log-10-1-6-16384-real]          28.1316 (1.58)   
test_chirp_cpu[lin-10-1-6-16384-real]         182.4054 (10.25)  
test_chirp_cpu[hyp-10-1-6-16384-complex]      232.2149 (13.05)  
test_chirp_cpu[hyp-10-1-6-16384-real]         237.3360 (13.34)  
test_chirp_cpu[lin-10-1-6-16384-complex]      371.0492 (20.85)  
test_chirp_cpu[log-10-1-6-16384-complex]      386.9165 (21.74)  
test_chirp_cpu[log-10-1-6-16384-real]         397.7282 (22.35)  
test_chirp_cpu[quad-10-1-6-16384-complex]     404.0797 (22.70)  
test_chirp_cpu[quad-10-1-6-16384-real]        406.1122 (22.82)  
----------------------------------------------------------------
```