### PR TITLE
Simplify conda recipes

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -18,15 +18,13 @@ build:
   script_env:
     - VERSION_SUFFIX
   ignore_run_exports_from:
-    - nvcc_linux-64 # [linux64]
-    - nvcc_linux-aarch64 # [aarch64]
+    - {{ compiler('cuda') }}
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
-    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
-    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - python
     - setuptools


### PR DESCRIPTION
Simplify recipes using `{{ target_platform }}` for `sysroot` package and `compiler()` function in `ignore_run_exports_from`