### PR TITLE
Fix Numpy / Numba mismatch

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - scipy>=1.6.0
-    - numpy>=1.17.3
+    - numpy>=1.17.3,<=1.22
     - boost
     - numba>=0.49.0
     - cupy>=8.3.0,<11.0.0a0


### PR DESCRIPTION
The latest version of Numba (0.55) requires Numpy <= 1.22, but cuSignal currently pulls in Numpy 1.23+. Enforce upper bounds. @ajschmidt8 or other ops -- could we hot-fix this to the current 22.08 release too?