### PR TITLE
Flake8 migrated to GitHub and that broke some pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         hooks:
               - id: black
                 files: python/.*
-      - repo: https://gitlab.com/pycqa/flake8
+      - repo: https://github.com/pycqa/flake8
         rev: 3.8.3
         hooks:
               - id: flake8


### PR DESCRIPTION
I saw this in `dask-cloudprovider` earlier.