### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
-# cuSignal 22.06.00 (Date TBD)
+# cuSignal 22.06.00 (7 Jun 2022)
 
-Please see https://github.com/rapidsai/cusignal/releases/tag/v22.06.00a for the latest changes to this development branch.
+## 🛠️ Improvements
+
+- Simplify conda recipes ([#484](https://github.com/rapidsai/cusignal/pull/484)) [@Ethyling](https://github.com/Ethyling)
+- Use conda to build python packages during GPU tests ([#480](https://github.com/rapidsai/cusignal/pull/480)) [@Ethyling](https://github.com/Ethyling)
+- Fix pinned buffer IO issues ([#479](https://github.com/rapidsai/cusignal/pull/479)) [@charlesbluca](https://github.com/charlesbluca)
+- Use pre-commit to enforce Python style checks ([#478](https://github.com/rapidsai/cusignal/pull/478)) [@charlesbluca](https://github.com/charlesbluca)
+- Extend `get_pinned_mem` to work with more dtype / shapes ([#477](https://github.com/rapidsai/cusignal/pull/477)) [@charlesbluca](https://github.com/charlesbluca)
+- Add/fix installation sections for SDR example notebooks ([#476](https://github.com/rapidsai/cusignal/pull/476)) [@charlesbluca](https://github.com/charlesbluca)
+- Use conda compilers ([#461](https://github.com/rapidsai/cusignal/pull/461)) [@Ethyling](https://github.com/Ethyling)
+- Build packages using mambabuild ([#453](https://github.com/rapidsai/cusignal/pull/453)) [@Ethyling](https://github.com/Ethyling)
 
 # cuSignal 22.04.00 (6 Apr 2022)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.