### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-# cuSignal 22.08.00 (Date TBD)
+# cuSignal 22.08.00 (17 Aug 2022)
 
-Please see https://github.com/rapidsai/cusignal/releases/tag/v22.08.00a for the latest changes to this development branch.
+## 📖 Documentation
+
+- Switch to using common `js` &amp; `css` ([#499](https://github.com/rapidsai/cusignal/pull/499)) [@galipremsagar](https://github.com/galipremsagar)
+- Refresh README ([#487](https://github.com/rapidsai/cusignal/pull/487)) [@awthomp](https://github.com/awthomp)
+
+## 🛠️ Improvements
+
+- Revert &quot;Allow CuPy 11&quot; ([#497](https://github.com/rapidsai/cusignal/pull/497)) [@galipremsagar](https://github.com/galipremsagar)
+- Allow CuPy 11 ([#494](https://github.com/rapidsai/cusignal/pull/494)) [@jakirkham](https://github.com/jakirkham)
 
 # cuSignal 22.06.00 (7 Jun 2022)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.