### PR TITLE
Skip docs job in nightly runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
   docs-build:
-    if: ${{ startsWith(github.ref, 'refs/heads/branch-') }}
+    if: github.ref_type == 'branch' && github.event_name == 'push'
     needs: python-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.04


### PR DESCRIPTION
This PR configures the branch workflow to skip the docs job during nightly runs.