### PR TITLE
Dropping Python 3.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   python-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@py-39
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [python-build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@py-39
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -47,7 +47,7 @@ jobs:
     if: github.ref_type == 'branch' && github.event_name == 'push'
     needs: python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@py-39
     with:
       build_type: branch
       node_type: "gpu-v100-latest-1"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,26 +18,26 @@ jobs:
       - conda-notebook-tests
       - docs-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@py-39
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@py-39
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@py-39
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@py-39
     with:
       build_type: pull-request
   conda-notebook-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@py-39
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
@@ -47,7 +47,7 @@ jobs:
   docs-build:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@py-39
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@py-39
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ cuSignal can be installed with ([Miniconda](https://docs.conda.io/en/latest/mini
 conda install -c rapidsai -c conda-forge -c nvidia \
     cusignal
 
-# To specify a certain CUDA or Python version (e.g. 11.8 and 3.8, respectively)
+# To specify a certain CUDA or Python version (e.g. 11.8 and 3.9, respectively)
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cusignal python=3.8 cudatoolkit=11.8
+    cusignal python=3.9 cudatoolkit=11.8
 ```
 
 For the nightly verison of `cusignal`, which includes pre-release features:
@@ -141,9 +141,9 @@ For the nightly verison of `cusignal`, which includes pre-release features:
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
     cusignal
 
-# To specify a certain CUDA or Python version (e.g. 11.8 and 3.8, respectively)
+# To specify a certain CUDA or Python version (e.g. 11.8 and 3.9, respectively)
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cusignal python=3.8 cudatoolkit=11.8
+    cusignal python=3.9 cudatoolkit=11.8
 ```
 
 While only CUDA versions >= 11.2 are officially supported, cuSignal has been confirmed to work with CUDA version 10.2 and above. If you run into any issues with the conda install, please follow the source installation instructions, below.

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - pytest-benchmark
 - pytest-cov
 - pytest-xdist
-- python>=3.8,<3.11
+- python>=3.9,<3.11
 - pytorch <=1.12.1
 - scipy >=1.6.0
 - sphinx-copybutton

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,10 +81,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.8"
-            packages:
-              - python=3.8
-          - matrix:
               py: "3.9"
             packages:
               - python=3.9
@@ -94,7 +90,7 @@ dependencies:
               - python=3.10
           - matrix:
             packages:
-              - python>=3.8,<3.11
+              - python>=3.9,<3.11
   run:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
This PR drops Python 3.8 in favor of 3.9.