### PR TITLE
[REVIEW] Revisit WSL install instructions: additional dependency needed for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ We have confirmed that cuSignal successfully builds and runs on Windows by using
 6. Optional: Confirm unit testing via PyTest
     In the cuSignal top level directory:
     ```
-    pip install pytest
+    pip install pytest pytest-benchmark
     pytest
     ```
     


### PR DESCRIPTION
I recently spun up a new install of `cusignal` on my Windows 10 machine running WSL2. Once CUDA environment issues were sorted, everything went smoothly, except `pytest`. Current WSL install instructions need to include installation of `pytest-benchmark` to run `pytest`.

## Steps to reproduce

`conda create --name cusignal-dev`

`conda activate cusignal-dev`

`conda install numpy numba scipy cudatoolkit pip`

`pip install cupy-cuda118`

`./build.sh`

`pip install pytest`

`pytest`

<details>
<summary>Error output: </summary>

```bash
(cusignal-dev) evanmayer@Compy:~/github/cusignal-main/cusignal$ pytest
================================================ test session starts ================================================
platform linux -- Python 3.10.6, pytest-7.2.0, pluggy-1.0.0
rootdir: /home/evanmayer/github/cusignal-main/cusignal
collected 16 items / 11 errors

====================================================== ERRORS =======================================================
______________________________ ERROR collecting python/cusignal/test/test_acoustics.py ______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_acoustics.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_acoustics.py:19: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
______________________________ ERROR collecting python/cusignal/test/test_bsplines.py _______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_bsplines.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_bsplines.py:19: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
_____________________________ ERROR collecting python/cusignal/test/test_convolution.py _____________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_convolution.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_convolution.py:19: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
____________________________ ERROR collecting python/cusignal/test/test_filter_design.py ____________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_filter_design.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_filter_design.py:19: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
______________________________ ERROR collecting python/cusignal/test/test_filtering.py ______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_filtering.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_filtering.py:21: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
____________________________ ERROR collecting python/cusignal/test/test_peak_finding.py _____________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_peak_finding.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_peak_finding.py:20: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
_____________________________ ERROR collecting python/cusignal/test/test_radartools.py ______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_radartools.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_radartools.py:6: in <module>
    from cusignal.testing.utils import array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
__________________________ ERROR collecting python/cusignal/test/test_spectral_analysis.py __________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_spectral_analysis.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_spectral_analysis.py:20: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
______________________________ ERROR collecting python/cusignal/test/test_waveforms.py ______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_waveforms.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_waveforms.py:20: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
______________________________ ERROR collecting python/cusignal/test/test_wavelets.py _______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_wavelets.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_wavelets.py:20: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
_______________________________ ERROR collecting python/cusignal/test/test_windows.py _______________________________
ImportError while importing test module '/home/evanmayer/github/cusignal-main/cusignal/python/cusignal/test/test_windows.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.conda/envs/cusignal-dev/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/cusignal/test/test_windows.py:19: in <module>
    from cusignal.testing.utils import _check_rapids_pytest_benchmark, array_equal
../../../.conda/envs/cusignal-dev/lib/python3.10/site-packages/cusignal-22.12.0a0+6.g4f66c07-py3.10.egg/cusignal/testing/utils.py:15: in <module>
    import pytest_benchmark
E   ModuleNotFoundError: No module named 'pytest_benchmark'
============================================== short test summary info ==============================================
ERROR python/cusignal/test/test_acoustics.py
ERROR python/cusignal/test/test_bsplines.py
ERROR python/cusignal/test/test_convolution.py
ERROR python/cusignal/test/test_filter_design.py
ERROR python/cusignal/test/test_filtering.py
ERROR python/cusignal/test/test_peak_finding.py
ERROR python/cusignal/test/test_radartools.py
ERROR python/cusignal/test/test_spectral_analysis.py
ERROR python/cusignal/test/test_waveforms.py
ERROR python/cusignal/test/test_wavelets.py
ERROR python/cusignal/test/test_windows.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 11 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================ 11 errors in 1.11s =================================================
```

</details>

## Solution

To fix this, I had to run `pip3 install pytest-benchmark`, not `pip`. `pytest` ran after that. Curious to see if `pip` or `pip3` is what others have to do.