### PR TITLE
use rapids-upload-docs script

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -18,21 +18,21 @@ rapids-print-env
 
 rapids-logger "Downloading artifacts from previous jobs"
 PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
-VERSION_NUMBER="23.08"
 
 rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
   cusignal
 
-rapids-logger "Build Sphinx docs"
+export RAPIDS_VERSION_NUMBER="23.08"
+export RAPIDS_DOCS_DIR="$(mktemp -d)"
+
+rapids-logger "Build Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html
 sphinx-build -b text source _text
+mkdir -p "${RAPIDS_DOCS_DIR}/cusignal/"{html,txt}
+mv _html/* "${RAPIDS_DOCS_DIR}/cusignal/html"
+mv _text/* "${RAPIDS_DOCS_DIR}/cusignal/txt"
 popd
 
-
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
-  rapids-logger "Upload Docs to S3"
-  aws s3 sync --no-progress --delete docs/_html "s3://rapidsai-docs/cusignal/${VERSION_NUMBER}/html"
-  aws s3 sync --no-progress --delete docs/_text "s3://rapidsai-docs/cusignal/${VERSION_NUMBER}/txt"
-fi
+rapids-upload-docs

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -36,4 +36,4 @@ sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
-sed_runner "s/VERSION_NUMBER=\".*/VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh
+sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh


### PR DESCRIPTION
This PR updates the `build_docs.sh` script to use the new consolidatory `rapids-upload-script` [shared script](https://github.com/rapidsai/gha-tools/pull/56). 

The shared script enables docs uploads to applicable S3 buckets for branch. nightly and PR builds.