### PR TITLE
Use conda compilers

### DIFF
--- a/conda/recipes/cusignal/conda_build_config.yaml
+++ b/conda/recipes/cusignal/conda_build_config.yaml
@@ -1,0 +1,11 @@
+c_compiler_version:
+  - 9
+
+cxx_compiler_version:
+  - 9
+
+cuda_compiler:
+  - nvcc
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -17,12 +17,17 @@ build:
   noarch: python
   script_env:
     - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
+  ignore_run_exports_from:
+    - nvcc_linux-64 # [linux64]
+    - nvcc_linux-aarch64 # [aarch64]
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }} {{ cuda_version }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+  host:
     - python
     - setuptools
   run:


### PR DESCRIPTION
This PR enables the usage of conda compilers to build conda packages. This is required to use `mambabuild`