### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# cuSignal 23.08.00 (9 Aug 2023)
+
+## 🛠️ Improvements
+
+- Only run cusignal CI for CUDA 11. ([#583](https://github.com/rapidsai/cusignal/pull/583)) [@bdice](https://github.com/bdice)
+- use rapids-upload-docs script ([#580](https://github.com/rapidsai/cusignal/pull/580)) [@AyodeAwe](https://github.com/AyodeAwe)
+- Remove documentation build scripts for Jenkins ([#578](https://github.com/rapidsai/cusignal/pull/578)) [@ajschmidt8](https://github.com/ajschmidt8)
+
 # cuSignal 23.06.00 (7 Jun 2023)
 
 ## 🚨 Breaking Changes


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.