### PR TITLE
Fix docs builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,17 +100,6 @@ todo_include_todos = False
 html_theme = 'pydata_sphinx_theme'
 html_logo = "_static/RAPIDS-logo-purple.png"
 
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:
-    # only import and set the theme if we're building docs locally
-    # otherwise, readthedocs.org uses their theme by default,
-    # so no need to specify it
-    import pydata_sphinx_theme
-    html_theme = 'pydata_sphinx_theme'
-    html_theme_path = pydata_sphinx_theme.get_html_theme_path()
-
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This PR fixes an issue with the doc builds. `get_html_theme_path()` was removed in the commit below. After some local testing, it seems that the lines in this PR can be removed without any issues.

- https://github.com/pydata/pydata-sphinx-theme/commit/579d7ce695cb5c2611aa7b8ab76fbc3efc5fab26