### PR TITLE
Refresh requirements

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - matplotlib-base
 - notebook
 - numba >=0.49.0
-- numpy >=1.19,<1.24
+- numpy >=1.19
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - matplotlib-base
 - notebook
 - numba >=0.57.0
-- numpy >=1.19
+- numpy >=1.21
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - ipython
 - matplotlib-base
 - notebook
-- numba >=0.49.0
+- numba >=0.57.0
 - numpy >=1.19
 - numpydoc
 - pre-commit

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - cupy >=12.0.0
     - numba >=0.49.0
-    - numpy >=1.19,<1.24
+    - numpy >=1.19
     - python
     - scipy >=1.6.0
 

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
   run:
     - cupy >=12.0.0
-    - numba >=0.49.0
+    - numba >=0.57.0
     - numpy >=1.19
     - python
     - scipy >=1.6.0

--- a/conda/recipes/cusignal/meta.yaml
+++ b/conda/recipes/cusignal/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - cupy >=12.0.0
     - numba >=0.57.0
-    - numpy >=1.19
+    - numpy >=1.21
     - python
     - scipy >=1.6.0
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,7 +96,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cupy >=12.0.0
-          - numba >=0.49.0
+          - numba >=0.57.0
           - numpy >=1.19
           - scipy >=1.6.0
   test_notebooks:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,7 +97,7 @@ dependencies:
         packages:
           - cupy >=12.0.0
           - numba >=0.49.0
-          - numpy >=1.19,<1.24
+          - numpy >=1.19
           - scipy >=1.6.0
   test_notebooks:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,7 +97,7 @@ dependencies:
         packages:
           - cupy >=12.0.0
           - numba >=0.57.0
-          - numpy >=1.19
+          - numpy >=1.21
           - scipy >=1.6.0
   test_notebooks:
     common:

--- a/python/cusignal/convolution/_convolution_cuda.py
+++ b/python/cusignal/convolution/_convolution_cuda.py
@@ -400,7 +400,7 @@ def _convolve(
     in2 = in2.astype(promType)
 
     # Create empty array to hold number of aout dimensions
-    out_dimens = np.empty(in1.ndim, np.int)
+    out_dimens = np.empty(in1.ndim, int)
     if val == VALID:
         for i in range(in1.ndim):
             out_dimens[i] = (
@@ -465,7 +465,7 @@ def _convolve2d(in1, in2, use_convolve, mode, boundary, fillvalue):
             raise Exception("Unable to create fill array")
 
     # Create empty array to hold number of aout dimensions
-    out_dimens = np.empty(in1.ndim, np.int)
+    out_dimens = np.empty(in1.ndim, int)
     if val == VALID:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] - in2.shape[i] + 1
@@ -539,7 +539,7 @@ def _convolve1d2o(in1, in2, mode):
     in2 = in2.astype(promType)
 
     # Create empty array to hold number of aout dimensions
-    out_dimens = np.empty(in1.ndim, np.int)
+    out_dimens = np.empty(in1.ndim, int)
     if val == VALID:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] - in2.shape[i] + 1
@@ -602,7 +602,7 @@ def _convolve1d3o(in1, in2, mode):
     in2 = in2.astype(promType)
 
     # Create empty array to hold number of aout dimensions
-    out_dimens = np.empty(in1.ndim, np.int)
+    out_dimens = np.empty(in1.ndim, int)
     if val == VALID:
         for i in range(in1.ndim):
             out_dimens[i] = in1.shape[i] - in2.shape[i] + 1


### PR DESCRIPTION
* Require Numba 0.57+ consistently
* Require NumPy 1.21+ (to align with [Numba 0.57.0's NumPy minimum]( https://github.com/numba/numba/blob/0.57.0/setup.py#L25 ))
* Allow NumPy 1.24 (soften upper bounds)
* Replace deprecated `np.int` with `int`