### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - scipy>=1.6.0
-    - numpy>=1.17.3
+    - numpy>=1.17.3,<=1.22
     - boost
     - numba>=0.49.0
     - cupy>=8.3.0,<11.0.0a0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.