### PR TITLE
Update channel priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ cuSignal can be installed with ([Miniconda](https://docs.conda.io/en/latest/mini
 
 ```
 For CUDA 11.5 and Python 3.8
-conda install -c rapidsai -c nvidia -c conda-forge \
+conda install -c rapidsai -c conda-forge -c nvidia \
     cusignal python=3.8 cudatoolkit=11.5
 
 # or, for CUDA 11.2 and Python 3.8
-conda install -c rapidsai -c nvidia -c conda-forge \
+conda install -c rapidsai -c conda-forge -c nvidia \
     cusignal python=3.8 cudatoolkit=11.2
 ```
 
@@ -140,11 +140,11 @@ For the nightly verison of `cusignal`, which includes pre-release features:
 
 ```
 For CUDA 11.5 and Python 3.8
-conda install -c rapidsai-nightly -c nvidia -c conda-forge \
+conda install -c rapidsai-nightly -c conda-forge -c nvidia \
     cusignal python=3.8 cudatoolkit=11.5
 
 For CUDA 11.2 and Python 3.8
-conda install -c rapidsai-nightly -c nvidia -c conda-forge \
+conda install -c rapidsai-nightly -c conda-forge -c nvidia \
     cusignal python=3.8 cudatoolkit=11.2
 ```
 

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -56,7 +56,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Install required packages"
-gpuci_mamba_retry install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge \
+gpuci_mamba_retry install -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia \
 	"cudatoolkit=$CUDA_REL" \
 	"rapids-build-env=${MINOR_VERSION}" \
 	rapids-pytest-benchmark


### PR DESCRIPTION
Aligns conda channel priority in the installation guide with changes made for the 22.10.01 hotfix.