### PR TITLE
Enable `Recently Updated` Check

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -7,3 +7,4 @@ label_checker: true
 release_drafter: true
 external_contributors: false
 copy_prs: true
+recently_updated: true


### PR DESCRIPTION
This PR enables a new PR check, `Recently Updated`, that is intended to be used alongside GitHub Actions.

Details on this check can be found here: https://docs.rapids.ai/resources/recently-updated/.

**Note:** The new `Recently Updated` check won't appear on PRs until _after_ this change is merged to the default branch.