### PR TITLE
Allow CuPy 11

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - numpy>=1.17.3
     - boost
     - numba>=0.49.0
-    - cupy>=8.3.0,<11.0.0a0
+    - cupy>=8.3.0,<12.0.0a0
 
 test:
   requires:


### PR DESCRIPTION
Allows cuxfilter to be installed with CuPy 11.

xref: https://github.com/rapidsai/integration/pull/508