### PR TITLE
Extend `get_pinned_mem` to work with more dtype / shapes

### DIFF
--- a/python/cusignal/test/test_arraytools.py
+++ b/python/cusignal/test/test_arraytools.py
@@ -16,6 +16,7 @@ import pytest
 import cusignal
 import cupy as cp
 
+
 @pytest.mark.parametrize("dtype", [cp.ubyte, cp.complex64])
 @pytest.mark.parametrize("shape", [1024, (32, 32)])
 def test_get_pinned_mem(dtype, shape):
@@ -23,6 +24,6 @@ def test_get_pinned_mem(dtype, shape):
 
     if isinstance(shape, int):
         shape = (shape, )
-    
+
     assert arr.shape == shape
     assert arr.dtype == dtype

--- a/python/cusignal/test/test_arraytools.py
+++ b/python/cusignal/test/test_arraytools.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import cusignal
+import cupy as cp
+
+@pytest.mark.parametrize("dtype", [cp.ubyte, cp.complex64])
+@pytest.mark.parametrize("shape", [1024, (32, 32)])
+def test_get_pinned_mem(dtype, shape):
+    arr = cusignal.get_pinned_mem(shape=shape, dtype=dtype)
+
+    if isinstance(shape, int):
+        shape = (shape, )
+    
+    assert arr.shape == shape
+    assert arr.dtype == dtype

--- a/python/cusignal/utils/arraytools.py
+++ b/python/cusignal/utils/arraytools.py
@@ -114,21 +114,24 @@ def get_pinned_mem(shape, dtype):
 
     Parameters
     ----------
-    size : int or tuple of ints
+    shape : int or tuple of ints
         Output shape.
     dtype : data-type
         Output data type.
 
     Returns
     -------
-    out : ndarray
+    ret : ndarray
         Pinned memory numpy array.
 
     """
 
-    size = shape[0] * cp.dtype(dtype).itemsize
-    mem = cp.cuda.alloc_pinned_memory(size)
-    ret = np.frombuffer(mem, dtype, size)
+    from math import prod
+
+    count = prod(shape) if isinstance(shape, tuple) else shape
+    mem = cp.cuda.alloc_pinned_memory(count * cp.dtype(dtype).itemsize)
+    ret = np.frombuffer(mem, dtype, count).reshape(shape)
+
 
     return ret
 

--- a/python/cusignal/utils/arraytools.py
+++ b/python/cusignal/utils/arraytools.py
@@ -132,7 +132,6 @@ def get_pinned_mem(shape, dtype):
     mem = cp.cuda.alloc_pinned_memory(count * cp.dtype(dtype).itemsize)
     ret = np.frombuffer(mem, dtype, count).reshape(shape)
 
-
     return ret
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuSignal :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

This PR makes some changes to `get_pinned_mem` so that it properly handles dtypes other than `uint8` - it also adds some additional handling for `shape` so that integers are now supported, and the output array actually has the input `shape`.