### PR TITLE
Reduce error handling verbosity in CI tests scripts

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -34,9 +34,8 @@ pushd notebooks
 # (space-separated list of filenames without paths)
 SKIPNBS="sdr_wfm_demod.ipynb io_examples.ipynb rtlsdr_offline_demod_to_transcript.ipynb"
 
-# Set SUITEERROR to failure if any run fails
-SUITEERROR=0
-
+EXITCODE=0
+trap "EXITCODE=1" ERR
 set +e
 for nb in $(find . -name "*.ipynb"); do
     nbBasename=$(basename ${nb})
@@ -60,9 +59,9 @@ for nb in $(find . -name "*.ipynb"); do
         pushd $(dirname ${nb})
         nvidia-smi
         ${NBTEST} ${nbBasename}
-        SUITEERROR=$((SUITEERROR | $?))
         popd
     fi
 done
 
-exit ${SUITEERROR}
+rapids-logger "Notebooks test script exiting with value: $EXITCODE"
+exit ${EXITCODE}


### PR DESCRIPTION
This PR adds a less verbose [trap method](https://github.com/rapidsai/cugraph/blob/f2b081075704aabc789603e14ce552eac3fbe692/ci/test.sh#L19), for error handling to help ensure that we capture all potential error codes in our test scripts, and works as follows:

- setting an environment variable, EXITCODE, with a default value of 0
- setting a trap statement triggered by ERR signals which will set EXITCODE=1 when any commands return a non-zero exit code

cc @ajschmidt8