### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -18,15 +18,13 @@ build:
   script_env:
     - VERSION_SUFFIX
   ignore_run_exports_from:
-    - nvcc_linux-64 # [linux64]
-    - nvcc_linux-aarch64 # [aarch64]
+    - {{ compiler('cuda') }}
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
-    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
-    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - python
     - setuptools


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.